### PR TITLE
feat(cli,api): surface storage doctor via CLI and health endpoint

### DIFF
--- a/src/searchat/api/contracts.py
+++ b/src/searchat/api/contracts.py
@@ -606,8 +606,10 @@ def serialize_health_deep_payload(
     *,
     healthy: bool,
     checks: dict[str, Any],
+    storage: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         "healthy": healthy,
         "checks": checks,
+        "storage": storage,
     }

--- a/src/searchat/api/routers/health.py
+++ b/src/searchat/api/routers/health.py
@@ -58,7 +58,7 @@ async def health_deep() -> JSONResponse:
     checks["disk_space"] = _timed_check("disk_space", _check_disk_space)
 
     healthy = all(c["status"] == "ok" for c in checks.values())
-    payload = serialize_health_deep_payload(healthy=healthy, checks=checks)
+    payload = serialize_health_deep_payload(healthy=healthy, checks=checks, storage=_build_storage_report())
     status_code = 200 if healthy else 503
     return JSONResponse(content=payload, status_code=status_code)
 
@@ -143,3 +143,18 @@ def _check_disk_space() -> dict[str, Any]:
     if free_gb < 1.0:
         return {"status": "warning", "free_gb": round(free_gb, 2)}
     return {"status": "ok", "free_gb": round(free_gb, 2)}
+
+
+def _build_storage_report() -> dict[str, Any]:
+    """Read-only storage doctor report for the deep health payload.
+
+    Degrades to an error dict rather than failing the whole /health request —
+    this section is diagnostic, not a pass/fail readiness gate.
+    """
+    from searchat.services.storage_health import build_storage_doctor_report
+
+    try:
+        report = build_storage_doctor_report(deps.get_search_dir(), deps.get_config())
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+    return report.to_dict()

