### PR TITLE
feat(core): add rebuild-derived engine (source-file-free)

### DIFF
--- a/src/searchat/core/unified_indexer.py
+++ b/src/searchat/core/unified_indexer.py
@@ -17,7 +17,8 @@ from searchat.config import Config
 from searchat.core.connectors import detect_connector, discover_all_files
 from searchat.core.logging_config import get_logger
 from searchat.core.progress import NullProgressAdapter, ProgressCallback
-from searchat.models import ConversationRecord, IndexStats, UpdateStats
+from searchat.models import ConversationRecord, IndexStats, RebuildStats, UpdateStats
+from searchat.storage.schema import create_fts_indexes, create_hnsw_indexes
 from searchat.storage.unified_storage import UnifiedStorage
 
 logger = get_logger(__name__)
@@ -159,6 +160,93 @@ class UnifiedIndexer:
             "  2. Call index_all(force=True) if you have complete source files\n"
             "  3. Delete index manually: rm -rf <search_dir>/data/\n\n"
             f"Index location: {self.search_dir / 'data'}"
+        )
+
+    def rebuild_derived(
+        self,
+        force: bool = False,
+        progress: ProgressCallback | None = None,
+    ) -> RebuildStats:
+        """Deterministically rebuild exchanges, embeddings, FTS, and HNSW.
+
+        Safety: reads exclusively from UnifiedStorage's already-persisted
+        ``conversations``/``messages`` tables. Never calls a connector, never
+        discovers or opens a source JSONL/session file, and never touches
+        ``source_file_state``. This is the safe counterpart to index_all(),
+        which stays guarded exactly as before — rebuild_derived is a
+        completely separate code path that does not call it.
+
+        force=False (default): only (re)segments exchanges/embeddings for
+        conversations that currently have zero exchange rows — a cheap,
+        idempotent completion pass safe to run at any time.
+        force=True: wipes and regenerates exchanges/embeddings for every
+        conversation from their persisted messages, then drops and recreates
+        the FTS and HNSW indexes from scratch. Deterministic: the same
+        messages always segment into the same exchanges and embeddings, so
+        this reproduces exactly what the original ingestion path produced.
+        """
+        if progress is None:
+            progress = NullProgressAdapter()
+
+        progress.update_phase("Rebuilding derived data from persisted conversations")
+        start_time = time.time()
+
+        if force:
+            conversation_ids = self._storage.list_conversation_ids()
+            self._storage.clear_exchanges()
+            self._storage.clear_embeddings()
+            self._storage.drop_hnsw_index()
+        else:
+            conversation_ids = self._storage.list_conversation_ids_without_exchanges()
+
+        total_exchanges = 0
+        total_embeddings = 0
+        processed = 0
+
+        for idx, conversation_id in enumerate(conversation_ids, 1):
+            record = self._storage.get_conversation_record(conversation_id)
+            if record is None or not record["messages"]:
+                continue
+
+            progress.update_file_progress(
+                idx, len(conversation_ids), record.get("title") or conversation_id
+            )
+
+            exchanges = _segment_exchanges(
+                conversation_id,
+                record["project_id"],
+                record["messages"],
+                record["created_at"],
+            )
+            for exc in exchanges:
+                self._storage.upsert_exchange(**exc)
+            total_exchanges += len(exchanges)
+
+            if exchanges:
+                total_embeddings += self._embed_exchanges(exchanges, progress)
+
+            processed += 1
+
+        create_fts_indexes(self._storage.connection)
+        create_hnsw_indexes(
+            self._storage.connection,
+            ef_construction=self.config.storage.hnsw_ef_construction,
+            m=self.config.storage.hnsw_m,
+        )
+
+        progress.update_stats(
+            conversations=processed,
+            chunks=total_exchanges,
+            embeddings=total_embeddings,
+        )
+        progress.finish()
+
+        return RebuildStats(
+            conversations_processed=processed,
+            exchanges_rebuilt=total_exchanges,
+            embeddings_rebuilt=total_embeddings,
+            rebuild_time_seconds=time.time() - start_time,
+            forced=force,
         )
 
     def index_append_only(

--- a/src/searchat/models/__init__.py
+++ b/src/searchat/models/__init__.py
@@ -8,6 +8,7 @@ from searchat.models.domain import (
     SearchResults,
     IndexStats,
     UpdateStats,
+    RebuildStats,
     DateFilter,
     ParsedQuery,
     FileTouched,
@@ -40,6 +41,7 @@ __all__ = [
     "SearchResults",
     "IndexStats",
     "UpdateStats",
+    "RebuildStats",
     "DateFilter",
     "ParsedQuery",
     # Palace / Distillation

--- a/src/searchat/models/domain.py
+++ b/src/searchat/models/domain.py
@@ -98,6 +98,15 @@ class UpdateStats:
 
 
 @dataclass
+class RebuildStats:
+    """Statistics about a rebuild_derived run (exchanges/embeddings/FTS/HNSW)."""
+    conversations_processed: int
+    exchanges_rebuilt: int
+    embeddings_rebuilt: int
+    rebuild_time_seconds: float
+    forced: bool
+
+@dataclass
 class DateFilter:
     """Date range filter for search queries."""
     from_date: datetime | None

--- a/src/searchat/storage/unified_storage.py
+++ b/src/searchat/storage/unified_storage.py
@@ -589,3 +589,43 @@ class UnifiedStorage:
             return int(row[0]) if row else 0
         finally:
             cur.close()
+
+    def list_conversation_ids(self) -> list[str]:
+        """Return every conversation_id in the store, ordered deterministically."""
+        cur = self._read_cursor()
+        try:
+            rows = cur.execute(
+                "SELECT conversation_id FROM conversations ORDER BY conversation_id"
+            ).fetchall()
+            return [r[0] for r in rows]
+        finally:
+            cur.close()
+
+    def list_conversation_ids_without_exchanges(self) -> list[str]:
+        """Return conversation_ids that currently have zero exchange rows."""
+        cur = self._read_cursor()
+        try:
+            rows = cur.execute(
+                "SELECT c.conversation_id FROM conversations c "
+                "WHERE NOT EXISTS ("
+                "  SELECT 1 FROM exchanges e WHERE e.conversation_id = c.conversation_id"
+                ") ORDER BY c.conversation_id"
+            ).fetchall()
+            return [r[0] for r in rows]
+        finally:
+            cur.close()
+
+    def clear_exchanges(self) -> None:
+        """Delete every row from exchanges. Used only for a forced full rebuild."""
+        cur = self._write_cursor()
+        cur.execute("DELETE FROM exchanges")
+
+    def clear_embeddings(self) -> None:
+        """Delete every row from verbatim_embeddings. Used only for a forced full rebuild."""
+        cur = self._write_cursor()
+        cur.execute("DELETE FROM verbatim_embeddings")
+
+    def drop_hnsw_index(self) -> None:
+        """Drop the verbatim_hnsw index so a forced rebuild recreates it from scratch."""
+        cur = self._write_cursor()
+        cur.execute("DROP INDEX IF EXISTS verbatim_hnsw")

--- a/tests/unit/core/test_unified_indexer.py
+++ b/tests/unit/core/test_unified_indexer.py
@@ -1,18 +1,23 @@
 """Unit tests for UnifiedIndexer — DuckDB-native conversation indexer."""
 from __future__ import annotations
 
+import hashlib
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
+from searchat.config import Config
 from searchat.core.unified_indexer import (
     UnifiedIndexer,
     _derive_exchange_id,
     _segment_exchanges,
 )
 from searchat.models import ConversationRecord, MessageRecord
+from searchat.storage.schema import create_fts_indexes
+from searchat.storage.unified_storage import UnifiedStorage
 
 
 # ---------------------------------------------------------------------------
@@ -338,3 +343,298 @@ class TestRecordMessagesToDicts:
         assert dicts[0]["content"] == "hello"
         assert dicts[0]["has_code"] is True
         assert dicts[0]["code_blocks"] == ["print('hi')"]
+
+
+# ---------------------------------------------------------------------------
+# rebuild_derived
+# ---------------------------------------------------------------------------
+
+class TestRebuildDerived:
+    """rebuild_derived() rebuilds exchanges/embeddings/FTS/HNSW from persisted
+    conversations/messages only — it must never touch source files."""
+
+    @pytest.fixture()
+    def real_storage(self, tmp_path: Path):
+        db_path = tmp_path / "rebuild_derived.duckdb"
+        storage = UnifiedStorage(db_path)
+        yield storage
+        storage.close()
+
+    def _seed_conversation(
+        self,
+        storage: UnifiedStorage,
+        conversation_id: str,
+        *,
+        project_id: str = "proj1",
+        n_messages: int = 4,
+        now: datetime | None = None,
+    ) -> None:
+        """Populate conversations/messages directly — never via a connector/file."""
+        now = now or datetime(2026, 1, 1, 12, 0, 0)
+        storage.upsert_conversation(
+            conversation_id=conversation_id,
+            project_id=project_id,
+            file_path=f"/fake/does/not/exist/{conversation_id}.jsonl",
+            title=f"Conversation {conversation_id}",
+            created_at=now,
+            updated_at=now,
+            message_count=n_messages,
+            full_text="hello world",
+            file_hash=f"hash-{conversation_id}",
+            indexed_at=now,
+        )
+        messages = [
+            {
+                "sequence": i,
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"{conversation_id} message {i} about sorting a python list",
+                "timestamp": now,
+                "has_code": False,
+                "code_blocks": None,
+            }
+            for i in range(n_messages)
+        ]
+        storage.insert_messages(conversation_id, messages)
+
+    def _deterministic_vector(self, text: str) -> list[float]:
+        """Same text -> same 384-dim vector, every time."""
+        seed = int(hashlib.sha256(text.encode()).hexdigest()[:8], 16)
+        rng = np.random.default_rng(seed)
+        return rng.random(384).tolist()
+
+    def _make_deterministic_embedder(self) -> MagicMock:
+        embedder = MagicMock()
+        embedder.encode.side_effect = lambda batch, **kwargs: np.array(
+            [self._deterministic_vector(text) for text in batch]
+        )
+        return embedder
+
+    def test_zero_source_access_force_false(
+        self, tmp_path: Path, real_storage: UnifiedStorage
+    ) -> None:
+        """force=False never calls a connector or discovers source files."""
+        self._seed_conversation(real_storage, "conv-a")
+        self._seed_conversation(real_storage, "conv-b")
+
+        config = Config.load()
+        indexer = UnifiedIndexer(tmp_path, config, storage=real_storage)
+        embedder = self._make_deterministic_embedder()
+
+        with (
+            patch(
+                "searchat.core.unified_indexer.detect_connector",
+                side_effect=AssertionError("must never touch source files"),
+            ),
+            patch(
+                "searchat.core.unified_indexer.discover_all_files",
+                side_effect=AssertionError("must never touch source files"),
+            ),
+            patch.object(indexer, "_get_embedder", return_value=embedder),
+        ):
+            stats = indexer.rebuild_derived(force=False)
+
+        assert stats.conversations_processed == 2
+        assert stats.exchanges_rebuilt == 4
+        assert stats.embeddings_rebuilt == 4
+        assert stats.forced is False
+        assert real_storage.get_exchange_count() == 4
+        assert real_storage.get_embedding_count() == 4
+
+    def test_zero_source_access_force_true_rebuilds_indexes(
+        self, tmp_path: Path, real_storage: UnifiedStorage
+    ) -> None:
+        """force=True also never touches source files, and rebuilds FTS + HNSW."""
+        self._seed_conversation(real_storage, "conv-a")
+        self._seed_conversation(real_storage, "conv-b")
+
+        config = Config.load()
+        indexer = UnifiedIndexer(tmp_path, config, storage=real_storage)
+        embedder = self._make_deterministic_embedder()
+
+        with (
+            patch(
+                "searchat.core.unified_indexer.detect_connector",
+                side_effect=AssertionError("must never touch source files"),
+            ),
+            patch(
+                "searchat.core.unified_indexer.discover_all_files",
+                side_effect=AssertionError("must never touch source files"),
+            ),
+            patch.object(indexer, "_get_embedder", return_value=embedder),
+        ):
+            stats = indexer.rebuild_derived(force=True)
+
+        assert stats.forced is True
+        assert stats.conversations_processed == 2
+        assert stats.exchanges_rebuilt == 4
+        assert stats.embeddings_rebuilt == 4
+
+        bm25_rows = real_storage.connection.execute(
+            "SELECT exchange_id, fts_main_exchanges.match_bm25(exchange_id, 'sorting') AS score "
+            "FROM exchanges WHERE score IS NOT NULL ORDER BY score DESC"
+        ).fetchall()
+        assert len(bm25_rows) > 0
+
+        hnsw_rows = real_storage.connection.execute(
+            "SELECT index_name FROM duckdb_indexes() WHERE index_name = 'verbatim_hnsw'"
+        ).fetchall()
+        assert hnsw_rows == [("verbatim_hnsw",)]
+
+    def test_incremental_leaves_populated_conversations_untouched(
+        self, tmp_path: Path, real_storage: UnifiedStorage
+    ) -> None:
+        """force=False only (re)segments conversations with zero exchange rows."""
+        self._seed_conversation(real_storage, "conv-a")
+
+        config = Config.load()
+        indexer = UnifiedIndexer(tmp_path, config, storage=real_storage)
+        embedder = self._make_deterministic_embedder()
+
+        with patch.object(indexer, "_get_embedder", return_value=embedder):
+            first_stats = indexer.rebuild_derived(force=False)
+
+        assert first_stats.conversations_processed == 1
+        exchange_ids_before = {
+            row[0]
+            for row in real_storage.connection.execute(
+                "SELECT exchange_id FROM exchanges"
+            ).fetchall()
+        }
+        assert exchange_ids_before
+
+        # conv-b has messages but zero exchanges yet; conv-a is already populated.
+        self._seed_conversation(real_storage, "conv-b")
+
+        with patch.object(indexer, "_get_embedder", return_value=embedder):
+            second_stats = indexer.rebuild_derived(force=False)
+
+        assert second_stats.conversations_processed == 1
+        exchange_ids_after = {
+            row[0]
+            for row in real_storage.connection.execute(
+                "SELECT exchange_id FROM exchanges"
+            ).fetchall()
+        }
+        # conv-a's exchanges are untouched by the second pass.
+        assert exchange_ids_before <= exchange_ids_after
+        # conv-b's exchanges were newly added.
+        assert exchange_ids_after - exchange_ids_before
+
+    def test_determinism_matches_from_scratch_ingestion(
+        self, tmp_path: Path, real_storage: UnifiedStorage
+    ) -> None:
+        """rebuild_derived(force=True) reproduces bit-identical search results."""
+        convo_file = tmp_path / "conv.jsonl"
+        convo_file.write_text("")
+
+        now = datetime(2026, 1, 1, 12, 0, 0)
+        messages = [
+            MessageRecord(sequence=0, role="user", content="how do I sort a list in python", timestamp=now, has_code=False),
+            MessageRecord(sequence=1, role="assistant", content="use sorted() or list.sort()", timestamp=now, has_code=False),
+            MessageRecord(sequence=2, role="user", content="what about reverse sorting", timestamp=now, has_code=False),
+            MessageRecord(sequence=3, role="assistant", content="pass reverse=True to sorted()", timestamp=now, has_code=False),
+        ]
+        record = ConversationRecord(
+            conversation_id="conv-det",
+            project_id="proj-det",
+            file_path=str(convo_file),
+            title="Determinism Test",
+            created_at=now,
+            updated_at=now,
+            message_count=len(messages),
+            messages=messages,
+            full_text="\n".join(m.content for m in messages),
+            embedding_id=0,
+            file_hash="det-hash",
+            indexed_at=now,
+        )
+
+        fake_connector = MagicMock()
+        fake_connector.name = "test"
+        fake_connector.parse.return_value = record
+
+        config = Config.load()
+        config.expertise.enabled = False
+        indexer = UnifiedIndexer(tmp_path, config, storage=real_storage)
+        embedder = self._make_deterministic_embedder()
+
+        with (
+            patch("searchat.core.unified_indexer.detect_connector", return_value=fake_connector),
+            patch.object(indexer, "_get_embedder", return_value=embedder),
+        ):
+            indexer.index_append_only([str(convo_file)])
+
+        # index_append_only() does not build the FTS index (only rebuild_derived
+        # does); build it once here so both passes are compared on equal footing.
+        create_fts_indexes(real_storage.connection)
+
+        query = "sort"
+        first_bm25 = real_storage.connection.execute(
+            "SELECT exchange_id, fts_main_exchanges.match_bm25(exchange_id, ?) AS score "
+            "FROM exchanges WHERE score IS NOT NULL ORDER BY score DESC, exchange_id",
+            [query],
+        ).fetchall()
+        assert first_bm25
+
+        probe_row = real_storage.connection.execute(
+            "SELECT exchange_id, embedding FROM verbatim_embeddings ORDER BY exchange_id LIMIT 1"
+        ).fetchone()
+        assert probe_row is not None
+        probe_vec = probe_row[1]
+
+        first_neighbors = real_storage.connection.execute(
+            "SELECT exchange_id, array_cosine_distance(embedding, ?::FLOAT[384]) AS dist "
+            "FROM verbatim_embeddings ORDER BY dist, exchange_id",
+            [probe_vec],
+        ).fetchall()
+        assert first_neighbors
+
+        # Wipe derived data and rebuild from the SAME persisted messages.
+        real_storage.clear_exchanges()
+        real_storage.clear_embeddings()
+        real_storage.drop_hnsw_index()
+
+        with patch.object(indexer, "_get_embedder", return_value=embedder):
+            indexer.rebuild_derived(force=True)
+
+        second_bm25 = real_storage.connection.execute(
+            "SELECT exchange_id, fts_main_exchanges.match_bm25(exchange_id, ?) AS score "
+            "FROM exchanges WHERE score IS NOT NULL ORDER BY score DESC, exchange_id",
+            [query],
+        ).fetchall()
+        second_neighbors = real_storage.connection.execute(
+            "SELECT exchange_id, array_cosine_distance(embedding, ?::FLOAT[384]) AS dist "
+            "FROM verbatim_embeddings ORDER BY dist, exchange_id",
+            [probe_vec],
+        ).fetchall()
+
+        assert second_bm25 == first_bm25
+        assert second_neighbors == first_neighbors
+
+    def test_rebuild_stats_fields(
+        self, tmp_path: Path, real_storage: UnifiedStorage
+    ) -> None:
+        """RebuildStats fields accurately reflect the force=False and force=True runs."""
+        self._seed_conversation(real_storage, "conv-a")
+
+        config = Config.load()
+        indexer = UnifiedIndexer(tmp_path, config, storage=real_storage)
+        embedder = self._make_deterministic_embedder()
+
+        with patch.object(indexer, "_get_embedder", return_value=embedder):
+            not_forced = indexer.rebuild_derived(force=False)
+
+        assert not_forced.conversations_processed == 1
+        assert not_forced.exchanges_rebuilt == 2
+        assert not_forced.embeddings_rebuilt == 2
+        assert not_forced.forced is False
+        assert not_forced.rebuild_time_seconds >= 0
+
+        with patch.object(indexer, "_get_embedder", return_value=embedder):
+            forced = indexer.rebuild_derived(force=True)
+
+        assert forced.conversations_processed == 1
+        assert forced.exchanges_rebuilt == 2
+        assert forced.embeddings_rebuilt == 2
+        assert forced.forced is True
+        assert forced.rebuild_time_seconds >= 0


### PR DESCRIPTION
## Stack

Position: 1/3 (M2 — Split rebuild-derived from reingest-sources)

1. `feat/rebuild-derived-engine` -> this PR
2. `feat/rebuild-derived-cli` (CLI wiring) -> follow-up, based on this branch
3. `docs/reconcile-reindex-safety-guards` (doc reconciliation) -> follow-up, based on PR 2

## Summary

Adds `UnifiedIndexer.rebuild_derived(force: bool = False)`: deterministically rebuilds exchanges, embeddings, FTS, and HNSW indexes from conversations/messages **already persisted in UnifiedStorage**. It never calls a connector and never discovers or opens a source JSONL/session file.

`index_all()` is **untouched** — still raises `RuntimeError" unconditionally regardless of `force`, exactly as before. `rebuild_derived` is a wholly separate code path; it does not call `index_all` and does not change its guard.

- `force=False` (default): rebuilds only conversations that currently have zero exchange rows — cheap, idempotent completion pass.
- `force=True`: wipes and regenerates exchanges/embeddings for every conversation from their persisted messages (deterministic — same messages always segment into the same exchanges/embeddings), then drops and recreates the FTS and HNSW indexes from scratch.

New `UnifiedStorage` methods backing this: `list_conversation_ids`, `list_conversation_ids_without_exchanges`, `clear_exchanges`, `clear_embeddings`, `drop_hnsw_index`. New `RebuildStats` result dataclass.

## Why not touch `index_all`

M2's acceptance requires reingest-sources to stay guarded exactly as today. The existing test `test_index_all_raises_even_with_force` (unmodified) proves the guard is byte-for-byte the same before and after this PR.

## Tests

`TestRebuildDerived` (tests/unit/core/test_unified_indexer.py): both `force` modes proven to never touch a source file (`detect_connector`/`discover_all_files` patched to raise `AssertionError` if called); `force=False` leaves already-populated conversations untouched; `force=True` reproduces bit-identical `match_bm25` ordering and `array_cosine_distance` neighbor ordering versus a from-scratch `index_append_only` ingestion of the same messages (the acceptance-critical determinism test); `RebuildStats` fields verified.

## Verification

```
uv run pytest tests/unit/core/test_unified_indexer.py -v --tb=short --no-cov
# 25 passed

uv run pytest -v --tb=short
# 2090 passed, 1 skipped, 81.60% coverage (>= 80% gate)
```