### PR TITLE
Fix DuckDB startup overhead and update Ollama defaults

### DIFF
--- a/config/settings.default.toml
+++ b/config/settings.default.toml
@@ -65,7 +65,7 @@ use_rich_console = true
 [llm]
 default_provider = "ollama"
 openai_model = "gpt-4.1-mini"
-ollama_model = "ollama/gemma3"
+ollama_model = "ollama/gemma4:latest"
 
 [chat]
 # Controls the non-streaming RAG endpoint and citation/source output.

--- a/src/searchat/api/dependencies.py
+++ b/src/searchat/api/dependencies.py
@@ -77,7 +77,11 @@ def initialize_services():
         from searchat.services.analytics import SearchAnalyticsService
         from searchat.services.storage_service import build_storage_service
 
-        _duckdb_store = build_storage_service(_search_dir, config=_config)
+        _duckdb_store = build_storage_service(
+            _search_dir,
+            config=_config,
+            read_only=False,
+        )
 
         if _config.expertise.enabled:
             from searchat.expertise.store import ExpertiseStore
@@ -433,7 +437,11 @@ def _ensure_indexer():
         try:
             from searchat.core.unified_indexer import UnifiedIndexer
 
-            _indexer = UnifiedIndexer(_search_dir, _config)
+            _indexer = UnifiedIndexer(
+                _search_dir,
+                _config,
+                storage=get_duckdb_store(),
+            )
             readiness.set_component("indexer", "ready")
         except Exception as e:
             readiness.set_component("indexer", "error", error=str(e))

--- a/src/searchat/config/settings.default.toml
+++ b/src/searchat/config/settings.default.toml
@@ -69,7 +69,7 @@ use_rich_console = true
 [llm]
 default_provider = "ollama"
 openai_model = "gpt-4.1-mini"
-ollama_model = "ollama/gemma3"
+ollama_model = "ollama/gemma4:latest"
 
 # Embedded (local GGUF via llama-cpp-python). Only used when default_provider = "embedded"
 embedded_model_path = ""

