### PR TITLE
docs: improve README lineage and upstream credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ Semantic search and RAG-powered Q&A for AI coding agent conversations. Find past
 
 This repository is inspired by and built on the original [Process-Point-Technologies-Corporation/searchat](https://github.com/Process-Point-Technologies-Corporation/searchat).
 
+The original repository is also accompanied by and stems from the paper [Structured Distillation for Personalized Agent Memory: 11× Token Reduction with Retrieval Preservation](https://arxiv.org/html/2603.13017) (arXiv:2603.13017, March 13, 2026).
+
 Credit to the original repository and its authors for the foundation:
 
 - local-first semantic search for AI coding conversations
 - append-only indexing and live file watching
 - the initial FastAPI + web UI shape
 - the original Claude Code and Mistral Vibe support
+- the structured distillation and personalized agent memory framing described in the paper
 
 This fork has since expanded substantially beyond that baseline. It now includes:
 


### PR DESCRIPTION
## Summary

Improve the top-level README attribution and project-positioning text so the repository gives explicit credit to both:

- the original upstream repository: `Process-Point-Technologies-Corporation/searchat`
- the accompanying paper: `Structured Distillation for Personalized Agent Memory: 11× Token Reduction with Retrieval Preservation` (`arXiv:2603.13017`)

This branch is documentation-only and is limited to `README.md`.

## What Changed

### 1. Added a dedicated project lineage section

Replaced the previous one-line fork reference with a clearer `Project Lineage` section near the top of the README.

That section now:

- credits the upstream repository directly
- states that this repository is inspired by and built on that original work
- references the paper associated with the upstream project
- credits the original work for the foundational search/indexing/web structure

### 2. Clarified how this fork has diverged from upstream

Expanded the lineage text to explain that this repository has grown substantially beyond the original baseline, including:

- broader connector coverage
- RAG chat and session chat
- MCP and embedded local LLM support
- expertise extraction / priming workflows
- L3 knowledge graph capabilities
- the larger API / CLI / frontend / docs / test surface

### 3. Tightened the fork enhancements section

Updated the existing `Fork Enhancements` section so it reads as a cleaner delta against upstream instead of a loosely accumulated feature list.

Changes include:

- explicitly framing the section as a comparison with the original upstream repository
- replacing outdated wording such as "OpenCode Support" as the main connector delta
- adding missing higher-signal capabilities already present in this fork, including:
  - session chat
  - expanded connector coverage
  - MCP server support
  - embedded LLM support
  - expertise store
  - knowledge graph
  - pattern mining
  - agent config export
  - operational health tooling
- normalizing markdown punctuation in that section

## Why

The old README acknowledged the fork, but only at the repository level and without enough context for readers to understand:

- what came from the original work
- that the upstream project is tied to a research paper
- how far this fork has evolved beyond the original implementation

This change makes the README more accurate from both an attribution and product-positioning standpoint.

## Scope

- Documentation only
- No code changes
- No behavioral changes
- No test updates required

## Validation

- Reviewed the current branch diff against `origin/main`
- Verified the branch contains only `README.md` changes
- Confirmed the branch commit set is:
  - `13468cd` `docs(readme): clarify project lineage and fork scope`
  - `68cbd4d` `docs(readme): add paper attribution to project credits`
