### PR TITLE
chore(watcher): summarize watch targets and reduce startup log spam

### DIFF
--- a/src/searchat/core/connectors/claude.py
+++ b/src/searchat/core/connectors/claude.py
@@ -27,6 +27,18 @@ class ClaudeConnector:
                 files.append(json_file)
         return files
 
+    def watch_dirs(self, config: Config) -> list[Path]:
+        return [p for p in PathResolver.resolve_claude_dirs(config) if p.exists()]
+
+    def watch_stats(self, config: Config) -> dict[str, int]:
+        project_count = 0
+        for root in self.watch_dirs(config):
+            try:
+                project_count += sum(1 for p in root.iterdir() if p.is_dir())
+            except OSError:
+                continue
+        return {"projects": project_count}
+
     def can_parse(self, path: Path) -> bool:
         return path.suffix == ".jsonl"
 

--- a/src/searchat/core/connectors/opencode.py
+++ b/src/searchat/core/connectors/opencode.py
@@ -23,6 +23,26 @@ class OpenCodeConnector:
             files.extend(storage_session_dir.glob("*/*.json"))
         return files
 
+    def watch_dirs(self, config: Config) -> list[Path]:
+        dirs: list[Path] = []
+        for opencode_dir in PathResolver.resolve_opencode_dirs(config):
+            storage_dir = opencode_dir / "storage"
+            if storage_dir.exists():
+                dirs.append(storage_dir)
+        return dirs
+
+    def watch_stats(self, config: Config) -> dict[str, int]:
+        project_count = 0
+        for root in self.watch_dirs(config):
+            session_root = root / "session"
+            if not session_root.exists():
+                continue
+            try:
+                project_count += sum(1 for p in session_root.iterdir() if p.is_dir())
+            except OSError:
+                continue
+        return {"projects": project_count}
+
     def can_parse(self, path: Path) -> bool:
         if path.suffix != ".json":
             return False

--- a/src/searchat/core/connectors/vibe.py
+++ b/src/searchat/core/connectors/vibe.py
@@ -22,6 +22,18 @@ class VibeConnector:
             files.extend(vibe_dir.glob("*.json"))
         return files
 
+    def watch_dirs(self, _config: Config) -> list[Path]:
+        return [p for p in PathResolver.resolve_vibe_dirs() if p.exists()]
+
+    def watch_stats(self, _config: Config) -> dict[str, int]:
+        session_count = 0
+        for root in self.watch_dirs(_config):
+            try:
+                session_count += sum(1 for p in root.glob("*.json") if p.is_file())
+            except OSError:
+                continue
+        return {"sessions": session_count}
+
     def can_parse(self, path: Path) -> bool:
         if path.suffix != ".json":
             return False

--- a/tests/unit/core/test_connectors_watch_dirs.py
+++ b/tests/unit/core/test_connectors_watch_dirs.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from searchat.core.connectors import discover_watch_dirs
+from searchat.config.path_resolver import PathResolver
+
+
+def test_discover_watch_dirs_uses_connector_watch_dirs(monkeypatch, tmp_path: Path):
+    claude_root = tmp_path / "claude"
+    claude_root.mkdir()
+    vibe_root = tmp_path / "vibe"
+    vibe_root.mkdir()
+    opencode_root = tmp_path / "opencode"
+    (opencode_root / "storage").mkdir(parents=True)
+
+    monkeypatch.setattr(PathResolver, "resolve_claude_dirs", staticmethod(lambda _cfg=None: [claude_root]))
+    monkeypatch.setattr(PathResolver, "resolve_vibe_dirs", staticmethod(lambda: [vibe_root]))
+    monkeypatch.setattr(PathResolver, "resolve_opencode_dirs", staticmethod(lambda _cfg=None: [opencode_root]))
+
+    config = Mock()
+    watch_dirs = discover_watch_dirs(config)
+
+    assert claude_root in watch_dirs
+    assert vibe_root in watch_dirs
+    assert (opencode_root / "storage") in watch_dirs
+
+    # Ensure we are not generating a directory per discovered file.
+    assert len(watch_dirs) == 3

--- a/tests/unit/core/test_watcher_filtering.py
+++ b/tests/unit/core/test_watcher_filtering.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from queue import Queue
+from pathlib import Path
+
+from searchat.core.watcher import ConversationEventHandler
+
+
+def test_watcher_filters_files_without_connector(monkeypatch, tmp_path: Path):
+    q: Queue = Queue()
+    handler = ConversationEventHandler(q)
+
+    p = tmp_path / "random.json"
+    p.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "searchat.core.watcher.detect_connector",
+        lambda _path: (_ for _ in ()).throw(ValueError("no connector")),
+    )
+    assert handler._should_process(str(p)) is False
+
+    monkeypatch.setattr("searchat.core.watcher.detect_connector", lambda _path: object())
+    assert handler._should_process(str(p)) is True


### PR DESCRIPTION
## What
Reduce terminal spam on startup by switching from per-directory INFO logs to a single summary line, and add a per-agent count of watch targets.

- Logs one line like: `Watching N directories (claude projects: X, vibe sessions: Y, opencode projects: Z)`
- Keeps per-directory listing at DEBUG for troubleshooting.
- Avoids noisy indexing by ensuring file events are only enqueued when a connector can actually parse the file.

## Why
On systems with many Claude/OpenCode/Vibe projects (and nested `subagents/` directories), the watcher produced hundreds of INFO log lines at startup and watched far more directories than necessary.

## Implementation
- Add `watch_dirs()` + `watch_stats()` to connectors:
  - `src/searchat/core/connectors/claude.py`
  - `src/searchat/core/connectors/vibe.py`
  - `src/searchat/core/connectors/opencode.py`
- Update watcher scheduling/logging and event filtering:
  - `src/searchat/core/watcher.py`

## Tests
- `tests/unit/core/test_connectors_watch_dirs.py`
- `tests/unit/core/test_watcher_filtering.py`
- `uv run pytest`