### PR TITLE
docs: reconcile rebuild-derived vs reingest-sources safety guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ searchat setup-index
 searchat web
 ```
 
-Open http://localhost:8000
+Open http://localhost:8000 (searches ports up to 8010 if 8000 is busy; override with `SEARCHAT_PORT`).
 
 ### Install From Source
 
@@ -137,9 +137,30 @@ python scripts/setup-index
 searchat web
 ```
 
-Open http://localhost:8000
+Open http://localhost:8000 (searches ports up to 8010 if 8000 is busy; override with `SEARCHAT_PORT`).
 
 The setup script indexes all conversations from supported agents. On subsequent runs, the web server automatically indexes new conversations via live file watching.
+
+### Rebuilding The Index
+
+Two different operations can be confused — know which one you need:
+
+- **`searchat rebuild-derived [--force]`** — always safe. Rebuilds the
+  keyword and vector search indexes from conversations already stored in
+  the local database. Never opens a source conversation file, so it's safe
+  to run at any time, including after a compaction or backup restore, or
+  with no source files present at all.
+- **`searchat reingest-sources [--force]`** — guarded and dangerous if
+  source files are incomplete. Re-scans source JSONL/session files and
+  replaces the existing index with what it finds there. If source files are
+  missing or incomplete, indexed conversations absent from those files are
+  permanently lost. Refuses with an error unless an existing index is
+  absent or `--force` is explicitly passed.
+
+For routine maintenance (fixing a corrupted index, restoring after backup,
+recovering from disk compaction) use `rebuild-derived`. Only use
+`reingest-sources --force` if you have personally verified every source
+file is present and complete.
 
 ## MCP Server (Claude Desktop, Cursor, ...)
 
@@ -255,6 +276,8 @@ searchat  # interactive mode
 searchat web
 searchat mcp
 searchat setup-index [--force]
+searchat rebuild-derived [--force]   # rebuild search indexes from already-indexed data — always safe
+searchat reingest-sources [--force]  # re-scan source files and replace the index — guarded, see above
 
 # Download a default embedded GGUF model and update ~/.searchat/config/settings.toml
 searchat download-model --activate


### PR DESCRIPTION
## Stack

Position: 3/3 (M2 — Split rebuild-derived from reingest-sources)

1. `feat/rebuild-derived-engine` -> #90
2. `feat/rebuild-derived-cli` -> #91
3. `docs/reconcile-reindex-safety-guards` -> this PR (based on #91)

## Summary

`README.md` Quick Start gains a **Rebuilding The Index** section distinguishing `rebuild-derived` (always safe) from `reingest-sources` (guarded, dangerous with incomplete source files) and lists both in the CLI usage block. Also fixes the port note: the shipped default is genuinely **8000** (`DEFAULT_PORT = 8000`, `PORT_SCAN_RANGE = (8000, 8010)` in `config/constants.py`) — README wasn't wrong about the number, it just didn't document the auto-scan-on-busy behavior or the `SEARCHAT_PORT` override, which is what actually caused the 8000-vs-8001 confusion on a machine where port 8000 was already occupied. I verified this against the code rather than blindly changing 8000 to 8001, which would have been incorrect.

## `.claude/CLAUDE.md` — important note

`.claude/CLAUDE.md` is **not tracked by git** in this repository (`.claude/` is in `.gitignore`; `git log -- .claude/CLAUDE.md` has zero history). It cannot be part of any PR diff. I updated it locally on disk — same reconciliation as this PR's README changes, rewriting both its `CRITICAL: DATA SAFETY` and `Safety Guards` sections to distinguish `rebuild-derived` from `reingest-sources` — so it's consistent for this and future agent sessions using this checkout, but that change has no commit and won't appear in this PR or any diff. I did not force-add a previously-gitignored file into version control without being asked; flagging this so the milestone's "no remaining doc contradiction" claim is understood correctly: README (tracked, in this PR) is reconciled; the local `.claude/CLAUDE.md` is also reconciled but out-of-band from git.

## Verification

`grep`-verified: no remaining bare "never run index_all()"/"never reindex" language without the rebuild-derived/reingest-sources distinction in either file.

```
uv run pytest -v --tb=short
# 2099 passed, 1 skipped, 81.60% coverage (>= 80% gate)
```