--- a/src/searchat/cli/doctor_cmd.py
+++ b/src/searchat/cli/doctor_cmd.py
@@ -1,0 +1,127 @@
+"""CLI command: searchat doctor — read-only storage diagnostics report."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def _format_bytes(num_bytes: int | float) -> str:
+    value = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(value) < 1024.0:
+            return f"{value:.1f} {unit}"
+        value /= 1024.0
+    return f"{value:.1f} PB"
+
+
+def _format_age(seconds: float | None) -> str:
+    if seconds is None:
+        return "never"
+    if seconds < 60:
+        return f"{seconds:.0f}s ago"
+    minutes = seconds / 60
+    if minutes < 60:
+        return f"{minutes:.0f}m ago"
+    hours = minutes / 60
+    if hours < 24:
+        return f"{hours:.1f}h ago"
+    return f"{hours / 24:.1f}d ago"
+
+
+def _bloat_style(ratio: float) -> str:
+    if ratio >= 3.0:
+        return "red"
+    if ratio >= 1.5:
+        return "yellow"
+    return "green"
+
+
+def run_doctor(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="searchat doctor",
+        description=(
+            "Read-only storage diagnostics: DuckDB bloat ratio, per-backup redundancy, "
+            "per-harness source sizes, WAL size, and last-backup age. Never mutates data."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Output raw JSON instead of tables.")
+    args = parser.parse_args(argv)
+
+    from searchat.config import Config, PathResolver
+    from searchat.services.storage_health import build_storage_doctor_report
+
+    config = Config.load()
+    search_dir = PathResolver.get_shared_search_dir(config)
+
+    try:
+        report = build_storage_doctor_report(search_dir, config)
+    except Exception as exc:
+        print(f"Error: failed to build storage doctor report: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(report.to_dict(), indent=2))
+        return 0
+
+    from rich.console import Console
+    from rich.panel import Panel
+    from rich.table import Table
+
+    console = Console()
+    console.print(Panel(f"[bold]Storage Doctor[/bold]\n{search_dir}", expand=False))
+
+    if not report.db_exists:
+        console.print("[yellow]No DuckDB index found yet — nothing to diagnose.[/yellow]")
+    else:
+        overview = Table(show_header=True, header_style="bold", title="Database")
+        overview.add_column("Metric")
+        overview.add_column("Value")
+        overview.add_row("On-disk size", _format_bytes(report.total_bytes))
+        overview.add_row("Live data (estimated)", _format_bytes(report.live_bytes))
+        overview.add_row("WAL size", _format_bytes(report.wal_bytes))
+        style = _bloat_style(report.bloat_ratio)
+        overview.add_row("Bloat ratio", f"[{style}]{report.bloat_ratio:.2f}x[/{style}]")
+        console.print(overview)
+
+    console.print(f"\nLast backup: {_format_age(report.last_backup_age_seconds)}")
+
+    if report.backups:
+        backups_table = Table(show_header=True, header_style="bold", title="\nBackups")
+        backups_table.add_column("Name")
+        backups_table.add_column("Files", justify="right")
+        backups_table.add_column("Size", justify="right")
+        backups_table.add_column("Redundant")
+        for backup in report.backups:
+            redundant_str = "[green]yes[/green]" if backup.redundant else "no"
+            backups_table.add_row(
+                backup.backup_name,
+                str(backup.file_count),
+                _format_bytes(backup.total_size_bytes),
+                redundant_str,
+            )
+        console.print(backups_table)
+    else:
+        console.print("\n[dim]No backups found.[/dim]")
+
+    if report.harness_sources:
+        harness_table = Table(show_header=True, header_style="bold", title="\nHarness Sources")
+        harness_table.add_column("Connector")
+        harness_table.add_column("Files", justify="right")
+        harness_table.add_column("Size", justify="right")
+        for harness in sorted(report.harness_sources, key=lambda h: h.total_size_bytes, reverse=True):
+            harness_table.add_row(
+                harness.connector, str(harness.file_count), _format_bytes(harness.total_size_bytes)
+            )
+        console.print(harness_table)
+    else:
+        console.print("\n[dim]No harness sources discovered.[/dim]")
+
+    redundant_count = sum(1 for backup in report.backups if backup.redundant)
+    if redundant_count:
+        console.print(
+            f"\n[yellow]{redundant_count} backup(s) are fully redundant with live data "
+            "and may be safe to delete.[/yellow]"
+        )
+
+    return 0

--- a/src/searchat/cli/main.py
+++ b/src/searchat/cli/main.py
@@ -440,6 +440,11 @@ def main():
 
             raise SystemExit(run_health(argv[1:]))
 
+        if argv and argv[0] == "doctor":
+            from searchat.cli.doctor_cmd import run_doctor
+
+            raise SystemExit(run_doctor(argv[1:]))
+
         if argv and argv[0] == "ci-check":
             from searchat.cli.ci_check_cmd import run_ci_check
 
@@ -475,6 +480,7 @@ def main():
             print("  searchat distill [--project PROJECT] [--retry-errors] [--dry-run]")
             print("  searchat migrate-storage [--dry-run] [--verify] [--rollback]")
             print("  searchat health [--url URL] [--json]")
+            print("  searchat doctor [--json]")
             print("  searchat ci-check [--fail-on-contradictions] [--fail-on-staleness-threshold FLOAT]")
             print()
             return

--- a/tests/api/test_health_routes.py
+++ b/tests/api/test_health_routes.py
@@ -289,3 +289,117 @@ def test_health_deep_disk_space_warning(
     body = resp.json()
     assert body["checks"]["disk_space"]["status"] == "warning"
     assert body["healthy"] is False
+
+
+# ---------------------------------------------------------------------------
+# /api/health (deep) — storage section
+# ---------------------------------------------------------------------------
+
+
+def test_health_deep_includes_storage_section_with_real_data(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import duckdb
+
+    import searchat.api.dependencies as deps
+
+    search_dir = tmp_path / ".searchat"
+    data_dir = search_dir / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "conversations.parquet").touch()
+
+    backup_dir = search_dir / "backups"
+    backup_dir.mkdir()
+
+    db_path = data_dir / "searchat.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE TABLE conversations(id INTEGER)")
+    con.execute("INSERT INTO conversations SELECT * FROM range(5)")
+    con.execute("CHECKPOINT")
+    con.close()
+
+    monkeypatch.setattr(
+        "searchat.services.storage_health.get_connectors", lambda: ()
+    )
+
+    store = MagicMock()
+    store.validate_parquet_scan.return_value = None
+    store.count_conversations.return_value = 42
+
+    faiss_index = MagicMock()
+    faiss_index.ntotal = 100
+    engine = MagicMock()
+    engine.faiss_index = faiss_index
+    engine.embedder = MagicMock()
+
+    backup_manager = MagicMock()
+    backup_manager.backup_dir = backup_dir
+
+    config = MagicMock()
+    config.storage.resolve_duckdb_path.return_value = db_path
+
+    monkeypatch.setattr(deps, "_duckdb_store", store)
+    monkeypatch.setattr(deps, "_search_dir", search_dir)
+    monkeypatch.setattr(deps, "_search_engine", engine)
+    monkeypatch.setattr(deps, "_backup_manager", backup_manager)
+    monkeypatch.setattr(deps, "_config", config)
+
+    mod = _api_app_module()
+    client = TestClient(mod.app, raise_server_exceptions=False)
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    storage = body["storage"]
+    assert storage["db_exists"] is True
+    assert storage["total_bytes"] > 0
+    assert storage["live_bytes"] > 0
+    assert storage["bloat_ratio"] >= 1.0
+    assert storage["harness_sources"] == []
+    assert isinstance(storage["backups"], list)
+
+
+def test_health_deep_storage_section_degrades_gracefully_on_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    import searchat.api.dependencies as deps
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "conversations.parquet").touch()
+
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+
+    store = MagicMock()
+    store.validate_parquet_scan.return_value = None
+    store.count_conversations.return_value = 42
+
+    faiss_index = MagicMock()
+    faiss_index.ntotal = 100
+    engine = MagicMock()
+    engine.faiss_index = faiss_index
+    engine.embedder = MagicMock()
+
+    backup_manager = MagicMock()
+    backup_manager.backup_dir = backup_dir
+
+    config = MagicMock()
+    config.storage.resolve_duckdb_path.side_effect = RuntimeError("storage unavailable")
+
+    monkeypatch.setattr(deps, "_duckdb_store", store)
+    monkeypatch.setattr(deps, "_search_dir", tmp_path)
+    monkeypatch.setattr(deps, "_search_engine", engine)
+    monkeypatch.setattr(deps, "_backup_manager", backup_manager)
+    monkeypatch.setattr(deps, "_config", config)
+
+    mod = _api_app_module()
+    client = TestClient(mod.app, raise_server_exceptions=False)
+    resp = client.get("/api/health")
+    # The storage diagnostics section failing must never affect the overall
+    # readiness-critical checks or status code.
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["healthy"] is True
+    assert body["storage"]["status"] == "error"
+    assert "storage unavailable" in body["storage"]["error"]

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -1,0 +1,219 @@
+"""Unit tests for `searchat doctor` CLI command."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import duckdb
+import pytest
+
+from searchat.services.backup import BackupManager
+
+
+def _cfg(search_dir: Path) -> SimpleNamespace:
+    """Minimal Config stand-in exposing only what run_doctor touches."""
+    return SimpleNamespace(
+        storage=SimpleNamespace(resolve_duckdb_path=lambda _search_dir: search_dir / "data" / "searchat.duckdb")
+    )
+
+
+def test_doctor_help_text(capsys) -> None:
+    from searchat.cli.doctor_cmd import run_doctor
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_doctor(["--help"])
+    assert exc_info.value.code == 0
+
+    captured = capsys.readouterr()
+    assert "doctor" in captured.out.lower()
+    assert "--json" in captured.out
+
+
+def test_doctor_reports_friendly_message_when_no_db_exists(temp_search_dir: Path, capsys) -> None:
+    from searchat.cli.doctor_cmd import run_doctor
+
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch("searchat.services.storage_health.get_connectors", return_value=()),
+    ):
+        result = run_doctor([])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "no duckdb index found" in captured.out.lower()
+
+
+def test_doctor_table_output_shows_bloat_ratio_and_backups(temp_search_dir: Path, capsys) -> None:
+    from searchat.cli.doctor_cmd import run_doctor
+
+    data_dir = temp_search_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    db_path = data_dir / "searchat.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE TABLE conversations(id INTEGER)")
+    con.execute("INSERT INTO conversations SELECT * FROM range(5)")
+    con.execute("CHECKPOINT")
+    con.close()
+
+    manager = BackupManager(temp_search_dir)
+    (data_dir / "conversations" / "conv.parquet").parent.mkdir(parents=True, exist_ok=True)
+    (data_dir / "conversations" / "conv.parquet").write_bytes(b"PAR1")
+    manager.create_backup(backup_name="snap1")
+
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch("searchat.services.storage_health.get_connectors", return_value=()),
+    ):
+        result = run_doctor([])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Bloat ratio" in captured.out
+    assert "Backups" in captured.out
+    assert "snap1" in captured.out
+    assert "Redundant" in captured.out
+
+
+def test_doctor_json_output_matches_documented_schema(temp_search_dir: Path, capsys) -> None:
+    from searchat.cli.doctor_cmd import run_doctor
+
+    data_dir = temp_search_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    db_path = data_dir / "searchat.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE TABLE conversations(id INTEGER)")
+    con.execute("INSERT INTO conversations SELECT * FROM range(5)")
+    con.execute("CHECKPOINT")
+    con.close()
+
+    manager = BackupManager(temp_search_dir)
+    (data_dir / "conversations").mkdir(parents=True, exist_ok=True)
+    (data_dir / "conversations" / "conv.parquet").write_bytes(b"PAR1")
+    manager.create_backup(backup_name="snap1")
+
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch("searchat.services.storage_health.get_connectors", return_value=()),
+    ):
+        result = run_doctor(["--json"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    payload = json.loads(captured.out)
+
+    # Top-level schema.
+    assert set(payload.keys()) == {
+        "search_dir",
+        "db_path",
+        "db_exists",
+        "total_bytes",
+        "live_bytes",
+        "wal_bytes",
+        "bloat_ratio",
+        "backups",
+        "harness_sources",
+        "last_backup_at",
+        "last_backup_age_seconds",
+    }
+    assert isinstance(payload["db_exists"], bool)
+    assert isinstance(payload["total_bytes"], int)
+    assert isinstance(payload["live_bytes"], int)
+    assert isinstance(payload["wal_bytes"], int)
+    assert isinstance(payload["bloat_ratio"], (int, float))
+    assert isinstance(payload["backups"], list)
+    assert isinstance(payload["harness_sources"], list)
+
+    assert len(payload["backups"]) == 1
+    backup_entry = payload["backups"][0]
+    assert set(backup_entry.keys()) == {
+        "backup_name",
+        "backup_path",
+        "file_count",
+        "total_size_bytes",
+        "redundant",
+        "unique_files",
+    }
+    assert isinstance(backup_entry["redundant"], bool)
+    assert isinstance(backup_entry["unique_files"], list)
+    assert backup_entry["redundant"] is True
+
+
+def test_doctor_json_reports_synthetic_bloat_ratio(temp_search_dir: Path, capsys) -> None:
+    """CLI-level acceptance check: a fixture DB with deliberate bloat reports a
+    ratio consistent with an independently-derived reference (>1.0, and within
+    5% of the same raw-pragma computation used in the engine-level test)."""
+    from searchat.cli.doctor_cmd import run_doctor
+
+    data_dir = temp_search_dir / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    db_path = data_dir / "searchat.duckdb"
+
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE TABLE live_data(id INTEGER, payload VARCHAR)")
+    con.execute(
+        "INSERT INTO live_data SELECT i, md5(i::VARCHAR) || md5((i + 1)::VARCHAR) || md5((i + 2)::VARCHAR) "
+        "FROM range(20000) t(i)"
+    )
+    con.execute("CHECKPOINT")
+    con.close()
+
+    for cycle in range(15):
+        con = duckdb.connect(str(db_path))
+        con.execute(
+            "UPDATE live_data SET payload = md5((? || id)::VARCHAR) || md5((? || id + 1)::VARCHAR) "
+            "WHERE id % 5 = ?",
+            [str(cycle), str(cycle), cycle % 5],
+        )
+        con.execute("CHECKPOINT")
+        con.close()
+
+    con = duckdb.connect(str(db_path), read_only=True)
+    size_row = con.execute("PRAGMA database_size").fetchone()
+    columns = {desc[0]: value for desc, value in zip(con.description, size_row)}
+    block_size, total_blocks = int(columns["block_size"]), int(columns["total_blocks"])
+    known_live_blocks = {
+        int(row[0])
+        for row in con.execute(
+            "SELECT DISTINCT block_id FROM pragma_storage_info('\"main\".\"live_data\"') "
+            "WHERE block_id IS NOT NULL AND block_id >= 0"
+        ).fetchall()
+    }
+    con.close()
+    known_ratio = (total_blocks * block_size) / (len(known_live_blocks) * block_size)
+
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch("searchat.services.storage_health.get_connectors", return_value=()),
+    ):
+        result = run_doctor(["--json"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    payload = json.loads(captured.out)
+
+    assert payload["bloat_ratio"] > 1.0
+    assert payload["bloat_ratio"] == pytest.approx(known_ratio, rel=0.05)
+
+
+def test_doctor_returns_one_and_prints_error_on_failure(temp_search_dir: Path, capsys) -> None:
+    from searchat.cli.doctor_cmd import run_doctor
+
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch(
+            "searchat.services.storage_health.build_storage_doctor_report",
+            side_effect=RuntimeError("disk read failed"),
+        ),
+    ):
+        result = run_doctor([])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "disk read failed" in captured.err


### PR DESCRIPTION
## Stack

Stack-Id: `storage-doctor-m1-a1f9c2`
Base: `feat/storage-doctor-engine` (#88)
Position: 2/2

1. `feat/storage-doctor-engine` -> #88
2. `feat/storage-doctor-cli-api` -> this PR

Depends on: #88
Upstack: (none - leaf)

## Summary

CLI and API surfacing for M1 (Storage doctor diagnostics), on top of #88's diagnostics engine.

- `cli/doctor_cmd.py` (new) — `searchat doctor` renders the storage report as rich tables (bloat ratio color-coded green/yellow/red, backups table with redundancy flags, per-harness source sizes table) or, with `--json`, dumps `StorageDoctorReport.to_dict()` verbatim for scripting.
- `cli/main.py` — dispatch entry + help text, following the existing flat `if argv[0] == "..."` pattern used by every other subcommand.
- `api/routers/health.py` + `api/contracts.py` — `/api/health` (deep) gains a top-level `storage` field. It is deliberately **not** part of the `checks` dict: a bloated database is diagnostic information, not a readiness failure, so it never flips the endpoint's 200/503 status. Building the report is wrapped in try/except and degrades to `{"status": "error", "error": ...}` rather than failing the request.

## Testing

- `tests/unit/test_cli_doctor.py` (new): help text, no-DB-yet friendly message, table output content, `--json` schema (asserts the exact top-level and per-backup key sets), a CLI-level synthetic-bloat acceptance test (same churn-fixture technique as the engine test, independently re-derived reference, `ratio > 1.0` and within 5%), and error-path exit code 1.
- `tests/api/test_health_routes.py` additions: storage section present with real DuckDB + backup fixture data; storage failure degrades gracefully without affecting `healthy`/status code.

Smoke-tested against this machine's real `~/.searchat` (1.4 GB DuckDB, 471 MB live data, 3.10x bloat ratio, one of two backups correctly flagged fully redundant) via both `searchat doctor` and `searchat doctor --json`.

## Validation

- `uv run pytest tests/unit/services/test_storage_health.py tests/unit/test_cli_doctor.py tests/api/test_health_routes.py -v --tb=short --no-cov` — 37 passed
- `uv run pytest -v --tb=short` (full suite, matches CI) — 2085 passed, 1 skipped, 81.50% coverage (gate: 80%)
- `uv run ruff check` on all new/modified files — clean (pre-existing unrelated `cli/main.py` unused-import warnings, verified identical on `main` via `git stash`)
- `uv run mypy` on all new/modified files — clean