### PR TITLE
feat(cli): add rebuild-derived CLI, clarify reingest-sources

### DIFF
--- a/src/searchat/cli/main.py
+++ b/src/searchat/cli/main.py
@@ -445,6 +445,16 @@ def main():
 
             raise SystemExit(run_doctor(argv[1:]))
 
+        if argv and argv[0] == "rebuild-derived":
+            from searchat.cli.rebuild_cmd import run_rebuild_derived
+
+            raise SystemExit(run_rebuild_derived(argv[1:]))
+
+        if argv and argv[0] == "reingest-sources":
+            from searchat.cli.rebuild_cmd import run_reingest_sources
+
+            raise SystemExit(run_reingest_sources(argv[1:]))
+
         if argv and argv[0] == "ci-check":
             from searchat.cli.ci_check_cmd import run_ci_check
 
@@ -481,6 +491,8 @@ def main():
             print("  searchat migrate-storage [--dry-run] [--verify] [--rollback]")
             print("  searchat health [--url URL] [--json]")
             print("  searchat doctor [--json]")
+            print("  searchat rebuild-derived [--force] [--json]")
+            print("  searchat reingest-sources [--force]")
             print("  searchat ci-check [--fail-on-contradictions] [--fail-on-staleness-threshold FLOAT]")
             print()
             return

