### PR TITLE
feat(storage): add storage diagnostics engine

### DIFF
--- a/src/searchat/services/storage_health.py
+++ b/src/searchat/services/storage_health.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
+
+import duckdb
 
 from searchat.services.backup import BackupManager
 from searchat.services.storage_contracts import (
@@ -262,3 +265,136 @@ def repair_storage_metadata(
         issues=refreshed.issues,
         repairs_applied=repairs_applied,
     )
+
+
+# ---------------------------------------------------------------------------
+# Storage doctor diagnostics: live-data size estimation (searchat doctor)
+# ---------------------------------------------------------------------------
+
+_DUCKDB_SIZE_UNITS = {
+    "bytes": 1,
+    "kib": 1024,
+    "mib": 1024**2,
+    "gib": 1024**3,
+    "tib": 1024**4,
+    "pib": 1024**5,
+}
+
+
+def _parse_duckdb_size(text: str) -> int:
+    """Parse a DuckDB-formatted size string (e.g. '1.4 GiB', '0 bytes') to bytes."""
+    match = re.match(r"^\s*([\d.]+)\s*([A-Za-z]+)\s*$", text)
+    if not match:
+        return 0
+    multiplier = _DUCKDB_SIZE_UNITS.get(match.group(2).lower())
+    if multiplier is None:
+        return 0
+    return int(float(match.group(1)) * multiplier)
+
+
+@dataclass(frozen=True)
+class DatabaseSizeInfo:
+    """Raw PRAGMA database_size fields for a DuckDB file, read-only."""
+
+    total_bytes: int
+    block_size: int
+    total_blocks: int
+    used_blocks: int
+    free_blocks: int
+    wal_bytes: int
+
+
+_EMPTY_DATABASE_SIZE_INFO = DatabaseSizeInfo(
+    total_bytes=0, block_size=0, total_blocks=0, used_blocks=0, free_blocks=0, wal_bytes=0
+)
+
+
+def inspect_database_size(db_path: Path) -> DatabaseSizeInfo:
+    """Read PRAGMA database_size for `db_path` without mutating it.
+
+    Returns an all-zero report when `db_path` does not exist yet (fresh install).
+    """
+    if not db_path.exists():
+        return _EMPTY_DATABASE_SIZE_INFO
+    con = duckdb.connect(str(db_path), read_only=True)
+    try:
+        cursor = con.execute("PRAGMA database_size")
+        row = cursor.fetchone()
+        if row is None:
+            return _EMPTY_DATABASE_SIZE_INFO
+        columns = {desc[0]: value for desc, value in zip(cursor.description, row)}
+        block_size = int(columns.get("block_size", 0) or 0)
+        total_blocks = int(columns.get("total_blocks", 0) or 0)
+        used_blocks = int(columns.get("used_blocks", 0) or 0)
+        free_blocks = int(columns.get("free_blocks", 0) or 0)
+        wal_bytes = _parse_duckdb_size(str(columns.get("wal_size", "0 bytes")))
+        return DatabaseSizeInfo(
+            total_bytes=block_size * total_blocks,
+            block_size=block_size,
+            total_blocks=total_blocks,
+            used_blocks=used_blocks,
+            free_blocks=free_blocks,
+            wal_bytes=wal_bytes,
+        )
+    finally:
+        con.close()
+
+
+def estimate_live_data_size(db_path: Path) -> int:
+    """Estimate the bytes actually occupied by live tables in `db_path`.
+
+    Sums the distinct storage blocks referenced by `pragma_storage_info` across
+    the `main` schema and every `fts_main_*` schema, deduplicated so segments
+    packed into the same block are not double-counted. This is the "live"
+    footprint that `compute_bloat_ratio` compares against the on-disk file
+    size — blocks that no longer belong to any current table (freed by
+    deletes/updates/rebuilds but not reclaimed by DuckDB's allocator) are
+    invisible to `pragma_storage_info` and therefore excluded here, which is
+    exactly the bloat `searchat compact` (M3) reclaims.
+
+    Returns 0 when `db_path` does not exist yet.
+    """
+    if not db_path.exists():
+        return 0
+    con = duckdb.connect(str(db_path), read_only=True)
+    try:
+        size_row = con.execute("PRAGMA database_size").fetchone()
+        if size_row is None:
+            return 0
+        columns = {desc[0]: value for desc, value in zip(con.description, size_row)}
+        block_size = int(columns.get("block_size", 0) or 0)
+        if block_size <= 0:
+            return 0
+
+        schemas = [
+            row[0]
+            for row in con.execute(
+                "SELECT DISTINCT table_schema FROM information_schema.tables "
+                "WHERE table_schema = 'main' OR table_schema LIKE 'fts_main_%'"
+            ).fetchall()
+        ]
+
+        live_blocks: set[int] = set()
+        for schema in schemas:
+            tables = [
+                row[0]
+                for row in con.execute(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = ?",
+                    [schema],
+                ).fetchall()
+            ]
+            for table in tables:
+                qualified = f'"{schema}"."{table}"'
+                try:
+                    block_rows = con.execute(
+                        "SELECT DISTINCT block_id FROM pragma_storage_info(?) "
+                        "WHERE block_id IS NOT NULL AND block_id >= 0",
+                        [qualified],
+                    ).fetchall()
+                except duckdb.Error:
+                    continue
+                live_blocks.update(int(row[0]) for row in block_rows)
+
+        return len(live_blocks) * block_size
+    finally:
+        con.close()

--- a/src/searchat/services/storage_health.py
+++ b/src/searchat/services/storage_health.py
@@ -398,3 +398,16 @@ def estimate_live_data_size(db_path: Path) -> int:
         return len(live_blocks) * block_size
     finally:
         con.close()
+
+
+def compute_bloat_ratio(total_bytes: int, live_bytes: int) -> float:
+    """Ratio of on-disk size to estimated live-data footprint.
+
+    1.0 means no measurable bloat (including the degenerate case where either
+    side cannot be measured). Values above 1.0 indicate the file holds more
+    bytes than its live tables need — the amount `searchat compact` (M3) can
+    reclaim via copy-compaction.
+    """
+    if total_bytes <= 0 or live_bytes <= 0:
+        return 1.0
+    return total_bytes / live_bytes

--- a/src/searchat/services/storage_health.py
+++ b/src/searchat/services/storage_health.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import duckdb
 
-from searchat.services.backup import BackupManager
+from searchat.services.backup import BackupManager, _sha256_file
 from searchat.services.storage_contracts import (
     BACKUP_MANIFEST_FILE,
     BACKUP_METADATA_FILE,
@@ -411,3 +411,70 @@ def compute_bloat_ratio(total_bytes: int, live_bytes: int) -> float:
     if total_bytes <= 0 or live_bytes <= 0:
         return 1.0
     return total_bytes / live_bytes
+
+
+@dataclass(frozen=True)
+class BackupAudit:
+    """Redundancy verdict for a single backup directory."""
+
+    backup_name: str
+    backup_path: Path
+    file_count: int
+    total_size_bytes: int
+    redundant: bool
+    unique_files: tuple[str, ...]
+
+
+def audit_backup_redundancy(backup_dir: Path, data_dir: Path) -> list[BackupAudit]:
+    """Flag backups under `backup_dir` whose files are a strict subset of `data_dir`.
+
+    A backup is `redundant` when every file it captured (compared by
+    `content_sha256`, which is the pre-encryption hash even for encrypted
+    backups) still exists, byte-identical, in the current live dataset at
+    `data_dir` — meaning the backup adds nothing recoverable that isn't
+    already live and is safe to delete. Backups with malformed or missing
+    manifests are skipped (read-only diagnostics degrade, never error).
+    """
+    if not backup_dir.exists():
+        return []
+
+    live_sha_cache: dict[str, str | None] = {}
+
+    def live_sha(rel_path: str) -> str | None:
+        if rel_path not in live_sha_cache:
+            candidate = data_dir / rel_path
+            live_sha_cache[rel_path] = _sha256_file(candidate) if candidate.is_file() else None
+        return live_sha_cache[rel_path]
+
+    audits: list[BackupAudit] = []
+    for backup_path in sorted(path for path in backup_dir.iterdir() if path.is_dir()):
+        manifest_path = backup_path / BACKUP_MANIFEST_FILE
+        if not manifest_path.exists():
+            continue
+        try:
+            manifest = BackupManifest.from_dict(json.loads(manifest_path.read_text(encoding="utf-8")))
+        except (StorageCompatibilityError, json.JSONDecodeError, OSError):
+            continue
+
+        total_size = 0
+        unique_files: list[str] = []
+        for rel_path, meta in manifest.files.items():
+            size_bytes = meta.get("size_bytes")
+            if isinstance(size_bytes, (int, float)):
+                total_size += int(size_bytes)
+            content_sha = meta.get("content_sha256")
+            if not isinstance(content_sha, str) or live_sha(rel_path) != content_sha:
+                unique_files.append(rel_path)
+
+        audits.append(
+            BackupAudit(
+                backup_name=backup_path.name,
+                backup_path=backup_path,
+                file_count=len(manifest.files),
+                total_size_bytes=total_size,
+                redundant=bool(manifest.files) and not unique_files,
+                unique_files=tuple(sorted(unique_files)),
+            )
+        )
+
+    return audits

--- a/src/searchat/services/storage_health.py
+++ b/src/searchat/services/storage_health.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import duckdb
 
+from searchat.config import Config
+from searchat.core.connectors.registry import get_connectors
 from searchat.services.backup import BackupManager, _sha256_file
 from searchat.services.storage_contracts import (
     BACKUP_MANIFEST_FILE,
@@ -478,3 +482,129 @@ def audit_backup_redundancy(backup_dir: Path, data_dir: Path) -> list[BackupAudi
         )
 
     return audits
+
+
+@dataclass(frozen=True)
+class HarnessSourceSize:
+    """On-disk size of a registered connector's discovered conversation files."""
+
+    connector: str
+    file_count: int
+    total_size_bytes: int
+
+
+def estimate_harness_source_sizes(config: Config) -> list[HarnessSourceSize]:
+    """Sum discovered source-file sizes per registered connector.
+
+    A harness whose connector is not yet registered (e.g. omp before M5)
+    simply does not appear in the result; a connector whose discovery raises
+    is skipped so one bad harness never fails the whole report.
+    """
+    results: list[HarnessSourceSize] = []
+    for connector in get_connectors():
+        try:
+            files = connector.discover_files(config)
+        except Exception:
+            continue
+        total_size = 0
+        file_count = 0
+        for file_path in files:
+            try:
+                total_size += file_path.stat().st_size
+            except OSError:
+                continue
+            file_count += 1
+        results.append(
+            HarnessSourceSize(connector=connector.name, file_count=file_count, total_size_bytes=total_size)
+        )
+    return results
+
+
+def estimate_last_backup_age(
+    search_dir: Path,
+    *,
+    now: datetime | None = None,
+) -> tuple[str | None, float | None]:
+    """Return (ISO timestamp, age in seconds) of the most recent backup, or (None, None)."""
+    backups = BackupManager(search_dir).list_backups()
+    if not backups:
+        return None, None
+    try:
+        backed_at = datetime.strptime(backups[0].timestamp, "%Y%m%d_%H%M%S")
+    except ValueError:
+        return None, None
+    current = now or datetime.now()
+    return backed_at.isoformat(), (current - backed_at).total_seconds()
+
+
+@dataclass(frozen=True)
+class StorageDoctorReport:
+    """Unified, read-only storage diagnostics consumed by `searchat doctor` and
+    the `/api/health` storage section."""
+
+    search_dir: Path
+    db_path: Path
+    db_exists: bool
+    total_bytes: int
+    live_bytes: int
+    wal_bytes: int
+    bloat_ratio: float
+    backups: tuple[BackupAudit, ...]
+    harness_sources: tuple[HarnessSourceSize, ...]
+    last_backup_at: str | None
+    last_backup_age_seconds: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "search_dir": str(self.search_dir),
+            "db_path": str(self.db_path),
+            "db_exists": self.db_exists,
+            "total_bytes": self.total_bytes,
+            "live_bytes": self.live_bytes,
+            "wal_bytes": self.wal_bytes,
+            "bloat_ratio": self.bloat_ratio,
+            "backups": [
+                {
+                    "backup_name": backup.backup_name,
+                    "backup_path": str(backup.backup_path),
+                    "file_count": backup.file_count,
+                    "total_size_bytes": backup.total_size_bytes,
+                    "redundant": backup.redundant,
+                    "unique_files": list(backup.unique_files),
+                }
+                for backup in self.backups
+            ],
+            "harness_sources": [
+                {
+                    "connector": harness.connector,
+                    "file_count": harness.file_count,
+                    "total_size_bytes": harness.total_size_bytes,
+                }
+                for harness in self.harness_sources
+            ],
+            "last_backup_at": self.last_backup_at,
+            "last_backup_age_seconds": self.last_backup_age_seconds,
+        }
+
+
+def build_storage_doctor_report(search_dir: Path, config: Config) -> StorageDoctorReport:
+    """Assemble the full read-only storage doctor report for `search_dir`."""
+    db_path = config.storage.resolve_duckdb_path(search_dir)
+    size_info = inspect_database_size(db_path)
+    live_bytes = estimate_live_data_size(db_path)
+    backups = audit_backup_redundancy(search_dir / "backups", search_dir)
+    harness_sources = estimate_harness_source_sizes(config)
+    last_backup_at, last_backup_age_seconds = estimate_last_backup_age(search_dir)
+    return StorageDoctorReport(
+        search_dir=search_dir,
+        db_path=db_path,
+        db_exists=db_path.exists(),
+        total_bytes=size_info.total_bytes,
+        live_bytes=live_bytes,
+        wal_bytes=size_info.wal_bytes,
+        bloat_ratio=compute_bloat_ratio(size_info.total_bytes, live_bytes),
+        backups=tuple(backups),
+        harness_sources=tuple(harness_sources),
+        last_backup_at=last_backup_at,
+        last_backup_age_seconds=last_backup_age_seconds,
+    )

--- a/tests/unit/services/test_storage_health.py
+++ b/tests/unit/services/test_storage_health.py
@@ -4,9 +4,16 @@ import json
 import shutil
 from pathlib import Path
 
+import duckdb
+
 from searchat.services.backup import BackupManager
 from searchat.services.storage_contracts import BACKUP_MANIFEST_FILE
-from searchat.services.storage_health import inspect_storage_health, repair_storage_metadata
+from searchat.services.storage_health import (
+    estimate_live_data_size,
+    inspect_database_size,
+    inspect_storage_health,
+    repair_storage_metadata,
+)
 
 
 def test_inspect_storage_health_flags_repairable_legacy_backup_metadata(temp_search_dir: Path) -> None:
@@ -158,3 +165,44 @@ def test_inspect_storage_health_flags_fixture_backup_contract_bundle(temp_search
         and issue.repairable
         for issue in report.issues
     )
+
+
+# ---------------------------------------------------------------------------
+# Storage doctor diagnostics: live-data size estimation
+# ---------------------------------------------------------------------------
+
+
+def test_inspect_database_size_missing_file_returns_zeros(tmp_path: Path) -> None:
+    info = inspect_database_size(tmp_path / "missing.duckdb")
+    assert info.total_bytes == 0
+    assert info.block_size == 0
+    assert info.wal_bytes == 0
+
+
+def test_estimate_live_data_size_missing_file_returns_zero(tmp_path: Path) -> None:
+    assert estimate_live_data_size(tmp_path / "missing.duckdb") == 0
+
+
+def test_estimate_live_data_size_matches_known_block_count(tmp_path: Path) -> None:
+    db_path = tmp_path / "live.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE TABLE conversations(id INTEGER, payload VARCHAR)")
+    con.execute(
+        "INSERT INTO conversations SELECT i, md5(i::VARCHAR) || md5((i + 1)::VARCHAR) "
+        "FROM range(5000) t(i)"
+    )
+    con.execute("CHECKPOINT")
+
+    known_blocks = {
+        int(row[0])
+        for row in con.execute(
+            "SELECT DISTINCT block_id FROM pragma_storage_info('\"main\".\"conversations\"') "
+            "WHERE block_id IS NOT NULL AND block_id >= 0"
+        ).fetchall()
+    }
+    block_size = int(
+        con.execute("PRAGMA database_size").fetchdf()["block_size"][0]
+    )
+    con.close()
+
+    assert estimate_live_data_size(db_path) == len(known_blocks) * block_size

--- a/tests/unit/services/test_storage_health.py
+++ b/tests/unit/services/test_storage_health.py
@@ -5,10 +5,12 @@ import shutil
 from pathlib import Path
 
 import duckdb
+import pytest
 
 from searchat.services.backup import BackupManager
 from searchat.services.storage_contracts import BACKUP_MANIFEST_FILE
 from searchat.services.storage_health import (
+    compute_bloat_ratio,
     estimate_live_data_size,
     inspect_database_size,
     inspect_storage_health,
@@ -206,3 +208,83 @@ def test_estimate_live_data_size_matches_known_block_count(tmp_path: Path) -> No
     con.close()
 
     assert estimate_live_data_size(db_path) == len(known_blocks) * block_size
+
+
+def test_compute_bloat_ratio_pure_math() -> None:
+    assert compute_bloat_ratio(3_000_000, 1_000_000) == pytest.approx(3.0)
+    assert compute_bloat_ratio(1_000_000, 1_000_000) == pytest.approx(1.0)
+
+
+def test_compute_bloat_ratio_degenerate_inputs_return_one() -> None:
+    assert compute_bloat_ratio(0, 0) == 1.0
+    assert compute_bloat_ratio(100, 0) == 1.0
+    assert compute_bloat_ratio(0, 100) == 1.0
+
+
+def _duckdb_size_info(con: duckdb.DuckDBPyConnection) -> tuple[int, int]:
+    cursor = con.execute("PRAGMA database_size")
+    row = cursor.fetchone()
+    assert row is not None
+    columns = {desc[0]: value for desc, value in zip(cursor.description, row)}
+    return int(columns["block_size"]), int(columns["total_blocks"])
+
+
+def _live_blocks(con: duckdb.DuckDBPyConnection, schema: str, table: str) -> set[int]:
+    qualified = f'"{schema}"."{table}"'
+    rows = con.execute(
+        "SELECT DISTINCT block_id FROM pragma_storage_info(?) WHERE block_id IS NOT NULL AND block_id >= 0",
+        [qualified],
+    ).fetchall()
+    return {int(row[0]) for row in rows}
+
+
+def _build_bloated_fixture_db(db_path: Path) -> None:
+    """Insert incompressible data, then churn it with deterministic updates across many
+    separate connections and checkpoints, so DuckDB's block allocator leaves free blocks
+    behind: the "used blocks >> live table footprint" pattern this module flags as bloat.
+    """
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE TABLE live_data(id INTEGER, payload VARCHAR)")
+    con.execute(
+        "INSERT INTO live_data SELECT i, md5(i::VARCHAR) || md5((i + 1)::VARCHAR) || md5((i + 2)::VARCHAR) "
+        "FROM range(20000) t(i)"
+    )
+    con.execute("CHECKPOINT")
+    con.close()
+
+    for cycle in range(15):
+        con = duckdb.connect(str(db_path))
+        con.execute(
+            "UPDATE live_data SET payload = md5((? || id)::VARCHAR) || md5((? || id + 1)::VARCHAR) "
+            "WHERE id % 5 = ?",
+            [str(cycle), str(cycle), cycle % 5],
+        )
+        con.execute("CHECKPOINT")
+        con.close()
+
+
+def test_estimate_live_data_size_and_bloat_ratio_detect_synthetic_bloat(tmp_path: Path) -> None:
+    db_path = tmp_path / "bloat.duckdb"
+    _build_bloated_fixture_db(db_path)
+
+    # Independently recompute the fixture's known ratio straight from DuckDB's own
+    # pragmas, without going through the functions under test.
+    con = duckdb.connect(str(db_path), read_only=True)
+    block_size, total_blocks = _duckdb_size_info(con)
+    known_live_blocks = _live_blocks(con, "main", "live_data")
+    con.close()
+
+    known_total_bytes = block_size * total_blocks
+    known_live_bytes = len(known_live_blocks) * block_size
+    known_ratio = known_total_bytes / known_live_bytes
+
+    size_info = inspect_database_size(db_path)
+    live_bytes = estimate_live_data_size(db_path)
+    ratio = compute_bloat_ratio(size_info.total_bytes, live_bytes)
+
+    assert size_info.total_bytes == known_total_bytes
+    assert live_bytes == known_live_bytes
+    assert ratio == pytest.approx(known_ratio, rel=0.05)
+    # The churn pattern must actually have produced measurable bloat for this fixture
+    # to be meaningful (used blocks left behind beyond the live table's footprint).
+    assert ratio > 1.0

--- a/tests/unit/services/test_storage_health.py
+++ b/tests/unit/services/test_storage_health.py
@@ -10,6 +10,7 @@ import pytest
 from searchat.services.backup import BackupManager
 from searchat.services.storage_contracts import BACKUP_MANIFEST_FILE
 from searchat.services.storage_health import (
+    audit_backup_redundancy,
     compute_bloat_ratio,
     estimate_live_data_size,
     inspect_database_size,
@@ -288,3 +289,49 @@ def test_estimate_live_data_size_and_bloat_ratio_detect_synthetic_bloat(tmp_path
     # The churn pattern must actually have produced measurable bloat for this fixture
     # to be meaningful (used blocks left behind beyond the live table's footprint).
     assert ratio > 1.0
+
+
+# ---------------------------------------------------------------------------
+# Storage doctor diagnostics: backup redundancy audit
+# ---------------------------------------------------------------------------
+
+
+def test_audit_backup_redundancy_flags_strict_subset_as_redundant(temp_search_dir: Path) -> None:
+    data_root = temp_search_dir / "data" / "conversations"
+    data_root.mkdir(parents=True, exist_ok=True)
+    (data_root / "conv1.parquet").write_bytes(b"PAR1conv1data")
+    (data_root / "conv2.parquet").write_bytes(b"PAR1conv2data")
+
+    manager = BackupManager(temp_search_dir)
+    manager.create_backup(backup_name="snap1")
+
+    # Live data grows after the backup — the backup's files remain a strict subset.
+    (data_root / "conv3.parquet").write_bytes(b"PAR1conv3newdata")
+
+    audits = audit_backup_redundancy(temp_search_dir / "backups", temp_search_dir)
+
+    assert len(audits) == 1
+    assert audits[0].file_count == 2
+    assert audits[0].redundant is True
+    assert audits[0].unique_files == ()
+
+
+def test_audit_backup_redundancy_flags_modified_live_file_as_not_redundant(temp_search_dir: Path) -> None:
+    data_root = temp_search_dir / "data" / "conversations"
+    data_root.mkdir(parents=True, exist_ok=True)
+    (data_root / "conv1.parquet").write_bytes(b"PAR1conv1data")
+
+    manager = BackupManager(temp_search_dir)
+    manager.create_backup(backup_name="snap1")
+
+    (data_root / "conv1.parquet").write_bytes(b"MODIFIED-CONTENT")
+
+    audits = audit_backup_redundancy(temp_search_dir / "backups", temp_search_dir)
+
+    assert len(audits) == 1
+    assert audits[0].redundant is False
+    assert audits[0].unique_files == ("data/conversations/conv1.parquet",)
+
+
+def test_audit_backup_redundancy_missing_backup_dir_returns_empty(tmp_path: Path) -> None:
+    assert audit_backup_redundancy(tmp_path / "no_backups", tmp_path) == []

--- a/tests/unit/services/test_storage_health.py
+++ b/tests/unit/services/test_storage_health.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import shutil
+from datetime import datetime, timedelta
 from pathlib import Path
+from unittest.mock import Mock
 
 import duckdb
 import pytest
@@ -10,8 +12,12 @@ import pytest
 from searchat.services.backup import BackupManager
 from searchat.services.storage_contracts import BACKUP_MANIFEST_FILE
 from searchat.services.storage_health import (
+    HarnessSourceSize,
     audit_backup_redundancy,
+    build_storage_doctor_report,
     compute_bloat_ratio,
+    estimate_harness_source_sizes,
+    estimate_last_backup_age,
     estimate_live_data_size,
     inspect_database_size,
     inspect_storage_health,
@@ -335,3 +341,104 @@ def test_audit_backup_redundancy_flags_modified_live_file_as_not_redundant(temp_
 
 def test_audit_backup_redundancy_missing_backup_dir_returns_empty(tmp_path: Path) -> None:
     assert audit_backup_redundancy(tmp_path / "no_backups", tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Storage doctor diagnostics: harness sizes, backup age, and full report
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_harness_source_sizes_sums_discovered_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    file_a = tmp_path / "a.jsonl"
+    file_a.write_bytes(b"x" * 100)
+    file_b = tmp_path / "b.jsonl"
+    file_b.write_bytes(b"y" * 250)
+
+    fake_connector = Mock()
+    fake_connector.name = "fake_harness"
+    fake_connector.discover_files.return_value = [file_a, file_b]
+
+    monkeypatch.setattr(
+        "searchat.services.storage_health.get_connectors", lambda: (fake_connector,)
+    )
+
+    sizes = estimate_harness_source_sizes(Mock())
+
+    assert sizes == [HarnessSourceSize(connector="fake_harness", file_count=2, total_size_bytes=350)]
+
+
+def test_estimate_harness_source_sizes_skips_failing_connector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broken_connector = Mock()
+    broken_connector.name = "broken"
+    broken_connector.discover_files.side_effect = RuntimeError("harness unavailable")
+
+    monkeypatch.setattr(
+        "searchat.services.storage_health.get_connectors", lambda: (broken_connector,)
+    )
+
+    assert estimate_harness_source_sizes(Mock()) == []
+
+
+def test_estimate_last_backup_age_returns_none_when_no_backups(temp_search_dir: Path) -> None:
+    assert estimate_last_backup_age(temp_search_dir) == (None, None)
+
+
+def test_estimate_last_backup_age_computes_seconds_since_latest(temp_search_dir: Path) -> None:
+    manager = BackupManager(temp_search_dir)
+    live_file = temp_search_dir / "data" / "conversations" / "conv.parquet"
+    live_file.parent.mkdir(parents=True, exist_ok=True)
+    live_file.write_bytes(b"PAR1")
+    manager.create_backup(backup_name="snap1")
+
+    backed_at = datetime.strptime(manager.list_backups()[0].timestamp, "%Y%m%d_%H%M%S")
+
+    last_at, age_seconds = estimate_last_backup_age(temp_search_dir, now=backed_at + timedelta(hours=2))
+
+    assert last_at == backed_at.isoformat()
+    assert age_seconds == pytest.approx(7200, abs=1)
+
+
+def test_build_storage_doctor_report_assembles_all_sections(
+    temp_search_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_root = temp_search_dir / "data"
+    (data_root / "conversations").mkdir(parents=True, exist_ok=True)
+    (data_root / "conversations" / "conv.parquet").write_bytes(b"PAR1conv")
+
+    db_path = data_root / "searchat.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE TABLE conversations(id INTEGER)")
+    con.execute("INSERT INTO conversations SELECT * FROM range(10)")
+    con.execute("CHECKPOINT")
+    con.close()
+
+    manager = BackupManager(temp_search_dir)
+    manager.create_backup(backup_name="snap1")
+
+    monkeypatch.setattr("searchat.services.storage_health.get_connectors", lambda: ())
+
+    config = Mock()
+    config.storage.resolve_duckdb_path.return_value = db_path
+
+    report = build_storage_doctor_report(temp_search_dir, config)
+
+    assert report.db_path == db_path
+    assert report.db_exists is True
+    assert report.total_bytes > 0
+    assert report.live_bytes > 0
+    assert report.bloat_ratio >= 1.0
+    assert len(report.backups) == 1
+    assert report.backups[0].redundant is True
+    assert report.harness_sources == ()
+    assert report.last_backup_at is not None
+    assert report.last_backup_age_seconds is not None
+    assert report.last_backup_age_seconds >= 0
+
+    payload = report.to_dict()
+    assert payload["db_exists"] is True
+    assert isinstance(payload["backups"], list)
+    assert isinstance(payload["harness_sources"], list)


### PR DESCRIPTION
## Stack

Stack-Id: `storage-doctor-m1-a1f9c2`
Base: `main`
Position: 1/2

1. `feat/storage-doctor-engine` -> this PR
2. `feat/storage-doctor-cli-api` -> depends on this PR

Depends on: (none - root)
Upstack: PR-2 (CLI + API surfacing)

## Summary

Read-only storage diagnostics engine for M1 (Storage doctor diagnostics), per `.docs/DEVELOPMENT_PLAN.md` §4 M1 and `.docs/searchat-memory-management-enhancement-analysis.md` Part 5 E1.1.

Adds to `services/storage_health.py`:

- `inspect_database_size` / `estimate_live_data_size` — live-data footprint via `pragma_storage_info` across `main` + every `fts_main_*` schema, distinguishing on-disk file size from what live tables actually need.
- `compute_bloat_ratio` — pure ratio math (on-disk size ÷ live-data footprint).
- `audit_backup_redundancy` — flags backups whose captured files are a byte-identical (`content_sha256`) strict subset of current live data, safe to delete.
- `estimate_harness_source_sizes` — per-connector discovered-file totals, degrading gracefully for unregistered/failing harnesses.
- `estimate_last_backup_age` — age of the most recent backup.
- `build_storage_doctor_report` / `StorageDoctorReport.to_dict()` — single source of truth composing all of the above into one JSON-serializable report, consumed by PR-2's CLI and API surfacing.

All functions are read-only: connections open with `read_only=True`, no writes, no deletes.

## Testing

- `test_estimate_live_data_size_and_bloat_ratio_detect_synthetic_bloat` builds a deterministic bloat fixture (incompressible per-row content, churned via repeated update+checkpoint cycles across separate connections) and cross-checks the engine's output against an independently-recomputed reference derived from raw DuckDB pragmas in the same test — non-flaky, and asserts `ratio > 1.0` (real bloat detected).
- `audit_backup_redundancy`: strict-subset-is-redundant and modified-file-is-not-redundant cases, mirroring the Tier-0 forensic precedent (a real backup with fully-contained file set was deleted manually pre-code).
- `estimate_harness_source_sizes`: sums discovered files, skips a connector whose `discover_files` raises.
- `build_storage_doctor_report`: end-to-end assembly against a fixture search dir with a real DuckDB file and a real backup.

## Validation

- `uv run pytest tests/unit/services/test_storage_health.py -v --tb=short --no-cov` — 21 passed
- `uv run pytest -v --tb=short` (full suite, matches CI) — 2077 passed, 1 skipped, 81.49% coverage (gate: 80%)
- `uv run ruff check src/searchat/services/storage_health.py tests/unit/services/test_storage_health.py` — clean
- `uv run mypy src/searchat/services/storage_health.py` — 4 pre-existing errors in untouched code (verified identical on `main` via `git stash`), zero new errors in the added code