### PR TITLE
fix(api): separate read-only query store from read-write indexer connection

### DIFF
--- a/src/searchat/api/dependencies.py
+++ b/src/searchat/api/dependencies.py
@@ -3,6 +3,7 @@
 This module must stay lightweight: avoid importing heavy ML/search modules at
 import time. Heavy resources are initialized lazily and/or in background warmup.
 """
+
 from __future__ import annotations
 
 import logging
@@ -15,6 +16,7 @@ from searchat.contracts.errors import snapshot_mode_disabled_message
 from searchat.services import BackupManager, PlatformManager
 from searchat.config import Config, PathResolver
 from searchat.api.readiness import get_readiness
+
 logger = logging.getLogger(__name__)
 
 
@@ -48,7 +50,18 @@ _service_lock = Lock()
 
 def initialize_services():
     """Initialize all services on app startup."""
-    global _config, _search_dir, _backup_manager, _platform_manager, _bookmarks_service, _saved_queries_service, _dashboards_service, _analytics_service, _duckdb_store, _expertise_store, _knowledge_graph_store
+    global \
+        _config, \
+        _search_dir, \
+        _backup_manager, \
+        _platform_manager, \
+        _bookmarks_service, \
+        _saved_queries_service, \
+        _dashboards_service, \
+        _analytics_service, \
+        _duckdb_store, \
+        _expertise_store, \
+        _knowledge_graph_store
 
     readiness = get_readiness()
     readiness.set_component("services", "loading")
@@ -68,9 +81,11 @@ def initialize_services():
 
         if _config.expertise.enabled:
             from searchat.expertise.store import ExpertiseStore
+
             _expertise_store = ExpertiseStore(_search_dir)
         if _config.knowledge_graph.enabled:
             from searchat.knowledge_graph import KnowledgeGraphStore
+
             _knowledge_graph_store = KnowledgeGraphStore(_search_dir)
         _bookmarks_service = BookmarksService(_config)
         _analytics_service = SearchAnalyticsService(_config)
@@ -130,21 +145,27 @@ def invalidate_search_index() -> None:
 def get_config() -> Config:
     """Get configuration singleton."""
     if _config is None:
-        raise RuntimeError("Services not initialized. Call initialize_services() first.")
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services() first."
+        )
     return _config
 
 
 def get_search_dir() -> Path:
     """Get search directory path."""
     if _search_dir is None:
-        raise RuntimeError("Services not initialized. Call initialize_services() first.")
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services() first."
+        )
     return _search_dir
 
 
 def get_duckdb_store():
     """Get DuckDBStore singleton."""
     if _duckdb_store is None:
-        raise RuntimeError("Services not initialized. Call initialize_services() first.")
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services() first."
+        )
     return _duckdb_store
 
 
@@ -188,7 +209,9 @@ def resolve_dataset_search_dir(snapshot: str | None) -> tuple[Path, str | None]:
         raise ValueError("Snapshot not found")
     # Only allow snapshot browsing for backups that are explicitly marked as browsable.
     try:
-        artifact = backup_manager.validate_backup_artifact(snapshot, verify_hashes=False)
+        artifact = backup_manager.validate_backup_artifact(
+            snapshot, verify_hashes=False
+        )
     except AttributeError:
         artifact = {"snapshot_browsable": backup_manager.validate_backup(snapshot_dir)}
     if not artifact.get("snapshot_browsable"):
@@ -237,7 +260,9 @@ def get_or_create_search_engine_for(search_dir: Path) -> "RetrievalBackend":
 def get_search_engine():
     """Get search engine singleton."""
     if _config is None or _search_dir is None:
-        raise RuntimeError("Services not initialized. Call initialize_services() first.")
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services() first."
+        )
     engine = _search_engine
     if engine is None:
         raise RuntimeError("Search engine not ready")
@@ -247,7 +272,9 @@ def get_search_engine():
 def get_indexer():
     """Get indexer singleton."""
     if _config is None or _search_dir is None:
-        raise RuntimeError("Services not initialized. Call initialize_services() first.")
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services() first."
+        )
     idx = _indexer
     if idx is None:
         # Indexer is created lazily on first use.
@@ -258,28 +285,36 @@ def get_indexer():
 def get_backup_manager() -> BackupManager:
     """Get backup manager singleton."""
     if _backup_manager is None:
-        raise RuntimeError("Services not initialized. Call initialize_services() first.")
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services() first."
+        )
     return _backup_manager
 
 
 def get_platform_manager() -> PlatformManager:
     """Get platform manager singleton."""
     if _platform_manager is None:
-        raise RuntimeError("Services not initialized. Call initialize_services() first.")
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services() first."
+        )
     return _platform_manager
 
 
 def get_expertise_store():
     """Get expertise store singleton."""
     if _expertise_store is None:
-        raise RuntimeError("Expertise store not initialized. Check expertise.enabled in config.")
+        raise RuntimeError(
+            "Expertise store not initialized. Check expertise.enabled in config."
+        )
     return _expertise_store
 
 
 def get_knowledge_graph_store():
     """Get knowledge graph store singleton."""
     if _knowledge_graph_store is None:
-        raise RuntimeError("Knowledge graph store not initialized. Check knowledge_graph.enabled in config.")
+        raise RuntimeError(
+            "Knowledge graph store not initialized. Check knowledge_graph.enabled in config."
+        )
     return _knowledge_graph_store
 
 
@@ -291,7 +326,9 @@ def get_palace_query():
 
     config = get_config()
     if not config.palace.enabled:
-        raise RuntimeError("Palace is not enabled. Set palace.enabled = true in config.")
+        raise RuntimeError(
+            "Palace is not enabled. Set palace.enabled = true in config."
+        )
 
     search_dir = get_search_dir()
     with _service_lock:
@@ -308,28 +345,36 @@ def get_palace_query():
 def get_bookmarks_service():
     """Get bookmarks service singleton."""
     if _bookmarks_service is None:
-        raise RuntimeError("Services not initialized. Call initialize_services() first.")
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services() first."
+        )
     return _bookmarks_service
 
 
 def get_saved_queries_service():
     """Get saved queries service singleton."""
     if _saved_queries_service is None:
-        raise RuntimeError("Services not initialized. Call initialize_services() first.")
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services() first."
+        )
     return _saved_queries_service
 
 
 def get_dashboards_service():
     """Get dashboards service singleton."""
     if _dashboards_service is None:
-        raise RuntimeError("Services not initialized. Call initialize_services() first.")
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services() first."
+        )
     return _dashboards_service
 
 
 def get_analytics_service():
     """Get analytics service singleton."""
     if _analytics_service is None:
-        raise RuntimeError("Services not initialized. Call initialize_services() first.")
+        raise RuntimeError(
+            "Services not initialized. Call initialize_services() first."
+        )
     return _analytics_service
 
 
@@ -390,10 +435,10 @@ def _ensure_indexer():
 
             from searchat.storage.unified_storage import UnifiedStorage
 
-            storage = _duckdb_store if isinstance(_duckdb_store, UnifiedStorage) else None
-            _indexer = UnifiedIndexer(
-                _search_dir, _config, storage=storage
+            storage = (
+                _duckdb_store if isinstance(_duckdb_store, UnifiedStorage) else None
             )
+            _indexer = UnifiedIndexer(_search_dir, _config, storage=storage)
             readiness.set_component("indexer", "ready")
         except Exception as e:
             readiness.set_component("indexer", "error", error=str(e))

--- a/src/searchat/api/dependencies.py
+++ b/src/searchat/api/dependencies.py
@@ -433,12 +433,7 @@ def _ensure_indexer():
         try:
             from searchat.core.unified_indexer import UnifiedIndexer
 
-            from searchat.storage.unified_storage import UnifiedStorage
-
-            storage = (
-                _duckdb_store if isinstance(_duckdb_store, UnifiedStorage) else None
-            )
-            _indexer = UnifiedIndexer(_search_dir, _config, storage=storage)
+            _indexer = UnifiedIndexer(_search_dir, _config)
             readiness.set_component("indexer", "ready")
         except Exception as e:
             readiness.set_component("indexer", "error", error=str(e))

--- a/src/searchat/services/storage_service.py
+++ b/src/searchat/services/storage_service.py
@@ -1,4 +1,5 @@
 """Storage-facing service contract and construction helpers."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -45,16 +46,24 @@ class StorageService(Protocol):
     def get_statistics(self): ...
 
 
