### PR TITLE
fix: index Continue sessions and update tagline

### DIFF
--- a/src/searchat/api/app.py
+++ b/src/searchat/api/app.py
@@ -112,7 +112,7 @@ _CACHED_HTML = _cache_bust_static_assets(_HTML_PATH.read_text(encoding="utf-8"),
 # Create FastAPI app
 app = FastAPI(
     title="Searchat API",
-    description="Semantic search for AI coding agent conversations",
+    description="Local search for your AI coding conversations",
     version=APP_VERSION,
 )
 

--- a/src/searchat/core/indexer.py
+++ b/src/searchat/core/indexer.py
@@ -1352,7 +1352,13 @@ class ConversationIndexer:
                 logger.warning(f"File not found, skipping: {file_path}")
                 continue
 
-            connector = detect_connector(json_path)
+            try:
+                connector = detect_connector(json_path)
+            except ValueError as exc:
+                progress.update_file_progress(idx, len(new_files), f"unknown | {json_path.name}")
+                logger.warning("%s; skipping: %s", exc, file_path)
+                continue
+
             display_name = f"{connector.name} | {json_path.name}"
             progress.update_file_progress(idx, len(new_files), display_name)
 

--- a/src/searchat/web/index.html
+++ b/src/searchat/web/index.html
@@ -143,7 +143,7 @@
                 <a href="/" class="back-button">← Back to Search</a>
             </div>
             <h1 id="heroTitle" style="margin-bottom: 4px;"><span style="color: #4a9eff">sear</span><span style="background: linear-gradient(to right, #4a9eff, #ff9500); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">ch</span><span style="color: #ff9500">at</span></h1>
-            <p id="heroSubtitle" style="margin: 0 0 20px 0; font-size: 13px; color: #888;">Semantic search for AI coding agent conversations — Claude Code + Mistral Vibe + OpenCode</p>
+            <p id="heroSubtitle" style="margin: 0 0 20px 0; font-size: 13px; color: #888;">Local search for your AI coding conversations</p>
             <input type="text" id="search" class="search-box" placeholder="Search conversations..." />
             <div id="projectSuggestion" class="project-suggestion" style="display: none;"></div>
 

--- a/src/searchat/web_api.py
+++ b/src/searchat/web_api.py
@@ -994,7 +994,7 @@ async def root():
             </div>
 
             <h1 style="margin-bottom: 4px;"><span style="color: #4a9eff">sear</span><span style="background: linear-gradient(to right, #4a9eff, #ff9500); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">ch</span><span style="color: #ff9500">at</span></h1>
-            <p style="margin: 0 0 20px 0; font-size: 13px; color: #888;">Semantic search for AI coding agent conversations — Claude Code + Mistral Vibe</p>
+            <p style="margin: 0 0 20px 0; font-size: 13px; color: #888;">Local search for your AI coding conversations</p>
             <input type="text" id="search" class="search-box" placeholder="Search conversations..." />
 
             <div class="filters">


### PR DESCRIPTION
## What changed
- Index Continue sessions from `~/.continue/sessions/*.json` (history/message format) during append-only indexing.
- Skip unknown JSON files during append-only indexing instead of failing the entire operation.
- Update tagline to: \"Local search for your AI coding conversations\".

## Why
The manual \"Add Missing Conversations\" flow was failing with `No connector found for ...` on Continue session files.

## Testing
- `uv run pytest -q`