--- a/src/searchat/storage/unified_storage.py
+++ b/src/searchat/storage/unified_storage.py
@@ -5,6 +5,7 @@ that owns conversations, messages, exchanges, embeddings, file state,
 and code blocks. Thread safety: one shared connection, fresh cursors
 per read, thread-local cursors for writes.
 """
+
 from __future__ import annotations
 
 import logging
@@ -18,7 +19,6 @@ import duckdb
 
 from searchat.storage.schema import (
     EMBEDDING_DIM,
-    create_fts_indexes,
     create_hnsw_indexes,
     ensure_tables,
     install_fts,
@@ -80,9 +80,7 @@ class UnifiedStorage:
         if self._vss_available and not read_only:
             # Enable HNSW persistence for on-disk databases
             try:
-                self._conn.execute(
-                    "SET hnsw_enable_experimental_persistence = true"
-                )
+                self._conn.execute("SET hnsw_enable_experimental_persistence = true")
             except duckdb.Error:
                 pass
             create_hnsw_indexes(
@@ -90,8 +88,6 @@ class UnifiedStorage:
                 ef_construction=hnsw_ef_construction,
                 m=hnsw_m,
             )
-        if self._fts_available and not read_only:
-            create_fts_indexes(self._conn)
 
     @property
     def connection(self) -> duckdb.DuckDBPyConnection:
@@ -158,7 +154,9 @@ class UnifiedStorage:
                     "project_id": pid,
                     "conversation_count": int(cc),
                     "message_count": int(mc),
-                    "updated_at": ua.isoformat() if isinstance(ua, datetime) else str(ua),
+                    "updated_at": ua.isoformat()
+                    if isinstance(ua, datetime)
+                    else str(ua),
                 }
                 for pid, cc, mc, ua in rows
             ]
@@ -213,8 +211,14 @@ class UnifiedStorage:
         try:
             rows = cur.execute(query, params).fetchall()
             columns = [
-                "conversation_id", "project_id", "title", "created_at",
-                "updated_at", "message_count", "file_path", "full_text",
+                "conversation_id",
+                "project_id",
+                "title",
+                "created_at",
+                "updated_at",
+                "message_count",
+                "file_path",
+                "full_text",
             ]
             return [dict(zip(columns, row)) for row in rows]
         finally:
@@ -275,8 +279,13 @@ class UnifiedStorage:
             if row is None:
                 return None
             columns = [
-                "conversation_id", "project_id", "title", "created_at",
-                "updated_at", "message_count", "file_path",
+                "conversation_id",
+                "project_id",
+                "title",
+                "created_at",
+                "updated_at",
+                "message_count",
+                "file_path",
             ]
             return dict(zip(columns, row))
         finally:
@@ -372,9 +381,16 @@ class UnifiedStorage:
             "files_mentioned, git_branch) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
-                conversation_id, project_id, file_path, title,
-                created_at, updated_at, message_count, full_text,
-                file_hash, indexed_at,
+                conversation_id,
+                project_id,
+                file_path,
+                title,
+                created_at,
+                updated_at,
+                message_count,
+                full_text,
+                file_hash,
+                indexed_at,
                 json.dumps(files_mentioned) if files_mentioned else None,
                 git_branch,
             ],
@@ -434,8 +450,15 @@ class UnifiedStorage:
             "ON CONFLICT (exchange_id) DO UPDATE SET "
             "exchange_text = EXCLUDED.exchange_text, "
             "created_at = EXCLUDED.created_at",
-            [exchange_id, conversation_id, project_id, ply_start,
-             ply_end, exchange_text, created_at],
+            [
+                exchange_id,
+                conversation_id,
+                project_id,
+                ply_start,
+                ply_end,
+                exchange_text,
+                created_at,
+            ],
         )
 
     def upsert_embedding(
@@ -474,8 +497,13 @@ class UnifiedStorage:
             "status, file_size, file_hash, updated_at) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             [
-                file_path, conversation_id, project_id, connector_name,
-                status, file_size, file_hash,
+                file_path,
+                conversation_id,
+                project_id,
+                connector_name,
+                status,
+                file_size,
+                file_hash,
                 updated_at or datetime.now(),
             ],
         )
@@ -516,14 +544,26 @@ class UnifiedStorage:
             "functions, classes, imports, code, code_hash, lines) "
             "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
-                conversation_id, project_id, connector, file_path, title,
-                conversation_created_at, conversation_updated_at,
-                message_index, block_index, role, message_timestamp,
-                fence_language, language, language_source,
+                conversation_id,
+                project_id,
+                connector,
+                file_path,
+                title,
+                conversation_created_at,
+                conversation_updated_at,
+                message_index,
+                block_index,
+                role,
+                message_timestamp,
+                fence_language,
+                language,
+                language_source,
                 json.dumps(functions) if functions else None,
                 json.dumps(classes) if classes else None,
                 json.dumps(imports) if imports else None,
-                code, code_hash, lines,
+                code,
+                code_hash,
+                lines,
             ],
         )
 
@@ -545,9 +585,7 @@ class UnifiedStorage:
     def get_embedding_count(self) -> int:
         cur = self._read_cursor()
         try:
-            row = cur.execute(
-                "SELECT COUNT(*) FROM verbatim_embeddings"
-            ).fetchone()
+            row = cur.execute("SELECT COUNT(*) FROM verbatim_embeddings").fetchone()
             return int(row[0]) if row else 0
         finally:
             cur.close()

--- a/tests/api/test_app_dependencies_and_status.py
+++ b/tests/api/test_app_dependencies_and_status.py
@@ -88,7 +88,9 @@ async def test_status_endpoint_returns_readiness_snapshot() -> None:
     }
 
 
-def test_status_features_endpoint_returns_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_status_features_endpoint_returns_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from searchat.api.app import app
 
     retrieval_service = Mock()
@@ -101,7 +103,9 @@ def test_status_features_endpoint_returns_flags(monkeypatch: pytest.MonkeyPatch)
     config = SimpleNamespace(
         analytics=SimpleNamespace(enabled=True),
         chat=SimpleNamespace(enable_rag=True, enable_citations=False),
-        export=SimpleNamespace(enable_ipynb=False, enable_pdf=True, enable_tech_docs=False),
+        export=SimpleNamespace(
+            enable_ipynb=False, enable_pdf=True, enable_tech_docs=False
+        ),
         dashboards=SimpleNamespace(enabled=True),
         snapshots=SimpleNamespace(enabled=True),
     )
@@ -118,11 +122,16 @@ def test_status_features_endpoint_returns_flags(monkeypatch: pytest.MonkeyPatch)
     assert data["export"]["enable_pdf"] is True
     assert data["snapshots"]["enabled"] is True
     assert data["retrieval"]["semantic_available"] is False
-    assert data["retrieval"]["semantic_reason"] == "Embedding model unavailable: all-MiniLM-L6-v2"
+    assert (
+        data["retrieval"]["semantic_reason"]
+        == "Embedding model unavailable: all-MiniLM-L6-v2"
+    )
 
 
 @pytest.mark.asyncio
-async def test_status_endpoint_includes_retrieval_capabilities(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_status_endpoint_includes_retrieval_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from searchat.api.routers.status import get_status
     from searchat.api.readiness import get_readiness
 
@@ -163,7 +172,9 @@ def test_dependencies_getters_raise_when_not_initialized() -> None:
         deps.get_platform_manager()
 
 
-def test_start_background_warmup_no_event_loop_returns(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_start_background_warmup_no_event_loop_returns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import searchat.api.dependencies as deps
 
     deps._config = object()
@@ -173,7 +184,9 @@ def test_start_background_warmup_no_event_loop_returns(monkeypatch: pytest.Monke
     deps.start_background_warmup()
 
 
-def test_initialize_services_sets_error_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_initialize_services_sets_error_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import searchat.api.dependencies as deps
     from searchat.api.readiness import get_readiness
 
@@ -190,7 +203,9 @@ def test_initialize_services_sets_error_on_exception(monkeypatch: pytest.MonkeyP
     assert "services" in snap.errors
 
 
-def test_dependencies_indexer_is_created_lazily(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_dependencies_indexer_is_created_lazily(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     import searchat.api.dependencies as deps
 
     deps._config = object()
@@ -198,8 +213,11 @@ def test_dependencies_indexer_is_created_lazily(monkeypatch: pytest.MonkeyPatch,
 
     fake_indexer = object()
 
+    deps._duckdb_store = object()
+
     class FakeIndexer:
         def __new__(cls, *args, **kwargs):
+            assert kwargs["storage"] is deps._duckdb_store
             return fake_indexer
 
     monkeypatch.setattr("searchat.core.unified_indexer.UnifiedIndexer", FakeIndexer)
@@ -218,9 +236,13 @@ async def test_app_shutdown_stops_watcher(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(api_app, "set_watcher", set_watcher_mock)
     monkeypatch.setattr(api_app, "initialize_services", MagicMock())
     monkeypatch.setattr(api_app, "start_background_warmup", MagicMock())
-    monkeypatch.setattr(api_app, "get_config", lambda: SimpleNamespace(logging=SimpleNamespace()))
+    monkeypatch.setattr(
+        api_app, "get_config", lambda: SimpleNamespace(logging=SimpleNamespace())
+    )
     monkeypatch.setattr(api_app, "setup_logging", MagicMock())
-    monkeypatch.setattr(api_app.asyncio, "create_task", lambda coro: (coro.close(), MagicMock())[1])
+    monkeypatch.setattr(
+        api_app.asyncio, "create_task", lambda coro: (coro.close(), MagicMock())[1]
+    )
 
     async with api_app.lifespan(MagicMock()):
         pass  # shutdown runs after yield
@@ -230,12 +252,16 @@ async def test_app_shutdown_stops_watcher(monkeypatch: pytest.MonkeyPatch) -> No
 
 
 @pytest.mark.asyncio
-async def test_app_lifespan_initializes_services_and_schedules_watcher(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_app_lifespan_initializes_services_and_schedules_watcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     api_app = _api_app_module()
 
     monkeypatch.setattr(api_app, "initialize_services", MagicMock())
     monkeypatch.setattr(api_app, "start_background_warmup", MagicMock())
-    monkeypatch.setattr(api_app, "get_config", lambda: SimpleNamespace(logging=SimpleNamespace()))
+    monkeypatch.setattr(
+        api_app, "get_config", lambda: SimpleNamespace(logging=SimpleNamespace())
+    )
     monkeypatch.setattr(api_app, "setup_logging", MagicMock())
     monkeypatch.setattr(api_app, "get_watcher", lambda: None)
 
@@ -259,7 +285,9 @@ async def test_app_lifespan_profile_logging(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setenv("SEARCHAT_PROFILE_STARTUP", "1")
     monkeypatch.setattr(api_app, "initialize_services", MagicMock())
     monkeypatch.setattr(api_app, "start_background_warmup", MagicMock())
-    monkeypatch.setattr(api_app, "get_config", lambda: SimpleNamespace(logging=SimpleNamespace()))
+    monkeypatch.setattr(
+        api_app, "get_config", lambda: SimpleNamespace(logging=SimpleNamespace())
+    )
     monkeypatch.setattr(api_app, "setup_logging", MagicMock())
     monkeypatch.setattr(api_app, "get_watcher", lambda: None)
 
@@ -280,6 +308,7 @@ async def test_app_lifespan_profile_logging(monkeypatch: pytest.MonkeyPatch) -> 
 async def test_app_root_and_conversation_page_serve_html() -> None:
     """Verify that / and /conversation/{id} both return HTML via Jinja2 templates."""
     from httpx import ASGITransport, AsyncClient
+
     api_app = _api_app_module()
 
     transport = ASGITransport(app=api_app.app)
@@ -301,7 +330,9 @@ async def test_favicon_ico_redirects_to_svg() -> None:
     assert resp.headers.get("location") == "/static/favicon.svg"
 
 
-def test_on_new_conversations_indexes_and_invalidates(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_on_new_conversations_indexes_and_invalidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     api_app = _api_app_module()
     import searchat.api.dependencies as deps
 
@@ -319,11 +350,15 @@ def test_on_new_conversations_indexes_and_invalidates(monkeypatch: pytest.Monkey
     invalidate.assert_called_once()
 
 
-def test_on_new_conversations_uses_adaptive_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_on_new_conversations_uses_adaptive_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     api_app = _api_app_module()
     import searchat.api.dependencies as deps
 
-    fake_stats = SimpleNamespace(new_conversations=0, updated_conversations=1, update_time_seconds=0.01)
+    fake_stats = SimpleNamespace(
+        new_conversations=0, updated_conversations=1, update_time_seconds=0.01
+    )
 
     class FakeIndexing:
         enable_adaptive_indexing = True
@@ -349,7 +384,9 @@ def test_on_new_conversations_uses_adaptive_when_enabled(monkeypatch: pytest.Mon
     invalidate.assert_called_once()
 
 
-def test_on_new_conversations_handles_config_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_on_new_conversations_handles_config_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     api_app = _api_app_module()
     import searchat.api.dependencies as deps
 
@@ -376,11 +413,15 @@ def test_on_new_conversations_handles_config_error(monkeypatch: pytest.MonkeyPat
     invalidate.assert_called_once()
 
 
-def test_on_new_conversations_handles_indexer_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_on_new_conversations_handles_indexer_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     api_app = _api_app_module()
     import searchat.api.dependencies as deps
 
-    monkeypatch.setattr(api_app, "get_indexer", lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(
+        api_app, "get_indexer", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
     monkeypatch.setattr(deps, "get_or_create_search_engine", lambda: object())
 
     api_app.on_new_conversations(["a.jsonl"])
@@ -388,7 +429,9 @@ def test_on_new_conversations_handles_indexer_failure(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.asyncio
-async def test_start_watcher_background_sets_readiness_running(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_start_watcher_background_sets_readiness_running(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     api_app = _api_app_module()
     from searchat.api.readiness import get_readiness
 
@@ -415,7 +458,9 @@ async def test_start_watcher_background_sets_readiness_running(monkeypatch: pyte
 
 
 @pytest.mark.asyncio
-async def test_start_watcher_background_sets_readiness_error_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_start_watcher_background_sets_readiness_error_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     api_app = _api_app_module()
     from searchat.api.readiness import get_readiness
 
@@ -432,7 +477,9 @@ async def test_start_watcher_background_sets_readiness_error_on_exception(monkey
     assert "watcher" in snap.errors
 
 
-def test_app_main_invalid_port_prints_and_returns(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+def test_app_main_invalid_port_prints_and_returns(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     api_app = _api_app_module()
 
     monkeypatch.setenv(api_app.ENV_PORT, "not-a-number")
@@ -441,7 +488,9 @@ def test_app_main_invalid_port_prints_and_returns(monkeypatch: pytest.MonkeyPatc
     assert "Invalid" in out or "invalid" in out
 
 
-def test_app_main_invalid_port_out_of_range(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+def test_app_main_invalid_port_out_of_range(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     api_app = _api_app_module()
 
     monkeypatch.setenv(api_app.ENV_PORT, "70000")
@@ -450,7 +499,9 @@ def test_app_main_invalid_port_out_of_range(monkeypatch: pytest.MonkeyPatch, cap
     assert "Invalid" in out or "invalid" in out
 
 
-def test_app_main_scans_for_available_port_and_calls_uvicorn(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_app_main_scans_for_available_port_and_calls_uvicorn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     api_app = _api_app_module()
 
     monkeypatch.delenv(api_app.ENV_PORT, raising=False)
@@ -471,7 +522,9 @@ def test_app_main_scans_for_available_port_and_calls_uvicorn(monkeypatch: pytest
 
     import types
 
-    fake_socket_mod = types.SimpleNamespace(AF_INET=0, SOCK_STREAM=0, socket=lambda *a, **k: DummySocket())
+    fake_socket_mod = types.SimpleNamespace(
+        AF_INET=0, SOCK_STREAM=0, socket=lambda *a, **k: DummySocket()
+    )
     fake_uvicorn = types.SimpleNamespace(run=MagicMock())
 
     monkeypatch.setitem(os.environ, api_app.ENV_HOST, "127.0.0.1")
@@ -484,7 +537,9 @@ def test_app_main_scans_for_available_port_and_calls_uvicorn(monkeypatch: pytest
     fake_uvicorn.run.assert_called_once()
 
 
-def test_app_main_port_scan_exhausted(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+def test_app_main_port_scan_exhausted(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     api_app = _api_app_module()
 
     monkeypatch.delenv(api_app.ENV_PORT, raising=False)
@@ -503,7 +558,9 @@ def test_app_main_port_scan_exhausted(monkeypatch: pytest.MonkeyPatch, capsys: p
 
     import types
 
-    fake_socket_mod = types.SimpleNamespace(AF_INET=0, SOCK_STREAM=0, socket=lambda *a, **k: FailingSocket())
+    fake_socket_mod = types.SimpleNamespace(
+        AF_INET=0, SOCK_STREAM=0, socket=lambda *a, **k: FailingSocket()
+    )
     fake_uvicorn = types.SimpleNamespace(run=MagicMock())
 
     monkeypatch.setitem(sys.modules, "socket", fake_socket_mod)
@@ -584,7 +641,10 @@ def test_chat_streams_response_when_ready(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setattr("searchat.api.routers.chat.get_config", lambda: object())
     monkeypatch.setattr("searchat.api.routers.chat.get_search_engine", lambda: object())
-    monkeypatch.setattr("searchat.api.routers.chat.generate_answer_stream", lambda **_kwargs: ("test-session-id", _fake_stream()))
+    monkeypatch.setattr(
+        "searchat.api.routers.chat.generate_answer_stream",
+        lambda **_kwargs: ("test-session-id", _fake_stream()),
+    )
 
     client = TestClient(app)
     response = client.post(
@@ -615,7 +675,9 @@ def test_chat_snapshot_mode_returns_403() -> None:
     assert response.json()["detail"] == "Chat is disabled in snapshot mode"
 
 
-def test_chat_returns_400_on_generate_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_chat_returns_400_on_generate_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from searchat.api.app import app
     from searchat.api.readiness import get_readiness
 
@@ -637,7 +699,9 @@ def test_chat_returns_400_on_generate_value_error(monkeypatch: pytest.MonkeyPatc
     assert resp.json()["detail"] == "Invalid chat request."
 
 
-def test_chat_returns_400_on_stable_generate_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_chat_returns_400_on_stable_generate_value_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from searchat.api.app import app
     from searchat.api.readiness import get_readiness
 
@@ -650,16 +714,23 @@ def test_chat_returns_400_on_stable_generate_value_error(monkeypatch: pytest.Mon
     monkeypatch.setattr("searchat.api.routers.chat.get_search_engine", lambda: object())
     monkeypatch.setattr(
         "searchat.api.routers.chat.generate_answer_stream",
-        lambda **_kwargs: (_ for _ in ()).throw(ValueError("model_name must be provided or configured for this provider.")),
+        lambda **_kwargs: (_ for _ in ()).throw(
+            ValueError("model_name must be provided or configured for this provider.")
+        ),
     )
 
     client = TestClient(app)
     resp = client.post("/api/chat", json={"query": "hello", "model_provider": "openai"})
     assert resp.status_code == 400
-    assert resp.json()["detail"] == "model_name must be provided or configured for this provider."
+    assert (
+        resp.json()["detail"]
+        == "model_name must be provided or configured for this provider."
+    )
 
 
-def test_chat_returns_503_on_generate_llm_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_chat_returns_503_on_generate_llm_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from searchat.api.app import app
     from searchat.api.readiness import get_readiness
     from searchat.services.llm_service import LLMServiceError
@@ -682,7 +753,9 @@ def test_chat_returns_503_on_generate_llm_error(monkeypatch: pytest.MonkeyPatch)
     assert resp.json()["detail"] == "Generation service unavailable."
 
 
-def test_chat_returns_503_on_stable_generate_llm_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_chat_returns_503_on_stable_generate_llm_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from searchat.api.app import app
     from searchat.api.readiness import get_readiness
     from searchat.services.llm_service import LLMServiceError
@@ -696,7 +769,9 @@ def test_chat_returns_503_on_stable_generate_llm_error(monkeypatch: pytest.Monke
     monkeypatch.setattr("searchat.api.routers.chat.get_search_engine", lambda: object())
     monkeypatch.setattr(
         "searchat.api.routers.chat.generate_answer_stream",
-        lambda **_kwargs: (_ for _ in ()).throw(LLMServiceError("Ollama provider unreachable or returned an error.")),
+        lambda **_kwargs: (_ for _ in ()).throw(
+            LLMServiceError("Ollama provider unreachable or returned an error.")
+        ),
     )
 
     client = TestClient(app)
@@ -705,7 +780,9 @@ def test_chat_returns_503_on_stable_generate_llm_error(monkeypatch: pytest.Monke
     assert resp.json()["detail"] == "Ollama provider unreachable or returned an error."
 
 
-def test_chat_generation_outage_returns_archival_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_chat_generation_outage_returns_archival_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from searchat.api.app import app
     from searchat.api.readiness import get_readiness
     from searchat.models import SearchResult, SearchResults
@@ -747,19 +824,29 @@ def test_chat_generation_outage_returns_archival_fallback(monkeypatch: pytest.Mo
         )
     )
     monkeypatch.setattr("searchat.api.routers.chat.get_config", lambda: config)
-    monkeypatch.setattr("searchat.api.routers.chat.get_search_engine", lambda: retrieval_service)
+    monkeypatch.setattr(
+        "searchat.api.routers.chat.get_search_engine", lambda: retrieval_service
+    )
 
-    with patch("searchat.services.chat_service.build_generation_service") as mock_builder:
-        mock_builder.return_value.stream_completion.side_effect = LLMServiceError("nope")
+    with patch(
+        "searchat.services.chat_service.build_generation_service"
+    ) as mock_builder:
+        mock_builder.return_value.stream_completion.side_effect = LLMServiceError(
+            "nope"
+        )
 
         client = TestClient(app)
-        resp = client.post("/api/chat", json={"query": "hello", "model_provider": "openai"})
+        resp = client.post(
+            "/api/chat", json={"query": "hello", "model_provider": "openai"}
+        )
 
     assert resp.status_code == 200
     assert resp.text.startswith("Generation is temporarily unavailable.")
 
 
-def test_chat_returns_500_on_generate_unexpected_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_chat_returns_500_on_generate_unexpected_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from searchat.api.app import app
     from searchat.api.readiness import get_readiness
 
@@ -798,7 +885,9 @@ def test_resolve_dataset_search_dir_snapshot_mode_disabled(tmp_path) -> None:
 
     deps._search_dir = tmp_path
     deps._config = SimpleNamespace(snapshots=SimpleNamespace(enabled=False))
-    deps._backup_manager = SimpleNamespace(backup_dir=tmp_path, validate_backup=lambda _p: True)
+    deps._backup_manager = SimpleNamespace(
+        backup_dir=tmp_path, validate_backup=lambda _p: True
+    )
 
     try:
         deps.resolve_dataset_search_dir("backup_20250101_000000")
@@ -812,7 +901,9 @@ def test_resolve_dataset_search_dir_invalid_name(tmp_path) -> None:
 
     deps._search_dir = tmp_path
     deps._config = SimpleNamespace(snapshots=SimpleNamespace(enabled=True))
-    deps._backup_manager = SimpleNamespace(backup_dir=tmp_path, validate_backup=lambda _p: True)
+    deps._backup_manager = SimpleNamespace(
+        backup_dir=tmp_path, validate_backup=lambda _p: True
+    )
 
     try:
         deps.resolve_dataset_search_dir("../nope")
@@ -832,7 +923,9 @@ def test_resolve_dataset_search_dir_invalid_snapshot_path_symlink(tmp_path) -> N
 
     deps._search_dir = tmp_path
     deps._config = SimpleNamespace(snapshots=SimpleNamespace(enabled=True))
-    deps._backup_manager = SimpleNamespace(backup_dir=backup_root, validate_backup=lambda _p: True)
+    deps._backup_manager = SimpleNamespace(
+        backup_dir=backup_root, validate_backup=lambda _p: True
+    )
 
     try:
         deps.resolve_dataset_search_dir("snap")
@@ -849,7 +942,9 @@ def test_resolve_dataset_search_dir_not_found(tmp_path) -> None:
 
     deps._search_dir = tmp_path
     deps._config = SimpleNamespace(snapshots=SimpleNamespace(enabled=True))
-    deps._backup_manager = SimpleNamespace(backup_dir=backup_root, validate_backup=lambda _p: True)
+    deps._backup_manager = SimpleNamespace(
+        backup_dir=backup_root, validate_backup=lambda _p: True
+    )
 
     try:
         deps.resolve_dataset_search_dir("missing")
@@ -867,7 +962,9 @@ def test_resolve_dataset_search_dir_validation_failed(tmp_path) -> None:
 
     deps._search_dir = tmp_path
     deps._config = SimpleNamespace(snapshots=SimpleNamespace(enabled=True))
-    deps._backup_manager = SimpleNamespace(backup_dir=backup_root, validate_backup=lambda _p: False)
+    deps._backup_manager = SimpleNamespace(
+        backup_dir=backup_root, validate_backup=lambda _p: False
+    )
 
     try:
         deps.resolve_dataset_search_dir("snap")
@@ -886,7 +983,9 @@ def test_resolve_dataset_search_dir_returns_snapshot_dir(tmp_path) -> None:
 
     deps._search_dir = tmp_path
     deps._config = SimpleNamespace(snapshots=SimpleNamespace(enabled=True))
-    deps._backup_manager = SimpleNamespace(backup_dir=backup_root, validate_backup=lambda _p: True)
+    deps._backup_manager = SimpleNamespace(
+        backup_dir=backup_root, validate_backup=lambda _p: True
+    )
 
     resolved, name = deps.resolve_dataset_search_dir("snap")
     assert resolved == snapshot_dir
@@ -917,7 +1016,9 @@ def test_resolve_dataset_search_dir_accepts_legacy_browsable_snapshot(tmp_path) 
     assert name == "legacy"
 
 
-def test_resolve_dataset_search_dir_fixture_snapshots_follow_contracts(tmp_path) -> None:
+def test_resolve_dataset_search_dir_fixture_snapshots_follow_contracts(
+    tmp_path,
+) -> None:
     import shutil
     import searchat.api.dependencies as deps
     from searchat.services.backup import BackupManager
@@ -934,7 +1035,9 @@ def test_resolve_dataset_search_dir_fixture_snapshots_follow_contracts(tmp_path)
     assert resolved == backup_root / "repairable_manifest_base"
     assert name == "repairable_manifest_base"
 
-    resolved_mixed, name_mixed = deps.resolve_dataset_search_dir("mixed_version_metadata_full")
+    resolved_mixed, name_mixed = deps.resolve_dataset_search_dir(
+        "mixed_version_metadata_full"
+    )
     assert resolved_mixed == backup_root / "mixed_version_metadata_full"
     assert name_mixed == "mixed_version_metadata_full"
 
@@ -943,7 +1046,9 @@ def test_resolve_dataset_search_dir_fixture_snapshots_follow_contracts(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_start_background_warmup_schedules_once(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+async def test_start_background_warmup_schedules_once(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     import searchat.api.dependencies as deps
     import searchat.api.warmup as api_warmup
 
@@ -977,7 +1082,9 @@ async def test_start_background_warmup_schedules_once(monkeypatch: pytest.Monkey
         pass
 
 
-def test_warmup_duckdb_parquet_sets_error(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_warmup_duckdb_parquet_sets_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     import searchat.api.warmup as api_warmup
     from searchat.api.readiness import get_readiness
 
@@ -995,7 +1102,9 @@ def test_warmup_duckdb_parquet_sets_error(monkeypatch: pytest.MonkeyPatch, tmp_p
     assert snap.components["parquet"] == "error"
 
 
-def test_warmup_semantic_components_sets_error_only_for_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_warmup_semantic_components_sets_error_only_for_not_ready(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import searchat.api.warmup as api_warmup
     from searchat.api.readiness import get_readiness
 
@@ -1009,7 +1118,9 @@ def test_warmup_semantic_components_sets_error_only_for_not_ready(monkeypatch: p
         def ensure_embedder_loaded(self):
             raise AssertionError("should not be called")
 
-    monkeypatch.setattr("searchat.api.dependencies._ensure_search_engine", lambda: FakeEngine())
+    monkeypatch.setattr(
+        "searchat.api.dependencies._ensure_search_engine", lambda: FakeEngine()
+    )
 
     readiness = get_readiness()
     readiness.set_component("metadata", "idle")
@@ -1023,7 +1134,9 @@ def test_warmup_semantic_components_sets_error_only_for_not_ready(monkeypatch: p
     assert snap.components["embedder"] == "error"
 
 
-def test_get_duckdb_store_for_caches_per_dataset(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_get_duckdb_store_for_caches_per_dataset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     import searchat.api.dependencies as deps
     import searchat.services.storage_service as storage_mod
 
@@ -1062,7 +1175,9 @@ def test_get_duckdb_store_for_caches_per_dataset(monkeypatch: pytest.MonkeyPatch
     assert created == [other]
 
 
-def test_get_or_create_search_engine_for_caches_per_dataset(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_get_or_create_search_engine_for_caches_per_dataset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     import searchat.api.dependencies as deps
     import searchat.services.retrieval_service as retrieval_mod
 
@@ -1081,7 +1196,11 @@ def test_get_or_create_search_engine_for_caches_per_dataset(monkeypatch: pytest.
         def __init__(self, search_dir, _config):
             created.append(search_dir)
 
-    monkeypatch.setattr(retrieval_mod, "build_retrieval_service", lambda search_dir, *, config: FakeEngine(search_dir, config))
+    monkeypatch.setattr(
+        retrieval_mod,
+        "build_retrieval_service",
+        lambda search_dir, *, config: FakeEngine(search_dir, config),
+    )
 
     assert deps.get_or_create_search_engine_for(base) is deps._search_engine
 
@@ -1091,7 +1210,9 @@ def test_get_or_create_search_engine_for_caches_per_dataset(monkeypatch: pytest.
     assert created == [other]
 
 
-def test_ensure_search_engine_sets_readiness_error_on_failure(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_ensure_search_engine_sets_readiness_error_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     import searchat.api.dependencies as deps
     from searchat.api.readiness import get_readiness
     import searchat.services.retrieval_service as retrieval_mod
@@ -1104,7 +1225,11 @@ def test_ensure_search_engine_sets_readiness_error_on_failure(monkeypatch: pytes
         def __init__(self, *_a, **_k):
             raise RuntimeError("boom")
 
-    monkeypatch.setattr(retrieval_mod, "build_retrieval_service", lambda search_dir, *, config: BoomEngine(search_dir, config))
+    monkeypatch.setattr(
+        retrieval_mod,
+        "build_retrieval_service",
+        lambda search_dir, *, config: BoomEngine(search_dir, config),
+    )
 
     with pytest.raises(RuntimeError):
         deps.get_or_create_search_engine()
@@ -1112,7 +1237,9 @@ def test_ensure_search_engine_sets_readiness_error_on_failure(monkeypatch: pytes
     assert get_readiness().snapshot().components["search_engine"] == "error"
 
 
-def test_ensure_indexer_sets_readiness_error_on_failure(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+def test_ensure_indexer_sets_readiness_error_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     import searchat.api.dependencies as deps
     from searchat.api.readiness import get_readiness
     import searchat.core.unified_indexer as indexer_mod

--- a/tests/unit/api/test_dependencies.py
+++ b/tests/unit/api/test_dependencies.py
@@ -19,7 +19,9 @@ class FakeReadiness:
         self.warmup_started = False
         self.component_calls: list[tuple[str, str, str | None]] = []
 
-    def set_component(self, name: str, status: str, *, error: str | None = None) -> None:
+    def set_component(
+        self, name: str, status: str, *, error: str | None = None
+    ) -> None:
         self.components[name] = status
         if error is not None:
             self.errors[name] = error
@@ -54,7 +56,9 @@ def reset_dependency_singletons(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(api_state, "stats_cache", "x")
 
 
-def test_initialize_services_sets_components_ready(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_initialize_services_sets_components_ready(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     readiness = FakeReadiness()
     monkeypatch.setattr(deps, "get_readiness", lambda: readiness)
 
@@ -67,7 +71,9 @@ def test_initialize_services_sets_components_ready(monkeypatch: pytest.MonkeyPat
         storage=SimpleNamespace(backend="duckdb"),
     )
     monkeypatch.setattr(deps.Config, "load", staticmethod(lambda: cfg))
-    monkeypatch.setattr(deps.PathResolver, "get_shared_search_dir", staticmethod(lambda _cfg: tmp_path))
+    monkeypatch.setattr(
+        deps.PathResolver, "get_shared_search_dir", staticmethod(lambda _cfg: tmp_path)
+    )
 
     monkeypatch.setattr(deps, "BackupManager", lambda _p: object())
     monkeypatch.setattr(deps, "PlatformManager", lambda: object())
@@ -75,7 +81,12 @@ def test_initialize_services_sets_components_ready(monkeypatch: pytest.MonkeyPat
     fake_store = SimpleNamespace(memory_limit_mb=123)
 
     import searchat.services.storage_service as storage_mod
-    monkeypatch.setattr(storage_mod, "build_storage_service", lambda _sd, *, config: fake_store)
+
+    monkeypatch.setattr(
+        storage_mod,
+        "build_storage_service",
+        lambda _sd, *, config, read_only=None: fake_store,
+    )
 
     class _BookmarksService:
         def __init__(self, _cfg):
@@ -93,10 +104,26 @@ def test_initialize_services_sets_components_ready(monkeypatch: pytest.MonkeyPat
         def __init__(self, _cfg):
             self.cfg = _cfg
 
-    monkeypatch.setitem(sys.modules, "searchat.services.bookmarks", types.SimpleNamespace(BookmarksService=_BookmarksService))
-    monkeypatch.setitem(sys.modules, "searchat.services.saved_queries", types.SimpleNamespace(SavedQueriesService=_SavedQueriesService))
-    monkeypatch.setitem(sys.modules, "searchat.services.dashboards", types.SimpleNamespace(DashboardsService=_DashboardsService))
-    monkeypatch.setitem(sys.modules, "searchat.services.analytics", types.SimpleNamespace(SearchAnalyticsService=_AnalyticsService))
+    monkeypatch.setitem(
+        sys.modules,
+        "searchat.services.bookmarks",
+        types.SimpleNamespace(BookmarksService=_BookmarksService),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "searchat.services.saved_queries",
+        types.SimpleNamespace(SavedQueriesService=_SavedQueriesService),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "searchat.services.dashboards",
+        types.SimpleNamespace(DashboardsService=_DashboardsService),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "searchat.services.analytics",
+        types.SimpleNamespace(SearchAnalyticsService=_AnalyticsService),
+    )
 
     deps.initialize_services()
 
@@ -113,7 +140,9 @@ def test_initialize_services_sets_components_ready(monkeypatch: pytest.MonkeyPat
     assert readiness.components["services"] == "ready"
 
 
-def test_initialize_services_sets_error_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_initialize_services_sets_error_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     readiness = FakeReadiness()
     monkeypatch.setattr(deps, "get_readiness", lambda: readiness)
 
@@ -128,7 +157,9 @@ def test_initialize_services_sets_error_on_exception(monkeypatch: pytest.MonkeyP
     assert readiness.components["services"] == "error"
 
 
-def test_start_background_warmup_returns_if_not_initialized(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_start_background_warmup_returns_if_not_initialized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import searchat.api.warmup as api_warmup
 
     readiness = FakeReadiness()
@@ -139,7 +170,9 @@ def test_start_background_warmup_returns_if_not_initialized(monkeypatch: pytest.
     assert readiness.warmup_started is False
 
 
-def test_start_background_warmup_returns_without_event_loop(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_start_background_warmup_returns_without_event_loop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     import searchat.api.warmup as api_warmup
 
     readiness = FakeReadiness()
@@ -148,14 +181,20 @@ def test_start_background_warmup_returns_without_event_loop(monkeypatch: pytest.
     monkeypatch.setattr(deps, "_config", object())
     monkeypatch.setattr(deps, "_search_dir", tmp_path)
 
-    monkeypatch.setattr(asyncio, "get_running_loop", lambda: (_ for _ in ()).throw(RuntimeError("no loop")))
+    monkeypatch.setattr(
+        asyncio,
+        "get_running_loop",
+        lambda: (_ for _ in ()).throw(RuntimeError("no loop")),
+    )
 
     deps.start_background_warmup()
 
     assert readiness.warmup_started is True
 
 
-def test_start_background_warmup_is_idempotent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_start_background_warmup_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     import searchat.api.warmup as api_warmup
 
     readiness = FakeReadiness()
@@ -204,7 +243,9 @@ def test_warmup_duckdb_parquet_success(monkeypatch: pytest.MonkeyPatch) -> None:
     assert readiness.components["parquet"] == "ready"
 
 
-def test_warmup_duckdb_parquet_failure_sets_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_warmup_duckdb_parquet_failure_sets_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import searchat.api.warmup as api_warmup
 
     readiness = FakeReadiness()
@@ -238,7 +279,9 @@ def test_warmup_semantic_components_success(monkeypatch: pytest.MonkeyPatch) -> 
         def ensure_embedder_loaded(self) -> None:
             return None
 
-    monkeypatch.setattr("searchat.api.dependencies._ensure_search_engine", lambda: _Engine())
+    monkeypatch.setattr(
+        "searchat.api.dependencies._ensure_search_engine", lambda: _Engine()
+    )
     monkeypatch.setenv("SEARCHAT_PROFILE_WARMUP", "1")
 
     api_warmup._warmup_semantic_components()
@@ -248,7 +291,9 @@ def test_warmup_semantic_components_success(monkeypatch: pytest.MonkeyPatch) -> 
     assert readiness.components["embedder"] == "ready"
 
 
-def test_warmup_semantic_components_failure_marks_unready_components_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_warmup_semantic_components_failure_marks_unready_components_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import searchat.api.warmup as api_warmup
 
     readiness = FakeReadiness()
@@ -264,7 +309,9 @@ def test_warmup_semantic_components_failure_marks_unready_components_error(monke
         def ensure_embedder_loaded(self) -> None:
             return None
 
-    monkeypatch.setattr("searchat.api.dependencies._ensure_search_engine", lambda: _Engine())
+    monkeypatch.setattr(
+        "searchat.api.dependencies._ensure_search_engine", lambda: _Engine()
+    )
 
     api_warmup._warmup_semantic_components()
 
@@ -274,13 +321,23 @@ def test_warmup_semantic_components_failure_marks_unready_components_error(monke
 
 
 @pytest.mark.asyncio
-async def test_warmup_all_relies_on_semantic_component_warmup(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_warmup_all_relies_on_semantic_component_warmup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import searchat.api.warmup as api_warmup
 
     called = {"duckdb": 0, "embedded": 0, "semantic": 0}
 
-    monkeypatch.setattr(api_warmup, "_warmup_duckdb_parquet", lambda: called.__setitem__("duckdb", called["duckdb"] + 1))
-    monkeypatch.setattr(api_warmup, "_warmup_embedded_model", lambda: called.__setitem__("embedded", called["embedded"] + 1))
+    monkeypatch.setattr(
+        api_warmup,
+        "_warmup_duckdb_parquet",
+        lambda: called.__setitem__("duckdb", called["duckdb"] + 1),
+    )
+    monkeypatch.setattr(
+        api_warmup,
+        "_warmup_embedded_model",
+        lambda: called.__setitem__("embedded", called["embedded"] + 1),
+    )
     monkeypatch.setattr(
         api_warmup,
         "_warmup_semantic_components",
@@ -288,7 +345,9 @@ async def test_warmup_all_relies_on_semantic_component_warmup(monkeypatch: pytes
     )
     monkeypatch.setattr(
         "searchat.api.dependencies._ensure_search_engine",
-        lambda: (_ for _ in ()).throw(AssertionError("_ensure_search_engine should not be called directly")),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("_ensure_search_engine should not be called directly")
+        ),
     )
 
     await api_warmup._warmup_all()
@@ -296,7 +355,9 @@ async def test_warmup_all_relies_on_semantic_component_warmup(monkeypatch: pytes
     assert called == {"duckdb": 1, "embedded": 1, "semantic": 1}
 
 
-def test_invalidate_search_index_clears_caches_and_marks_idle(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_invalidate_search_index_clears_caches_and_marks_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import searchat.api.warmup as api_warmup
 
     readiness = FakeReadiness()
@@ -309,7 +370,11 @@ def test_invalidate_search_index_clears_caches_and_marks_idle(monkeypatch: pytes
             called["refresh"] += 1
 
     monkeypatch.setattr("searchat.api.dependencies._search_engine", _Engine())
-    monkeypatch.setattr(api_warmup, "start_background_warmup", lambda: called.__setitem__("warmup", called["warmup"] + 1))
+    monkeypatch.setattr(
+        api_warmup,
+        "start_background_warmup",
+        lambda: called.__setitem__("warmup", called["warmup"] + 1),
+    )
 
     api_warmup.invalidate_search_index()
 
@@ -323,7 +388,9 @@ def test_invalidate_search_index_clears_caches_and_marks_idle(monkeypatch: pytes
     assert called["warmup"] == 1
 
 
-def test_get_search_engine_raises_when_not_ready(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_get_search_engine_raises_when_not_ready(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.setattr(deps, "_config", object())
     monkeypatch.setattr(deps, "_search_dir", tmp_path)
     monkeypatch.setattr(deps, "_search_engine", None)
@@ -332,7 +399,9 @@ def test_get_search_engine_raises_when_not_ready(monkeypatch: pytest.MonkeyPatch
         deps.get_search_engine()
 
 
-def test_get_indexer_creates_lazily(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_get_indexer_creates_lazily(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.setattr(deps, "_config", object())
     monkeypatch.setattr(deps, "_search_dir", tmp_path)
 
@@ -345,7 +414,9 @@ def test_get_indexer_creates_lazily(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     assert deps.get_indexer() == "IDX"
 
 
-def test_ensure_search_engine_creates_instance(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_ensure_search_engine_creates_instance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     readiness = FakeReadiness()
     monkeypatch.setattr(deps, "get_readiness", lambda: readiness)
 
@@ -361,7 +432,11 @@ def test_ensure_search_engine_creates_instance(monkeypatch: pytest.MonkeyPatch, 
     monkeypatch.setitem(
         sys.modules,
         "searchat.services.retrieval_service",
-        types.SimpleNamespace(build_retrieval_service=lambda search_dir, *, config: _SearchEngine(search_dir, config)),
+        types.SimpleNamespace(
+            build_retrieval_service=lambda search_dir, *, config: _SearchEngine(
+                search_dir, config
+            )
+        ),
     )
 
     engine = deps._ensure_search_engine()
@@ -370,7 +445,9 @@ def test_ensure_search_engine_creates_instance(monkeypatch: pytest.MonkeyPatch, 
     assert readiness.components["search_engine"] == "ready"
 
 
-def test_ensure_search_engine_sets_error_on_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_ensure_search_engine_sets_error_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     readiness = FakeReadiness()
     monkeypatch.setattr(deps, "get_readiness", lambda: readiness)
 
@@ -384,7 +461,11 @@ def test_ensure_search_engine_sets_error_on_failure(monkeypatch: pytest.MonkeyPa
     monkeypatch.setitem(
         sys.modules,
         "searchat.services.retrieval_service",
-        types.SimpleNamespace(build_retrieval_service=lambda search_dir, *, config: _SearchEngine(search_dir, config)),
+        types.SimpleNamespace(
+            build_retrieval_service=lambda search_dir, *, config: _SearchEngine(
+                search_dir, config
+            )
+        ),
     )
 
     with pytest.raises(RuntimeError, match="init failed"):
@@ -393,40 +474,56 @@ def test_ensure_search_engine_sets_error_on_failure(monkeypatch: pytest.MonkeyPa
     assert readiness.components["search_engine"] == "error"
 
 
-def test_ensure_indexer_creates_instance(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_ensure_indexer_creates_instance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     readiness = FakeReadiness()
     monkeypatch.setattr(deps, "get_readiness", lambda: readiness)
 
     cfg = object()
     monkeypatch.setattr(deps, "_config", cfg)
     monkeypatch.setattr(deps, "_search_dir", tmp_path)
+    store = object()
+    monkeypatch.setattr(deps, "_duckdb_store", store)
 
     class _Indexer:
         def __init__(self, search_dir: Path, config, *, storage=None):
             self.search_dir = search_dir
             self.config = config
+            self.storage = storage
 
-    monkeypatch.setattr(deps, "_duckdb_store", None)
-    monkeypatch.setitem(sys.modules, "searchat.core.unified_indexer", types.SimpleNamespace(UnifiedIndexer=_Indexer))
+    monkeypatch.setitem(
+        sys.modules,
+        "searchat.core.unified_indexer",
+        types.SimpleNamespace(UnifiedIndexer=_Indexer),
+    )
 
     idx = deps._ensure_indexer()
     assert idx.search_dir == tmp_path
     assert idx.config is cfg
+    assert idx.storage is store
     assert readiness.components["indexer"] == "ready"
 
 
-def test_ensure_indexer_sets_error_on_failure(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_ensure_indexer_sets_error_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     readiness = FakeReadiness()
     monkeypatch.setattr(deps, "get_readiness", lambda: readiness)
 
     monkeypatch.setattr(deps, "_config", object())
     monkeypatch.setattr(deps, "_search_dir", tmp_path)
+    monkeypatch.setattr(deps, "_duckdb_store", object())
 
     class _Indexer:
         def __init__(self, _search_dir: Path, _config, *, storage=None):
             raise RuntimeError("indexer boom")
 
-    monkeypatch.setitem(sys.modules, "searchat.core.unified_indexer", types.SimpleNamespace(UnifiedIndexer=_Indexer))
+    monkeypatch.setitem(
+        sys.modules,
+        "searchat.core.unified_indexer",
+        types.SimpleNamespace(UnifiedIndexer=_Indexer),
+    )
 
     with pytest.raises(RuntimeError, match="indexer boom"):
         deps._ensure_indexer()

--- a/tests/unit/test_dependencies_coverage.py
+++ b/tests/unit/test_dependencies_coverage.py
@@ -1,11 +1,12 @@
 """Additional tests for api/dependencies.py — warmup, snapshot, and singleton paths."""
+
 from __future__ import annotations
 
 import sys
 import types
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -43,7 +44,9 @@ class FakeReadiness:
         self.errors: dict[str, str] = {}
         self.warmup_started = False
 
-    def set_component(self, name: str, status: str, *, error: str | None = None) -> None:
+    def set_component(
+        self, name: str, status: str, *, error: str | None = None
+    ) -> None:
         self.components[name] = status
         if error is not None:
             self.errors[name] = error
@@ -125,24 +128,39 @@ class TestGetterErrors:
 
 
 class TestGetDuckdbStoreFor:
-    def test_returns_main_store_for_same_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_returns_main_store_for_same_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         monkeypatch.setattr(deps, "_config", object())
         monkeypatch.setattr(deps, "_search_dir", tmp_path)
         monkeypatch.setattr(deps, "_duckdb_store", "MAIN")
 
         assert deps.get_duckdb_store_for(tmp_path) == "MAIN"
 
-    def test_creates_store_for_other_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_creates_store_for_other_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         import searchat.services.storage_service as storage_mod
 
         other = tmp_path / "other"
         other.mkdir()
-        monkeypatch.setattr(deps, "_config", SimpleNamespace(performance=SimpleNamespace(memory_limit_mb=128), storage=SimpleNamespace(backend="duckdb")))
+        monkeypatch.setattr(
+            deps,
+            "_config",
+            SimpleNamespace(
+                performance=SimpleNamespace(memory_limit_mb=128),
+                storage=SimpleNamespace(backend="duckdb"),
+            ),
+        )
         monkeypatch.setattr(deps, "_search_dir", tmp_path)
         monkeypatch.setattr(deps, "_duckdb_store", "MAIN")
 
         sentinel = SimpleNamespace(path=other)
-        monkeypatch.setattr(storage_mod, "build_storage_service", lambda _sd, *, config: sentinel)
+        monkeypatch.setattr(
+            storage_mod,
+            "build_storage_service",
+            lambda _sd, *, config, read_only=None: sentinel,
+        )
 
         store = deps.get_duckdb_store_for(other)
         assert store.path == other
@@ -153,7 +171,14 @@ class TestGetDuckdbStoreFor:
     def test_caches_by_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
         other = tmp_path / "alt"
         other.mkdir()
-        monkeypatch.setattr(deps, "_config", SimpleNamespace(performance=SimpleNamespace(memory_limit_mb=128), storage=SimpleNamespace(backend="parquet")))
+        monkeypatch.setattr(
+            deps,
+            "_config",
+            SimpleNamespace(
+                performance=SimpleNamespace(memory_limit_mb=128),
+                storage=SimpleNamespace(backend="parquet"),
+            ),
+        )
         monkeypatch.setattr(deps, "_search_dir", tmp_path)
         monkeypatch.setattr(deps, "_duckdb_store", "MAIN")
 
@@ -167,7 +192,9 @@ class TestGetDuckdbStoreFor:
 
 
 class TestGetOrCreateSearchEngineFor:
-    def test_returns_main_engine_for_same_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_returns_main_engine_for_same_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         readiness = FakeReadiness()
         monkeypatch.setattr(deps, "get_readiness", lambda: readiness)
         monkeypatch.setattr(deps, "_config", object())
@@ -182,14 +209,20 @@ class TestGetOrCreateSearchEngineFor:
         monkeypatch.setitem(
             sys.modules,
             "searchat.services.retrieval_service",
-            types.SimpleNamespace(build_retrieval_service=lambda search_dir, *, config: _SE(search_dir, config)),
+            types.SimpleNamespace(
+                build_retrieval_service=lambda search_dir, *, config: _SE(
+                    search_dir, config
+                )
+            ),
         )
         monkeypatch.setattr(deps, "_search_engine", fake_engine)
 
         result = deps.get_or_create_search_engine_for(tmp_path)
         assert result is fake_engine
 
-    def test_creates_engine_for_other_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_creates_engine_for_other_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         other = tmp_path / "snap"
         other.mkdir()
         cfg = object()
@@ -204,7 +237,11 @@ class TestGetOrCreateSearchEngineFor:
         monkeypatch.setitem(
             sys.modules,
             "searchat.services.retrieval_service",
-            types.SimpleNamespace(build_retrieval_service=lambda search_dir, *, config: _SE(search_dir, config)),
+            types.SimpleNamespace(
+                build_retrieval_service=lambda search_dir, *, config: _SE(
+                    search_dir, config
+                )
+            ),
         )
 
         engine = deps.get_or_create_search_engine_for(other)
@@ -218,7 +255,9 @@ class TestGetOrCreateSearchEngineFor:
 
 
 class TestWarmupEmbeddedModel:
-    def test_skips_when_provider_not_embedded(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_skips_when_provider_not_embedded(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         import searchat.api.warmup as api_warmup
 
         readiness = FakeReadiness()
@@ -232,7 +271,9 @@ class TestWarmupEmbeddedModel:
         deps._warmup_embedded_model()
         assert readiness.components["embedded_model"] == "idle"
 
-    def test_ready_when_model_path_exists(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_ready_when_model_path_exists(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         import searchat.api.warmup as api_warmup
 
         readiness = FakeReadiness()
@@ -263,7 +304,9 @@ class TestWarmupEmbeddedModel:
         deps._warmup_embedded_model()
         assert "embedded_model" not in readiness.components
 
-    def test_malformed_config_marks_embedded_model_idle(self, monkeypatch: pytest.MonkeyPatch):
+    def test_malformed_config_marks_embedded_model_idle(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         import searchat.api.warmup as api_warmup
 
         readiness = FakeReadiness()
@@ -278,7 +321,9 @@ class TestWarmupEmbeddedModel:
 
 
 class TestInitializeWithExpertise:
-    def test_initializes_expertise_store_when_enabled(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_initializes_expertise_store_when_enabled(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         readiness = FakeReadiness()
         monkeypatch.setattr(deps, "get_readiness", lambda: readiness)
 
@@ -291,29 +336,58 @@ class TestInitializeWithExpertise:
             storage=SimpleNamespace(backend="duckdb"),
         )
         monkeypatch.setattr(deps.Config, "load", staticmethod(lambda: cfg))
-        monkeypatch.setattr(deps.PathResolver, "get_shared_search_dir", staticmethod(lambda _: tmp_path))
+        monkeypatch.setattr(
+            deps.PathResolver, "get_shared_search_dir", staticmethod(lambda _: tmp_path)
+        )
         monkeypatch.setattr(deps, "BackupManager", lambda _: object())
         monkeypatch.setattr(deps, "PlatformManager", lambda: object())
 
         import searchat.services.storage_service as storage_mod
-        monkeypatch.setattr(storage_mod, "build_storage_service", lambda _sd, *, config: object())
+
+        monkeypatch.setattr(
+            storage_mod,
+            "build_storage_service",
+            lambda _sd, *, config, read_only=None: object(),
+        )
 
         class _ExpertiseStore:
             def __init__(self, path):
                 self.path = path
 
-        monkeypatch.setitem(sys.modules, "searchat.services.bookmarks", types.SimpleNamespace(BookmarksService=lambda _: object()))
-        monkeypatch.setitem(sys.modules, "searchat.services.saved_queries", types.SimpleNamespace(SavedQueriesService=lambda _: object()))
-        monkeypatch.setitem(sys.modules, "searchat.services.dashboards", types.SimpleNamespace(DashboardsService=lambda _: object()))
-        monkeypatch.setitem(sys.modules, "searchat.services.analytics", types.SimpleNamespace(SearchAnalyticsService=lambda _: object()))
-        monkeypatch.setitem(sys.modules, "searchat.expertise.store", types.SimpleNamespace(ExpertiseStore=_ExpertiseStore))
+        monkeypatch.setitem(
+            sys.modules,
+            "searchat.services.bookmarks",
+            types.SimpleNamespace(BookmarksService=lambda _: object()),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "searchat.services.saved_queries",
+            types.SimpleNamespace(SavedQueriesService=lambda _: object()),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "searchat.services.dashboards",
+            types.SimpleNamespace(DashboardsService=lambda _: object()),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "searchat.services.analytics",
+            types.SimpleNamespace(SearchAnalyticsService=lambda _: object()),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "searchat.expertise.store",
+            types.SimpleNamespace(ExpertiseStore=_ExpertiseStore),
+        )
 
         deps.initialize_services()
 
         store = deps.get_expertise_store()
         assert store.path == tmp_path
 
-    def test_initializes_kg_store_when_enabled(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_initializes_kg_store_when_enabled(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         readiness = FakeReadiness()
         monkeypatch.setattr(deps, "get_readiness", lambda: readiness)
 
@@ -326,22 +400,49 @@ class TestInitializeWithExpertise:
             storage=SimpleNamespace(backend="duckdb"),
         )
         monkeypatch.setattr(deps.Config, "load", staticmethod(lambda: cfg))
-        monkeypatch.setattr(deps.PathResolver, "get_shared_search_dir", staticmethod(lambda _: tmp_path))
+        monkeypatch.setattr(
+            deps.PathResolver, "get_shared_search_dir", staticmethod(lambda _: tmp_path)
+        )
         monkeypatch.setattr(deps, "BackupManager", lambda _: object())
         monkeypatch.setattr(deps, "PlatformManager", lambda: object())
 
         import searchat.services.storage_service as storage_mod
-        monkeypatch.setattr(storage_mod, "build_storage_service", lambda _sd, *, config: object())
+
+        monkeypatch.setattr(
+            storage_mod,
+            "build_storage_service",
+            lambda _sd, *, config, read_only=None: object(),
+        )
 
         class _KGStore:
             def __init__(self, path):
                 self.path = path
 
-        monkeypatch.setitem(sys.modules, "searchat.services.bookmarks", types.SimpleNamespace(BookmarksService=lambda _: object()))
-        monkeypatch.setitem(sys.modules, "searchat.services.saved_queries", types.SimpleNamespace(SavedQueriesService=lambda _: object()))
-        monkeypatch.setitem(sys.modules, "searchat.services.dashboards", types.SimpleNamespace(DashboardsService=lambda _: object()))
-        monkeypatch.setitem(sys.modules, "searchat.services.analytics", types.SimpleNamespace(SearchAnalyticsService=lambda _: object()))
-        monkeypatch.setitem(sys.modules, "searchat.knowledge_graph", types.SimpleNamespace(KnowledgeGraphStore=_KGStore))
+        monkeypatch.setitem(
+            sys.modules,
+            "searchat.services.bookmarks",
+            types.SimpleNamespace(BookmarksService=lambda _: object()),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "searchat.services.saved_queries",
+            types.SimpleNamespace(SavedQueriesService=lambda _: object()),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "searchat.services.dashboards",
+            types.SimpleNamespace(DashboardsService=lambda _: object()),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "searchat.services.analytics",
+            types.SimpleNamespace(SearchAnalyticsService=lambda _: object()),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "searchat.knowledge_graph",
+            types.SimpleNamespace(KnowledgeGraphStore=_KGStore),
+        )
 
         deps.initialize_services()
 
@@ -357,7 +458,11 @@ class TestTriggerSearchEngineWarmup:
         import searchat.api.warmup as api_warmup
 
         called = {"count": 0}
-        monkeypatch.setattr(api_warmup, "start_background_warmup", lambda: called.__setitem__("count", called["count"] + 1))
+        monkeypatch.setattr(
+            api_warmup,
+            "start_background_warmup",
+            lambda: called.__setitem__("count", called["count"] + 1),
+        )
 
         deps.trigger_search_engine_warmup()
         assert called["count"] == 1
@@ -367,7 +472,9 @@ class TestTriggerSearchEngineWarmup:
 
 
 class TestResolveDatasetSearchDir:
-    def test_returns_main_dir_when_snapshot_none(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_returns_main_dir_when_snapshot_none(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         monkeypatch.setattr(deps, "_config", object())
         monkeypatch.setattr(deps, "_search_dir", tmp_path)
 
@@ -375,7 +482,9 @@ class TestResolveDatasetSearchDir:
         assert search_dir == tmp_path
         assert snap is None
 
-    def test_returns_main_dir_when_snapshot_empty(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    def test_returns_main_dir_when_snapshot_empty(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
         monkeypatch.setattr(deps, "_config", object())
         monkeypatch.setattr(deps, "_search_dir", tmp_path)
 
@@ -383,15 +492,23 @@ class TestResolveDatasetSearchDir:
         assert search_dir == tmp_path
         assert snap is None
 
-    def test_raises_when_snapshots_disabled(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-        monkeypatch.setattr(deps, "_config", SimpleNamespace(snapshots=SimpleNamespace(enabled=False)))
+    def test_raises_when_snapshots_disabled(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        monkeypatch.setattr(
+            deps, "_config", SimpleNamespace(snapshots=SimpleNamespace(enabled=False))
+        )
         monkeypatch.setattr(deps, "_search_dir", tmp_path)
 
         with pytest.raises(ValueError, match="Snapshot mode is disabled"):
             deps.resolve_dataset_search_dir("some_snap")
 
-    def test_raises_for_invalid_snapshot_name(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-        monkeypatch.setattr(deps, "_config", SimpleNamespace(snapshots=SimpleNamespace(enabled=True)))
+    def test_raises_for_invalid_snapshot_name(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        monkeypatch.setattr(
+            deps, "_config", SimpleNamespace(snapshots=SimpleNamespace(enabled=True))
+        )
         monkeypatch.setattr(deps, "_search_dir", tmp_path)
 
         with pytest.raises(ValueError, match="Invalid snapshot name"):


### PR DESCRIPTION
## Summary
- remove the persistent DuckDB FTS rebuild from application startup to eliminate the 18s boot delay
- ensure the watcher/indexer reuses the shared write-capable DuckDB store instead of reopening the database with a conflicting configuration
- update shipped default Ollama model settings to `ollama/gemma4:latest`

## Problem
Startup of `uv run searchat web` was blocked inside FastAPI lifespan initialization long enough for the browser-open helper to time out. Profiling showed the hot path was not watcher startup or background warmup; it was the shared DuckDB storage bootstrap. The main issue was a full persistent FTS rebuild triggered on every process start via `PRAGMA create_fts_index(... overwrite = 1)` on the `exchanges` table.

The branch also fixes a separate DuckDB connection-mode conflict discovered during watcher startup: the app initialized the primary dataset store in one mode and then the indexer opened the same database file again with different settings, which DuckDB rejects.

## Scope
This PR includes the full branch scope across two logical commits:
- runtime/storage startup changes
- shipped config default changes for Ollama model selection

## Implementation Details
- open the primary dataset store in write mode during API service initialization so startup and indexing use a consistent DuckDB connection mode
- inject the shared DuckDB store into `UnifiedIndexer` construction so the watcher/indexer path reuses the existing connection owner instead of opening the same database file again
- remove the persistent `create_fts_indexes()` call from `UnifiedStorage` initialization, leaving table creation, extension loading, and HNSW setup intact while taking the expensive persistent FTS rebuild off the process startup path
- keep the in-memory search-engine FTS path unchanged; the active runtime BM25 flow in `UnifiedSearchEngine` still builds and refreshes its own in-memory FTS view as before
- update both shipped default config templates to use `ollama/gemma4:latest` as the default Ollama model
- update dependency tests to reflect the shared-store injection and service initialization contract

## Behavior Change
Before this branch:
- startup profiling showed `initialize_services + schedule warmup` taking about `18.4s`
- isolated profiling of `UnifiedStorage` init showed about `17.9s`
- isolated step timing showed `create_fts_indexes()` consuming about `17.7s`

After this branch:
- startup profiling showed the same startup path dropping to about `112ms`
- watcher startup continued to happen after the server began listening
- the browser-open timeout warning no longer reflects the startup bottleneck that previously existed

## Validation
- `uv run ruff check src/searchat/api/dependencies.py tests/api/test_app_dependencies_and_status.py tests/unit/api/test_dependencies.py tests/unit/test_dependencies_coverage.py`
- `uv run ruff format --check src/searchat/api/dependencies.py tests/api/test_app_dependencies_and_status.py tests/unit/api/test_dependencies.py tests/unit/test_dependencies_coverage.py`
- `uv run pytest --no-cov tests/api/test_app_dependencies_and_status.py tests/unit/api/test_dependencies.py tests/unit/test_dependencies_coverage.py`
- `uv run ruff check src/searchat/storage/unified_storage.py src/searchat/api/dependencies.py`
- `uv run pytest --no-cov tests/unit/storage/test_unified_storage.py tests/integration/test_unified_indexer.py`
- `uv run pytest --no-cov tests/unit/services/test_llm_service.py tests/unit/config/test_user_config_writer.py`

## Notes
- this PR changes shipped defaults, not the existing local user config in `~/.searchat/config/settings.toml`
- the persistent `exchanges` FTS index is no longer rebuilt during process startup; if a future feature needs that index refreshed automatically, it should be rebuilt on index mutation rather than on every boot