--- a/src/searchat/cli/rebuild_cmd.py
+++ b/src/searchat/cli/rebuild_cmd.py
@@ -1,0 +1,123 @@
+"""CLI commands: searchat rebuild-derived / searchat reingest-sources.
+
+rebuild-derived rebuilds exchange/FTS/HNSW indexes from already-indexed
+conversation data. It never opens a source connector file and is always
+safe to run — including with zero source files present.
+
+reingest-sources re-ingests from source JSONL/session files, replacing the
+existing legacy Parquet+FAISS index. It stays guarded exactly as before:
+refuses with RuntimeError unless an existing index is absent or --force is
+passed. For safe maintenance (restoring indexes after a compaction, backup
+restore, or corruption), use rebuild-derived instead.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def run_rebuild_derived(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="searchat rebuild-derived",
+        description=(
+            "Rebuild exchange, FTS keyword, and HNSW vector indexes from "
+            "already-indexed conversations. Reads only from the local "
+            "database — never opens a source conversation file. Always "
+            "safe to run, including with no source files present."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Wipe and regenerate exchanges/embeddings for every conversation "
+            "and rebuild the FTS/HNSW indexes from scratch, instead of only "
+            "completing conversations that are missing exchanges. Still "
+            "never touches source files — always safe."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Output raw JSON instead of a summary.")
+    args = parser.parse_args(argv)
+
+    from searchat.config import Config, PathResolver
+    from searchat.core.unified_indexer import UnifiedIndexer
+    from searchat.services.storage_service import build_storage_service
+
+    config = Config.load()
+    search_dir = PathResolver.get_shared_search_dir(config)
+
+    try:
+        storage = build_storage_service(search_dir, config=config, read_only=False)
+        indexer = UnifiedIndexer(search_dir, config, storage=storage)
+        stats = indexer.rebuild_derived(force=args.force)
+    except Exception as exc:
+        print(f"Error: failed to rebuild derived data: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        import json as json_module
+
+        print(json_module.dumps(
+            {
+                "conversations_processed": stats.conversations_processed,
+                "exchanges_rebuilt": stats.exchanges_rebuilt,
+                "embeddings_rebuilt": stats.embeddings_rebuilt,
+                "rebuild_time_seconds": stats.rebuild_time_seconds,
+                "forced": stats.forced,
+            },
+            indent=2,
+        ))
+        return 0
+
+    from rich.console import Console
+
+    console = Console()
+    console.print("[bold green]Rebuild complete[/bold green]")
+    console.print(f"  Conversations processed: {stats.conversations_processed}")
+    console.print(f"  Exchanges rebuilt:        {stats.exchanges_rebuilt}")
+    console.print(f"  Embeddings rebuilt:       {stats.embeddings_rebuilt}")
+    console.print(f"  Forced full rebuild:      {stats.forced}")
+    console.print(f"  Time:                     {stats.rebuild_time_seconds:.2f}s")
+    return 0
+
+
+def run_reingest_sources(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="searchat reingest-sources",
+        description=(
+            "Re-ingest conversations from source JSONL/session files, "
+            "replacing the existing index. DANGEROUS: if source files are "
+            "missing or incomplete, indexed conversations absent from "
+            "current source files are lost. Guarded — refuses with a "
+            "RuntimeError unless --force is passed and you have verified "
+            "complete source files. For safe maintenance (restoring "
+            "indexes after a compaction or backup restore), use "
+            "`searchat rebuild-derived` instead — it never touches source "
+            "files."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Required to proceed when an existing index is detected.",
+    )
+    args = parser.parse_args(argv)
+
+    from searchat.config import Config, PathResolver
+    from searchat.core.indexer import ConversationIndexer
+
+    config = Config.load()
+    search_dir = PathResolver.get_shared_search_dir(config)
+    indexer = ConversationIndexer(search_dir, config)
+
+    try:
+        stats = indexer.index_all(force=args.force)
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print("Reingest complete.")
+    print(f"  Conversations: {stats.total_conversations}")
+    print(f"  Messages:      {stats.total_messages}")
+    print(f"  Time:          {stats.index_time_seconds:.2f}s")
+    return 0

--- a/tests/unit/test_cli_rebuild.py
+++ b/tests/unit/test_cli_rebuild.py
@@ -1,0 +1,282 @@
+"""Unit tests for `searchat rebuild-derived` / `searchat reingest-sources` CLI commands."""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from searchat.config import Config
+from searchat.core.unified_indexer import UnifiedIndexer
+from searchat.models import IndexStats
+from searchat.storage.unified_storage import UnifiedStorage
+
+
+def _db_path(search_dir: Path) -> Path:
+    return search_dir / "data" / "searchat.duckdb"
+
+
+def _seed_conversation(storage: UnifiedStorage, conversation_id: str, *, n_messages: int = 4) -> None:
+    """Populate conversations/messages directly — never via a connector/file."""
+    now = datetime(2026, 1, 1, 12, 0, 0)
+    storage.upsert_conversation(
+        conversation_id=conversation_id,
+        project_id="proj1",
+        file_path=f"/fake/does/not/exist/{conversation_id}.jsonl",
+        title=f"Conversation {conversation_id}",
+        created_at=now,
+        updated_at=now,
+        message_count=n_messages,
+        full_text="hello world",
+        file_hash=f"hash-{conversation_id}",
+        indexed_at=now,
+    )
+    messages = [
+        {
+            "sequence": i,
+            "role": "user" if i % 2 == 0 else "assistant",
+            "content": f"{conversation_id} message {i} about sorting a python list",
+            "timestamp": now,
+            "has_code": False,
+            "code_blocks": None,
+        }
+        for i in range(n_messages)
+    ]
+    storage.insert_messages(conversation_id, messages)
+
+
+def _deterministic_vector(text: str) -> list[float]:
+    """Same text -> same 384-dim vector, every time."""
+    seed = int(hashlib.sha256(text.encode()).hexdigest()[:8], 16)
+    rng = np.random.default_rng(seed)
+    return rng.random(384).tolist()
+
+
+def _fake_embedder() -> MagicMock:
+    """Deterministic stand-in for SentenceTransformer — avoids loading a real model."""
+    embedder = MagicMock()
+    embedder.encode.side_effect = lambda batch, **kwargs: np.array(
+        [_deterministic_vector(text) for text in batch]
+    )
+    return embedder
+
+
+def _seed_two_conversations(temp_search_dir: Path) -> None:
+    storage = UnifiedStorage(_db_path(temp_search_dir))
+    _seed_conversation(storage, "conv-a")
+    _seed_conversation(storage, "conv-b")
+    storage.close()
+
+
+# ---------------------------------------------------------------------------
+# --help
+# ---------------------------------------------------------------------------
+
+def test_rebuild_derived_help_text(capsys) -> None:
+    from searchat.cli.rebuild_cmd import run_rebuild_derived
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_rebuild_derived(["--help"])
+    assert exc_info.value.code == 0
+
+    captured = capsys.readouterr()
+    assert "rebuild-derived" in captured.out
+    assert "--force" in captured.out
+    assert "--json" in captured.out
+
+
+def test_reingest_sources_help_text(capsys) -> None:
+    from searchat.cli.rebuild_cmd import run_reingest_sources
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_reingest_sources(["--help"])
+    assert exc_info.value.code == 0
+
+    captured = capsys.readouterr()
+    assert "reingest-sources" in captured.out
+    assert "--force" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# rebuild-derived: success paths
+# ---------------------------------------------------------------------------
+
+def test_rebuild_derived_summary_output(temp_search_dir: Path, capsys) -> None:
+    from searchat.cli.rebuild_cmd import run_rebuild_derived
+
+    _seed_two_conversations(temp_search_dir)
+    config = Config.load()
+
+    with (
+        patch("searchat.config.Config.load", return_value=config),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch.object(UnifiedIndexer, "_get_embedder", return_value=_fake_embedder()),
+    ):
+        result = run_rebuild_derived([])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Rebuild complete" in captured.out
+    assert "Conversations processed:" in captured.out
+    assert "Exchanges rebuilt:" in captured.out
+    assert "Embeddings rebuilt:" in captured.out
+    assert "Forced full rebuild:" in captured.out
+    assert "Time:" in captured.out
+
+
+def test_rebuild_derived_json_output(temp_search_dir: Path, capsys) -> None:
+    from searchat.cli.rebuild_cmd import run_rebuild_derived
+
+    _seed_two_conversations(temp_search_dir)
+    config = Config.load()
+
+    with (
+        patch("searchat.config.Config.load", return_value=config),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch.object(UnifiedIndexer, "_get_embedder", return_value=_fake_embedder()),
+    ):
+        result = run_rebuild_derived(["--json"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    payload = json.loads(captured.out)
+
+    assert set(payload.keys()) == {
+        "conversations_processed",
+        "exchanges_rebuilt",
+        "embeddings_rebuilt",
+        "rebuild_time_seconds",
+        "forced",
+    }
+    assert payload["conversations_processed"] == 2
+    assert payload["exchanges_rebuilt"] == 4
+    assert payload["embeddings_rebuilt"] == 4
+    assert payload["forced"] is False
+
+
+def test_rebuild_derived_succeeds_on_empty_search_dir(temp_search_dir: Path, capsys) -> None:
+    """No DB exists yet — must still succeed (explicit read_only=False creates it)."""
+    from searchat.cli.rebuild_cmd import run_rebuild_derived
+
+    assert not _db_path(temp_search_dir).exists()
+    config = Config.load()
+
+    with (
+        patch("searchat.config.Config.load", return_value=config),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch.object(UnifiedIndexer, "_get_embedder", return_value=_fake_embedder()),
+    ):
+        result = run_rebuild_derived(["--json"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    payload = json.loads(captured.out)
+    assert payload["conversations_processed"] == 0
+    assert _db_path(temp_search_dir).exists()
+
+
+def test_rebuild_derived_returns_one_and_prints_error_on_failure(
+    temp_search_dir: Path, capsys
+) -> None:
+    from searchat.cli.rebuild_cmd import run_rebuild_derived
+
+    config = Config.load()
+
+    with (
+        patch("searchat.config.Config.load", return_value=config),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch.object(UnifiedIndexer, "rebuild_derived", side_effect=RuntimeError("boom")),
+    ):
+        result = run_rebuild_derived([])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "Error: failed to rebuild derived data" in captured.err
+    assert "boom" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# reingest-sources: guard stays intact through the new CLI surface
+# ---------------------------------------------------------------------------
+
+def test_reingest_sources_guard_blocks_without_force(temp_search_dir: Path, capsys) -> None:
+    """Existing-index guard fires for real — no source scan ever starts."""
+    from searchat.cli.rebuild_cmd import run_reingest_sources
+
+    indices_dir = temp_search_dir / "data" / "indices"
+    indices_dir.mkdir(parents=True, exist_ok=True)
+    (indices_dir / "embeddings.faiss").write_bytes(b"FAISSSTUB")
+
+    config = Config.load()
+
+    with (
+        patch("searchat.config.Config.load", return_value=config),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+    ):
+        result = run_reingest_sources([])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "Existing index detected" in captured.err
+
+
+def test_reingest_sources_force_success(temp_search_dir: Path, capsys) -> None:
+    from searchat.cli.rebuild_cmd import run_reingest_sources
+
+    indices_dir = temp_search_dir / "data" / "indices"
+    indices_dir.mkdir(parents=True, exist_ok=True)
+    (indices_dir / "embeddings.faiss").write_bytes(b"FAISSSTUB")
+
+    config = Config.load()
+    fake_stats = IndexStats(
+        total_conversations=3,
+        total_messages=10,
+        index_time_seconds=1.5,
+        parquet_size_mb=0.0,
+        faiss_size_mb=0.0,
+    )
+    fake_indexer = MagicMock()
+    fake_indexer.index_all.return_value = fake_stats
+
+    with (
+        patch("searchat.config.Config.load", return_value=config),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch("searchat.core.indexer.ConversationIndexer", return_value=fake_indexer),
+    ):
+        result = run_reingest_sources(["--force"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Reingest complete." in captured.out
+    assert "3" in captured.out
+    assert "10" in captured.out
+    fake_indexer.index_all.assert_called_once_with(force=True)
+
+
+def test_reingest_sources_never_bypasses_guard_without_explicit_force(
+    temp_search_dir: Path, capsys
+) -> None:
+    """CLI must pass through args.force as-is — never silently force=True."""
+    from searchat.cli.rebuild_cmd import run_reingest_sources
+
+    config = Config.load()
+    fake_indexer = MagicMock()
+    fake_indexer.index_all.side_effect = RuntimeError(
+        "Existing index detected. Full rebuild will REPLACE all indexed data."
+    )
+
+    with (
+        patch("searchat.config.Config.load", return_value=config),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch("searchat.core.indexer.ConversationIndexer", return_value=fake_indexer),
+    ):
+        result = run_reingest_sources([])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "Existing index detected" in captured.err
+    fake_indexer.index_all.assert_called_once_with(force=False)


### PR DESCRIPTION
## Stack

Position: 2/3 (M2 — Split rebuild-derived from reingest-sources)

1. `feat/rebuild-derived-engine` -> #90
2. `feat/rebuild-derived-cli` -> this PR (based on #90)
3. `docs/reconcile-reindex-safety-guards` -> follow-up, based on this branch

## Summary

New `src/searchat/cli/rebuild_cmd.py`:

- **`searchat rebuild-derived [--force] [--json]`** — wires to `UnifiedIndexer.rebuild_derived`. Always safe. `--force` picks full rebuild vs. incremental completion; neither touches a source file.
- **`searchat reingest-sources [--force]`** — wires to the legacy `ConversationIndexer.index_all(force=...)`, byte-for-byte unchanged behavior. Still refuses with `RuntimeError` unless an existing index is absent or `--force` is passed. Gives the guarded operation a clear name distinct from `setup-index`, with help text pointing at `rebuild-derived` as the safe alternative.

Both dispatched from `cli/main.py` following the existing flat if/elif pattern, and listed in `--help`.

## Why reingest-sources wires to the legacy indexer

`core/indexer.py::ConversationIndexer.index_all` is the only `index_all` in the codebase that actually respects `force=True` (per M2's constraints, `core/unified_indexer.py::UnifiedIndexer.index_all` stays untouched and always raises regardless of force — see #90). Wiring `reingest-sources` to it reuses the existing, unmodified guard rather than inventing new guard logic.

## Tests

`tests/unit/test_cli_rebuild.py`: both `--help` texts; `rebuild-derived` summary/JSON output against a populated fixture store, empty-store success (creates the DB), and error propagation; `reingest-sources` existing-index guard fires for real through the CLI (zero source-file scanning risked — proven via a fixture `embeddings.faiss` stub, never a live scan), `--force` success path, and a check that the CLI passes `args.force` through unmodified rather than silently bypassing the guard.

Also manually smoke-tested both commands end-to-end (`--help`, functional success, and the guard/raise path) against isolated fixture directories.

## Verification

```
uv run pytest tests/unit/core/test_unified_indexer.py tests/unit/test_cli_rebuild.py -v --tb=short --no-cov
# 34 passed

uv run pytest -v --tb=short
# 2099 passed, 1 skipped, 81.60% coverage (>= 80% gate)
```