-def build_storage_service(search_dir: Path, *, config: Config) -> StorageService:
+def build_storage_service(
+    search_dir: Path, *, config: Config, read_only: bool | None = None
+) -> StorageService:
     """Create the storage service for a dataset root.
 
     Returns UnifiedStorage (DuckDB-native) backed by the persistent DuckDB file.
     Creates the database if it does not exist yet.
+
+    Args:
+        read_only: Explicit access mode. ``None`` auto-detects: read-only when
+            the database file already exists, read-write otherwise (first-run
+            bootstrap).
     """
     from searchat.storage.unified_storage import UnifiedStorage
 
     db_path = config.storage.resolve_duckdb_path(search_dir)
-    read_only = db_path.exists()
+    if read_only is None:
+        read_only = db_path.exists()
     return UnifiedStorage(
         db_path,
         memory_limit_mb=config.performance.memory_limit_mb,

--- a/tests/unit/services/test_read_path_cutover.py
+++ b/tests/unit/services/test_read_path_cutover.py
@@ -69,6 +69,51 @@ class TestBuildStorageServiceRouting:
         assert isinstance(store, UnifiedStorage)
         assert db_path.exists()
 
+    def test_explicit_read_only_false_opens_writable(self, tmp_path: Path) -> None:
+        from searchat.services.storage_service import build_storage_service
+
+        db_path = tmp_path / "data" / "searchat.duckdb"
+        _create_duckdb_file(db_path)
+
+        cfg = SimpleNamespace(
+            storage=SimpleNamespace(
+                backend="duckdb",
+                resolve_duckdb_path=lambda _sd: db_path,
+                hnsw_ef_construction=128,
+                hnsw_ef_search=64,
+                hnsw_m=16,
+            ),
+            performance=SimpleNamespace(memory_limit_mb=None),
+        )
+
+        store = build_storage_service(tmp_path, config=cfg, read_only=False)
+        from searchat.storage.unified_storage import UnifiedStorage
+
+        assert isinstance(store, UnifiedStorage)
+        assert not store._read_only
+
+    def test_explicit_read_only_true_when_db_missing_raises(
+        self, tmp_path: Path
+    ) -> None:
+        from searchat.services.storage_service import build_storage_service
+
+        db_path = tmp_path / "data" / "searchat.duckdb"
+        # DB does not exist — opening read-only should fail
+
+        cfg = SimpleNamespace(
+            storage=SimpleNamespace(
+                backend="duckdb",
+                resolve_duckdb_path=lambda _sd: db_path,
+                hnsw_ef_construction=128,
+                hnsw_ef_search=64,
+                hnsw_m=16,
+            ),
+            performance=SimpleNamespace(memory_limit_mb=None),
+        )
+
+        with pytest.raises(Exception):
+            build_storage_service(tmp_path, config=cfg, read_only=True)
+
 
 # ── Retrieval factory routing ────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The shared `_duckdb_store` singleton in `dependencies.py` is opened **read-only** when the database file already exists (via the `read_only = db_path.exists()` heuristic in `build_storage_service`). This singleton was injected into `UnifiedIndexer`, causing all INSERT operations during indexing to fail with:

```
Cannot execute statement of type "INSERT" on database "searchat"
which is attached in read-only mode!
```

This PR separates the read and write storage paths:
- The **query store** (API endpoints) remains read-only — a structural safeguard for irreplaceable conversation data.
- The **indexer** creates its own read-write DuckDB connection — leveraging DuckDB's native support for concurrent RO + RW connections to the same file.

## Root Cause

`_ensure_indexer()` in `dependencies.py` passed the shared read-only `_duckdb_store` to `UnifiedIndexer`. The indexer accepted it via its `storage` parameter, bypassing its own `storage=None` fallback which correctly creates a read-write `UnifiedStorage`.

## Changes

### 1. `src/searchat/services/storage_service.py`
- Added explicit `read_only: bool | None = None` parameter to `build_storage_service()`
- When `None` (default), preserves existing auto-detection (`db_path.exists()`)
- Callers that need a specific access mode can now pass `read_only=False` or `read_only=True`

### 2. `src/searchat/api/dependencies.py`
- **Bug fix:** Removed injection of the shared read-only store into `UnifiedIndexer` — the indexer now creates its own read-write connection via its existing `storage=None` fallback
- **Formatting:** Applied ruff formatting (line wrapping, blank lines) — no logic changes outside the indexer fix

### 3. `tests/unit/services/test_read_path_cutover.py`
- `test_explicit_read_only_false_opens_writable` — verifies `read_only=False` on an existing DB produces a writable store
- `test_explicit_read_only_true_when_db_missing_raises` — verifies `read_only=True` on a missing DB raises an error

## What Does NOT Change

- Main store initialization (`dependencies.py:67`) — auto-detect is correct for the query path
- Snapshot stores (`dependencies.py:212`) — always read-only for backup browsing
- CLI commands (`distill_cmd.py`, `extract.py`, `validate_cmd.py`) — read-only, correct
- MCP tools (`mcp/tools.py`) — read-only, correct
- `UnifiedIndexer` — no changes needed; its `storage=None` fallback was already the correct write path
- `UnifiedStorage` — no changes needed

## Test plan

- [x] 2 new tests for explicit `read_only` parameter (passed)
- [x] 99 dependency-related tests (passed)
- [x] Full test suite: 2063 passed, 1 skipped, 0 failed
- [x] `ruff check` and `ruff format --check` clean
- [ ] Manual verification: start app, trigger indexing, confirm no read-only errors