### PR TITLE
feat(web): submit RAG chat on Enter

### DIFF
--- a/src/searchat/web/static/js/modules/chat.js
+++ b/src/searchat/web/static/js/modules/chat.js
@@ -278,7 +278,13 @@ export function initChat() {
 
     if (queryEl) {
         queryEl.addEventListener('keydown', (event) => {
-            if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+            if (event.isComposing) {
+                return;
+            }
+
+            const isEnter = event.key === 'Enter';
+            const isSubmit = (event.metaKey || event.ctrlKey) || (!event.shiftKey && !event.altKey);
+            if (isEnter && isSubmit) {
                 event.preventDefault();
                 runChatRag();
             }

--- a/tests/ui/test_chat_ui_contract.py
+++ b/tests/ui/test_chat_ui_contract.py
@@ -39,3 +39,4 @@ def test_chat_js_targets_rag_endpoint_and_persists_options():
     assert "localStorage.setItem('chatTemperature'" in content
     assert "localStorage.setItem('chatMaxTokens'" in content
     assert "localStorage.setItem('chatSystemPrompt'" in content
+    assert "event.key === 'Enter'" in content


### PR DESCRIPTION
## What
Make the Chat with History textarea behave like Search conversations:
- `Enter` submits the RAG chat request
- `Shift+Enter` inserts a newline
- `Cmd/Ctrl+Enter` still submits
- IME composition is ignored to avoid accidental submits

## Where
- `src/searchat/web/static/js/modules/chat.js`
- `tests/ui/test_chat_ui_contract.py`

## Testing
- `uv run pytest`