### PR TITLE
feat(services): add verified copy-compaction engine

### DIFF
--- a/src/searchat/services/compaction.py
+++ b/src/searchat/services/compaction.py
@@ -1,0 +1,474 @@
+"""Safe copy-compaction for the DuckDB store.
+
+DuckDB files never shrink in place: long-running append/checkpoint
+workloads leave dead blocks behind that only a copy-compaction reclaims.
+This module implements the checkpoint -> attach -> COPY FROM DATABASE ->
+verify -> atomic-rename sequence documented as the Tier 0 manual recovery
+procedure in `.docs/searchat-memory-management-enhancement-analysis.md`
+Appendix A, and as the managed `duckdb-copy-compact` skill, so it can run
+unattended via `searchat compact` (M3).
+
+Every extension backing an index (vss, fts) is loaded, and HNSW
+persistence enabled, on every connection BEFORE any write op. Skipping
+this can make CHECKPOINT / COPY FROM DATABASE fail with FATAL "unknown
+index type 'HNSW'" when the on-disk catalog references an index whose
+extension has not been loaded in this connection yet -- the failure
+observed during the Tier 0 recovery. A FATAL error aborts the DuckDB
+process outright and no Python `except` clause can catch it -- callers
+that must survive that failure mode isolate `compact_database` in a
+subprocess so a FATAL there can never take down the parent process or
+leave the original file half-written.
+
+`compact_database` never mutates `db_path` until `verify_compaction` has
+proven the compacted copy is query-identical: same row counts across
+every schema (main + fts_main_*), the same index set, matching
+`match_bm25` and `array_cosine_distance` functional probes, and a
+zero-row symmetric diff on `conversations`.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+from searchat.storage.schema import install_fts, install_vss
+
+log = logging.getLogger(__name__)
+
+_PROBE_WORD_RE = re.compile(r"[A-Za-z]{4,}")
+
+# Restricted to `main` + `fts_main_*`, matching the scope
+# `services/storage_health.py::estimate_live_data_size` already verifies.
+_BASE_TABLES_SQL = (
+    "SELECT table_schema, table_name FROM information_schema.tables "
+    "WHERE table_catalog = ? AND table_type = 'BASE TABLE' "
+    "AND (table_schema = 'main' OR table_schema LIKE 'fts_main_%') "
+    "ORDER BY 1, 2"
+)
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Verdict from comparing a compacted copy against its source.
+
+    Mirrors Appendix A's manual verification: row counts, index set,
+    functional FTS + vector probes, and a symmetric-diff spot-check.
+    `fts_probe_match`/`vector_probe_match` are `None` when there was
+    nothing to probe (empty exchanges/embeddings) rather than `False`.
+    """
+
+    passed: bool
+    row_counts_match: bool
+    index_names_match: bool
+    fts_probe_match: bool | None
+    vector_probe_match: bool | None
+    symmetric_diff_match: bool
+    mismatches: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CompactionResult:
+    """Outcome of a `compact_database` run.
+
+    `success=False` always means `original_path` was never modified --
+    the compacted copy (and any quarantined leftovers) live at other
+    paths, never in place of the original, until every check passes.
+    """
+
+    success: bool
+    original_path: Path
+    original_size_bytes: int
+    compacted_size_bytes: int
+    bytes_reclaimed: int
+    preserved_original_path: Path | None
+    verification: VerificationResult | None
+    error: str | None
+    duration_seconds: float
+
+
+def _sql_literal(path: Path) -> str:
+    """Quote a filesystem path as a DuckDB SQL string literal.
+
+    ATTACH does not support bound parameters for its path argument, so the
+    path is escaped by doubling embedded single quotes (standard SQL
+    literal escaping) instead.
+    """
+    return "'" + str(path).replace("'", "''") + "'"
+
+
+def _quote_ident(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _prepare_connection(conn: duckdb.DuckDBPyConnection) -> None:
+    """Load every extension backing an index before any write op.
+
+    Mirrors `UnifiedStorage.__init__` (storage/unified_storage.py) so a
+    compaction connection sees the catalog exactly as the live app does.
+    """
+    install_vss(conn)
+    install_fts(conn)
+    try:
+        conn.execute("SET hnsw_enable_experimental_persistence = true")
+    except duckdb.Error:
+        pass
+
+
+def _table_row_counts(con: duckdb.DuckDBPyConnection, catalog: str) -> dict[tuple[str, str], int]:
+    tables = con.execute(_BASE_TABLES_SQL, [catalog]).fetchall()
+    counts: dict[tuple[str, str], int] = {}
+    for schema, table in tables:
+        qualified = f"{_quote_ident(catalog)}.{_quote_ident(schema)}.{_quote_ident(table)}"
+        counts[(schema, table)] = con.execute(f"SELECT COUNT(*) FROM {qualified}").fetchone()[0]
+    return counts
+
+
+def _index_names(con: duckdb.DuckDBPyConnection, catalog: str) -> set[tuple[str, str, str]]:
+    rows = con.execute(
+        "SELECT schema_name, index_name, table_name FROM duckdb_indexes() WHERE database_name = ?",
+        [catalog],
+    ).fetchall()
+    return {(schema, name, table) for schema, name, table in rows}
+
+
+def _fts_probe(src_path: Path, dst_path: Path, mismatches: list[str]) -> bool | None:
+    """Functional BM25 probe: pick a real exchange from `src`, search both
+    sides for a word drawn from its own text, and require identical hits.
+
+    Each side is queried on its OWN direct connection rather than through a
+    shared ATTACH: `match_bm25`'s generated macro resolves its internal
+    helper tables (`stats`, `dict`, ...) against the connection's *current*
+    catalog, not the catalog its call was schema-qualified from -- querying
+    `dst.fts_main_exchanges.match_bm25(...)` while `src` is the current
+    catalog silently scores against `src`'s own FTS state, which would
+    mask a real difference in `dst`.
+
+    Returns `None` (not applicable) when there is no FTS index to probe.
+    """
+    src_con = duckdb.connect(str(src_path), read_only=True)
+    try:
+        _prepare_connection(src_con)
+        has_fts = src_con.execute(
+            "SELECT COUNT(*) FROM information_schema.tables "
+            "WHERE table_schema = 'fts_main_exchanges' AND table_name = 'terms'"
+        ).fetchone()[0]
+        if not has_fts:
+            return None
+        row = src_con.execute(
+            "SELECT exchange_text FROM exchanges WHERE exchange_text IS NOT NULL "
+            "ORDER BY exchange_id LIMIT 1"
+        ).fetchone()
+        if row is None:
+            return None
+        term: str | None = None
+        src_hits: list[tuple] = []
+        for candidate in _PROBE_WORD_RE.findall(row[0] or ""):
+            hits = src_con.execute(
+                "SELECT exchange_id, fts_main_exchanges.match_bm25(exchange_id, ?) AS score "
+                "FROM exchanges WHERE score IS NOT NULL ORDER BY score DESC, exchange_id",
+                [candidate],
+            ).fetchall()
+            if hits:
+                term = candidate
+                src_hits = hits
+                break
+    finally:
+        src_con.close()
+
+    if term is None:
+        # Every candidate word in the sample text was filtered (stopword,
+        # below the FTS minimum length, etc.) -- nothing usable to probe.
+        return None
+
+    dst_con = duckdb.connect(str(dst_path), read_only=True)
+    try:
+        _prepare_connection(dst_con)
+        dst_hits = dst_con.execute(
+            "SELECT exchange_id, fts_main_exchanges.match_bm25(exchange_id, ?) AS score "
+            "FROM exchanges WHERE score IS NOT NULL ORDER BY score DESC, exchange_id",
+            [term],
+        ).fetchall()
+    finally:
+        dst_con.close()
+
+    ok = src_hits == dst_hits
+    if not ok:
+        mismatches.append(f"FTS probe mismatch for term {term!r}: src={src_hits} dst={dst_hits}")
+    return ok
+
+
+def _vector_probe(con: duckdb.DuckDBPyConnection, mismatches: list[str]) -> bool | None:
+    """Functional HNSW probe: fetch one real embedding from `src` and require
+    identical nearest-neighbor rankings on both sides.
+
+    Returns `None` (not applicable) when there are no embeddings to probe.
+    """
+    probe = con.execute(
+        "SELECT exchange_id, embedding FROM src.verbatim_embeddings ORDER BY exchange_id LIMIT 1"
+    ).fetchone()
+    if probe is None:
+        return None
+    dim = len(probe[1])
+    src_neighbors = con.execute(
+        f"SELECT exchange_id, round(array_cosine_distance(embedding, ?::FLOAT[{dim}]), 6) AS dist "
+        "FROM src.verbatim_embeddings ORDER BY dist, exchange_id LIMIT 10",
+        [probe[1]],
+    ).fetchall()
+    dst_neighbors = con.execute(
+        f"SELECT exchange_id, round(array_cosine_distance(embedding, ?::FLOAT[{dim}]), 6) AS dist "
+        "FROM dst.verbatim_embeddings ORDER BY dist, exchange_id LIMIT 10",
+        [probe[1]],
+    ).fetchall()
+    ok = bool(src_neighbors) and src_neighbors == dst_neighbors
+    if not ok:
+        mismatches.append(f"vector probe mismatch: src={src_neighbors} dst={dst_neighbors}")
+    return ok
+
+
+def _symmetric_diff(con: duckdb.DuckDBPyConnection, mismatches: list[str]) -> bool:
+    """Spot-check a zero-row symmetric diff on `conversations`, matching
+    Appendix A's final verification step."""
+    has_table = con.execute(
+        "SELECT COUNT(*) FROM information_schema.tables WHERE table_catalog IN ('src', 'dst') "
+        "AND table_schema = 'main' AND table_name = 'conversations'"
+    ).fetchone()[0]
+    if has_table < 2:
+        return True
+    forward = con.execute(
+        "SELECT COUNT(*) FROM (SELECT * FROM src.conversations EXCEPT SELECT * FROM dst.conversations)"
+    ).fetchone()[0]
+    backward = con.execute(
+        "SELECT COUNT(*) FROM (SELECT * FROM dst.conversations EXCEPT SELECT * FROM src.conversations)"
+    ).fetchone()[0]
+    ok = forward == 0 and backward == 0
+    if not ok:
+        mismatches.append(f"conversations symmetric diff nonzero: forward={forward} backward={backward}")
+    return ok
+
+
+def verify_compaction(src_path: Path, dst_path: Path) -> VerificationResult:
+    """Verify `dst_path` is query-identical to `src_path`.
+
+    Reuses M1's row-count/index verification pattern
+    (`services/storage_health.py`) and extends it with the functional FTS
+    + vector probes and symmetric-diff spot-check from Appendix A. Opens
+    both files read-only; never mutates either.
+    """
+    mismatches: list[str] = []
+    con = duckdb.connect()
+    try:
+        _prepare_connection(con)
+        con.execute(f"ATTACH {_sql_literal(src_path)} AS src (READ_ONLY)")
+        con.execute(f"ATTACH {_sql_literal(dst_path)} AS dst (READ_ONLY)")
+
+        src_counts = _table_row_counts(con, "src")
+        dst_counts = _table_row_counts(con, "dst")
+        row_counts_match = src_counts == dst_counts
+        if not row_counts_match:
+            mismatches.append(f"table row counts differ: src={src_counts} dst={dst_counts}")
+
+        src_indexes = _index_names(con, "src")
+        dst_indexes = _index_names(con, "dst")
+        index_names_match = src_indexes == dst_indexes
+        if not index_names_match:
+            mismatches.append(f"index set differs: src={src_indexes} dst={dst_indexes}")
+
+        fts_probe_match = _fts_probe(src_path, dst_path, mismatches)
+        vector_probe_match = _vector_probe(con, mismatches)
+        symmetric_diff_match = _symmetric_diff(con, mismatches)
+    finally:
+        con.close()
+
+    passed = (
+        row_counts_match
+        and index_names_match
+        and fts_probe_match is not False
+        and vector_probe_match is not False
+        and symmetric_diff_match
+    )
+    return VerificationResult(
+        passed=passed,
+        row_counts_match=row_counts_match,
+        index_names_match=index_names_match,
+        fts_probe_match=fts_probe_match,
+        vector_probe_match=vector_probe_match,
+        symmetric_diff_match=symmetric_diff_match,
+        mismatches=tuple(mismatches),
+    )
+
+
+def _copy_compact(src_path: Path, dst_path: Path) -> None:
+    """Checkpoint -> attach -> COPY FROM DATABASE -> checkpoint.
+
+    Only merges `src_path`'s own WAL into itself; never writes anything
+    else to it. `dst_path` is a fresh sibling file the caller cleans up on
+    failure.
+    """
+    checkpoint_con = duckdb.connect(str(src_path))
+    try:
+        _prepare_connection(checkpoint_con)
+        checkpoint_con.execute("CHECKPOINT")
+    finally:
+        checkpoint_con.close()
+
+    copy_con = duckdb.connect()
+    try:
+        _prepare_connection(copy_con)
+        copy_con.execute(f"ATTACH {_sql_literal(src_path)} AS s (READ_ONLY)")
+        copy_con.execute(f"ATTACH {_sql_literal(dst_path)} AS d")
+        copy_con.execute("COPY FROM DATABASE s TO d")
+        copy_con.execute("USE d")
+        copy_con.execute("CHECKPOINT")
+    finally:
+        copy_con.close()
+
+
+def _temp_dest_path(db_path: Path) -> Path:
+    return db_path.with_name(db_path.name + ".compact-tmp")
+
+
+def _stamped_sibling(db_path: Path, label: str, *, now: datetime | None = None) -> Path:
+    stamp = (now or datetime.now(timezone.utc)).strftime("%Y%m%dT%H%M%SZ")
+    return db_path.with_name(f"{db_path.name}.{label}-{stamp}")
+
+
+def _unlink_with_wal(path: Path) -> None:
+    path.unlink(missing_ok=True)
+    Path(str(path) + ".wal").unlink(missing_ok=True)
+
+
+def _post_swap_smoke_test(db_path: Path) -> bool:
+    """Confirm the newly swapped-in file actually opens and its catalog is
+    readable before deleting the preserved original."""
+    try:
+        con = duckdb.connect(str(db_path), read_only=True)
+        try:
+            _prepare_connection(con)
+            con.execute("SELECT COUNT(*) FROM information_schema.tables").fetchone()
+        finally:
+            con.close()
+        return True
+    except duckdb.Error as exc:
+        log.error("Post-swap smoke test failed for %s: %s", db_path, exc)
+        return False
+
+
+def compact_database(db_path: Path) -> CompactionResult:
+    """Reclaim dead blocks in `db_path` via verified copy-compaction.
+
+    `db_path` is never mutated until `verify_compaction` proves the
+    compacted copy is query-identical, and the pre-compaction original is
+    kept alongside as `<name>.pre-compact-<timestamp>` until a post-swap
+    smoke test on the new file also passes -- only then is it removed. Any
+    failure at any stage leaves `db_path` exactly as it was before the
+    call.
+    """
+    start = time.perf_counter()
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        return CompactionResult(
+            success=False,
+            original_path=db_path,
+            original_size_bytes=0,
+            compacted_size_bytes=0,
+            bytes_reclaimed=0,
+            preserved_original_path=None,
+            verification=None,
+            error=f"No database found at {db_path}",
+            duration_seconds=time.perf_counter() - start,
+        )
+
+    original_size = db_path.stat().st_size
+    dst_path = _temp_dest_path(db_path)
+    _unlink_with_wal(dst_path)
+
+    try:
+        _copy_compact(db_path, dst_path)
+    except duckdb.IOException as exc:
+        _unlink_with_wal(dst_path)
+        return CompactionResult(
+            success=False,
+            original_path=db_path,
+            original_size_bytes=original_size,
+            compacted_size_bytes=0,
+            bytes_reclaimed=0,
+            preserved_original_path=None,
+            verification=None,
+            error=f"Database is in use by another process; refusing to compact: {exc}",
+            duration_seconds=time.perf_counter() - start,
+        )
+    except Exception as exc:  # noqa: BLE001 - any failure here must leave db_path untouched
+        _unlink_with_wal(dst_path)
+        return CompactionResult(
+            success=False,
+            original_path=db_path,
+            original_size_bytes=original_size,
+            compacted_size_bytes=0,
+            bytes_reclaimed=0,
+            preserved_original_path=None,
+            verification=None,
+            error=f"Copy-compaction failed: {exc}",
+            duration_seconds=time.perf_counter() - start,
+        )
+
+    verification = verify_compaction(db_path, dst_path)
+    if not verification.passed:
+        dst_size = dst_path.stat().st_size if dst_path.exists() else 0
+        _unlink_with_wal(dst_path)
+        return CompactionResult(
+            success=False,
+            original_path=db_path,
+            original_size_bytes=original_size,
+            compacted_size_bytes=dst_size,
+            bytes_reclaimed=0,
+            preserved_original_path=None,
+            verification=verification,
+            error=f"Verification failed: {'; '.join(verification.mismatches)}",
+            duration_seconds=time.perf_counter() - start,
+        )
+
+    preserved_path = _stamped_sibling(db_path, "pre-compact")
+    db_path.rename(preserved_path)
+    dst_path.rename(db_path)
+
+    if not _post_swap_smoke_test(db_path):
+        # Roll back: quarantine the broken swap-in, restore the preserved original.
+        broken_path = _stamped_sibling(db_path, "post-swap-failed")
+        _unlink_with_wal(broken_path)
+        broken_size = db_path.stat().st_size
+        db_path.rename(broken_path)
+        preserved_path.rename(db_path)
+        return CompactionResult(
+            success=False,
+            original_path=db_path,
+            original_size_bytes=original_size,
+            compacted_size_bytes=broken_size,
+            bytes_reclaimed=0,
+            preserved_original_path=preserved_path,
+            verification=verification,
+            error=(
+                "Post-swap smoke test failed; original restored, broken copy "
+                f"quarantined at {broken_path}"
+            ),
+            duration_seconds=time.perf_counter() - start,
+        )
+
+    _unlink_with_wal(preserved_path)
+    compacted_size = db_path.stat().st_size
+    return CompactionResult(
+        success=True,
+        original_path=db_path,
+        original_size_bytes=original_size,
+        compacted_size_bytes=compacted_size,
+        bytes_reclaimed=max(original_size - compacted_size, 0),
+        preserved_original_path=None,
+        verification=verification,
+        error=None,
+        duration_seconds=time.perf_counter() - start,
+    )

--- a/src/searchat/services/compaction.py
+++ b/src/searchat/services/compaction.py
@@ -86,6 +86,7 @@ class CompactionResult:
     compacted_size_bytes: int
     bytes_reclaimed: int
     preserved_original_path: Path | None
+    quarantined_path: Path | None
     verification: VerificationResult | None
     error: str | None
     duration_seconds: float
@@ -119,12 +120,21 @@ def _prepare_connection(conn: duckdb.DuckDBPyConnection) -> None:
         pass
 
 
+def _scalar(con: duckdb.DuckDBPyConnection, sql: str, params: list | None = None) -> int:
+    """Run a query guaranteed to return exactly one row with one integer
+    column (e.g. `SELECT COUNT(*)`) and return that value.
+    """
+    row = con.execute(sql, params or []).fetchone()
+    assert row is not None, f"expected exactly one row from: {sql}"
+    return int(row[0])
+
+
 def _table_row_counts(con: duckdb.DuckDBPyConnection, catalog: str) -> dict[tuple[str, str], int]:
     tables = con.execute(_BASE_TABLES_SQL, [catalog]).fetchall()
     counts: dict[tuple[str, str], int] = {}
     for schema, table in tables:
         qualified = f"{_quote_ident(catalog)}.{_quote_ident(schema)}.{_quote_ident(table)}"
-        counts[(schema, table)] = con.execute(f"SELECT COUNT(*) FROM {qualified}").fetchone()[0]
+        counts[(schema, table)] = _scalar(con, f"SELECT COUNT(*) FROM {qualified}")
     return counts
 
 
@@ -153,10 +163,11 @@ def _fts_probe(src_path: Path, dst_path: Path, mismatches: list[str]) -> bool | 
     src_con = duckdb.connect(str(src_path), read_only=True)
     try:
         _prepare_connection(src_con)
-        has_fts = src_con.execute(
+        has_fts = _scalar(
+            src_con,
             "SELECT COUNT(*) FROM information_schema.tables "
-            "WHERE table_schema = 'fts_main_exchanges' AND table_name = 'terms'"
-        ).fetchone()[0]
+            "WHERE table_schema = 'fts_main_exchanges' AND table_name = 'terms'",
+        )
         if not has_fts:
             return None
         row = src_con.execute(
@@ -233,18 +244,19 @@ def _vector_probe(con: duckdb.DuckDBPyConnection, mismatches: list[str]) -> bool
 def _symmetric_diff(con: duckdb.DuckDBPyConnection, mismatches: list[str]) -> bool:
     """Spot-check a zero-row symmetric diff on `conversations`, matching
     Appendix A's final verification step."""
-    has_table = con.execute(
+    has_table = _scalar(
+        con,
         "SELECT COUNT(*) FROM information_schema.tables WHERE table_catalog IN ('src', 'dst') "
-        "AND table_schema = 'main' AND table_name = 'conversations'"
-    ).fetchone()[0]
+        "AND table_schema = 'main' AND table_name = 'conversations'",
+    )
     if has_table < 2:
         return True
-    forward = con.execute(
-        "SELECT COUNT(*) FROM (SELECT * FROM src.conversations EXCEPT SELECT * FROM dst.conversations)"
-    ).fetchone()[0]
-    backward = con.execute(
-        "SELECT COUNT(*) FROM (SELECT * FROM dst.conversations EXCEPT SELECT * FROM src.conversations)"
-    ).fetchone()[0]
+    forward = _scalar(
+        con, "SELECT COUNT(*) FROM (SELECT * FROM src.conversations EXCEPT SELECT * FROM dst.conversations)"
+    )
+    backward = _scalar(
+        con, "SELECT COUNT(*) FROM (SELECT * FROM dst.conversations EXCEPT SELECT * FROM src.conversations)"
+    )
     ok = forward == 0 and backward == 0
     if not ok:
         mismatches.append(f"conversations symmetric diff nonzero: forward={forward} backward={backward}")
@@ -379,6 +391,7 @@ def compact_database(db_path: Path) -> CompactionResult:
             compacted_size_bytes=0,
             bytes_reclaimed=0,
             preserved_original_path=None,
+            quarantined_path=None,
             verification=None,
             error=f"No database found at {db_path}",
             duration_seconds=time.perf_counter() - start,
@@ -399,6 +412,7 @@ def compact_database(db_path: Path) -> CompactionResult:
             compacted_size_bytes=0,
             bytes_reclaimed=0,
             preserved_original_path=None,
+            quarantined_path=None,
             verification=None,
             error=f"Database is in use by another process; refusing to compact: {exc}",
             duration_seconds=time.perf_counter() - start,
@@ -412,6 +426,7 @@ def compact_database(db_path: Path) -> CompactionResult:
             compacted_size_bytes=0,
             bytes_reclaimed=0,
             preserved_original_path=None,
+            quarantined_path=None,
             verification=None,
             error=f"Copy-compaction failed: {exc}",
             duration_seconds=time.perf_counter() - start,
@@ -428,6 +443,7 @@ def compact_database(db_path: Path) -> CompactionResult:
             compacted_size_bytes=dst_size,
             bytes_reclaimed=0,
             preserved_original_path=None,
+            quarantined_path=None,
             verification=verification,
             error=f"Verification failed: {'; '.join(verification.mismatches)}",
             duration_seconds=time.perf_counter() - start,
@@ -438,7 +454,11 @@ def compact_database(db_path: Path) -> CompactionResult:
     dst_path.rename(db_path)
 
     if not _post_swap_smoke_test(db_path):
-        # Roll back: quarantine the broken swap-in, restore the preserved original.
+        # Roll back: quarantine the broken swap-in, restore the preserved
+        # original. preserved_path no longer exists once this rename
+        # completes -- the original is back at db_path, not "preserved"
+        # separately -- so preserved_original_path is None here;
+        # quarantined_path points at the broken copy for forensics.
         broken_path = _stamped_sibling(db_path, "post-swap-failed")
         _unlink_with_wal(broken_path)
         broken_size = db_path.stat().st_size
@@ -450,7 +470,8 @@ def compact_database(db_path: Path) -> CompactionResult:
             original_size_bytes=original_size,
             compacted_size_bytes=broken_size,
             bytes_reclaimed=0,
-            preserved_original_path=preserved_path,
+            preserved_original_path=None,
+            quarantined_path=broken_path,
             verification=verification,
             error=(
                 "Post-swap smoke test failed; original restored, broken copy "
@@ -468,6 +489,7 @@ def compact_database(db_path: Path) -> CompactionResult:
         compacted_size_bytes=compacted_size,
         bytes_reclaimed=max(original_size - compacted_size, 0),
         preserved_original_path=None,
+        quarantined_path=None,
         verification=verification,
         error=None,
         duration_seconds=time.perf_counter() - start,

--- a/tests/unit/services/test_compaction.py
+++ b/tests/unit/services/test_compaction.py
@@ -1,0 +1,373 @@
+"""Unit tests for services/compaction.py -- verified copy-compaction engine."""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import duckdb
+import numpy as np
+
+from searchat.config import Config
+from searchat.core.unified_indexer import UnifiedIndexer
+from searchat.services.compaction import (
+    VerificationResult,
+    _prepare_connection,
+    compact_database,
+    verify_compaction,
+)
+from searchat.services.storage_health import compute_bloat_ratio, estimate_live_data_size, inspect_database_size
+from searchat.storage.unified_storage import UnifiedStorage
+
+
+# ---------------------------------------------------------------------------
+# Hand-built fixture DBs for verify_compaction unit tests
+# ---------------------------------------------------------------------------
+
+
+def _seed_minimal_db(db_path: Path, *, rows: tuple[tuple[str, str, list[float]], ...]) -> None:
+    con = duckdb.connect(str(db_path))
+    _prepare_connection(con)
+    con.execute("CREATE TABLE exchanges(exchange_id VARCHAR PRIMARY KEY, exchange_text VARCHAR)")
+    con.execute("CREATE TABLE verbatim_embeddings(exchange_id VARCHAR PRIMARY KEY, embedding FLOAT[4])")
+    for exchange_id, text, vector in rows:
+        con.execute("INSERT INTO exchanges VALUES (?, ?)", [exchange_id, text])
+        con.execute("INSERT INTO verbatim_embeddings VALUES (?, ?)", [exchange_id, vector])
+    con.execute(
+        "PRAGMA create_fts_index('exchanges', 'exchange_id', 'exchange_text', "
+        "stemmer = 'porter', stopwords = 'english', overwrite = 1)"
+    )
+    con.execute("CREATE INDEX verbatim_hnsw ON verbatim_embeddings USING HNSW (embedding) WITH (metric = 'cosine')")
+    con.execute("CHECKPOINT")
+    con.close()
+
+
+_FIXTURE_ROWS = (
+    ("e1", "hello world sorting lists", [1.0, 0.0, 0.0, 0.0]),
+    ("e2", "python reverse sorted arrays", [0.0, 1.0, 0.0, 0.0]),
+)
+
+
+class TestVerifyCompaction:
+    def test_identical_copy_passes_every_check(self, tmp_path: Path) -> None:
+        src = tmp_path / "src.duckdb"
+        dst = tmp_path / "dst.duckdb"
+        _seed_minimal_db(src, rows=_FIXTURE_ROWS)
+        _seed_minimal_db(dst, rows=_FIXTURE_ROWS)
+
+        result = verify_compaction(src, dst)
+
+        assert result.passed is True
+        assert result.row_counts_match is True
+        assert result.index_names_match is True
+        assert result.fts_probe_match is True
+        assert result.vector_probe_match is True
+        assert result.symmetric_diff_match is True
+        assert result.mismatches == ()
+
+    def test_row_count_mismatch_fails(self, tmp_path: Path) -> None:
+        src = tmp_path / "src.duckdb"
+        dst = tmp_path / "dst.duckdb"
+        _seed_minimal_db(src, rows=_FIXTURE_ROWS)
+        _seed_minimal_db(dst, rows=_FIXTURE_ROWS[:1])
+
+        result = verify_compaction(src, dst)
+
+        assert result.passed is False
+        assert result.row_counts_match is False
+        assert any("row counts differ" in m for m in result.mismatches)
+
+    def test_missing_index_fails(self, tmp_path: Path) -> None:
+        src = tmp_path / "src.duckdb"
+        dst = tmp_path / "dst.duckdb"
+        _seed_minimal_db(src, rows=_FIXTURE_ROWS)
+        _seed_minimal_db(dst, rows=_FIXTURE_ROWS)
+
+        con = duckdb.connect(str(dst))
+        _prepare_connection(con)
+        con.execute("DROP INDEX verbatim_hnsw")
+        con.execute("CHECKPOINT")
+        con.close()
+
+        result = verify_compaction(src, dst)
+
+        assert result.passed is False
+        assert result.index_names_match is False
+
+    def test_fts_probe_mismatch_fails(self, tmp_path: Path) -> None:
+        """Corrupt dst's FTS document length (affects BM25 scoring) without
+        touching any table's row count, so this is isolated to the FTS
+        probe rather than also tripping the row-count check."""
+        src = tmp_path / "src.duckdb"
+        dst = tmp_path / "dst.duckdb"
+        _seed_minimal_db(src, rows=_FIXTURE_ROWS)
+        _seed_minimal_db(dst, rows=_FIXTURE_ROWS)
+
+        con = duckdb.connect(str(dst))
+        _prepare_connection(con)
+        con.execute("UPDATE fts_main_exchanges.docs SET len = len * 100 WHERE name = 'e1'")
+        con.execute("CHECKPOINT")
+        con.close()
+
+        result = verify_compaction(src, dst)
+
+        assert result.row_counts_match is True
+        assert result.passed is False
+        assert result.fts_probe_match is False
+
+    def test_vector_probe_mismatch_fails(self, tmp_path: Path) -> None:
+        src = tmp_path / "src.duckdb"
+        dst = tmp_path / "dst.duckdb"
+        _seed_minimal_db(src, rows=_FIXTURE_ROWS)
+        _seed_minimal_db(
+            dst,
+            rows=(
+                ("e1", "hello world sorting lists", [0.0, 0.0, 1.0, 0.0]),
+                ("e2", "python reverse sorted arrays", [0.0, 1.0, 0.0, 0.0]),
+            ),
+        )
+
+        result = verify_compaction(src, dst)
+
+        assert result.passed is False
+        assert result.vector_probe_match is False
+
+    def test_empty_tables_probes_are_not_applicable(self, tmp_path: Path) -> None:
+        src = tmp_path / "src.duckdb"
+        dst = tmp_path / "dst.duckdb"
+        _seed_minimal_db(src, rows=())
+        _seed_minimal_db(dst, rows=())
+
+        result = verify_compaction(src, dst)
+
+        assert result.passed is True
+        assert result.fts_probe_match is None
+        assert result.vector_probe_match is None
+
+
+# ---------------------------------------------------------------------------
+# Real, indexed conversation DB with synthetic bloat -- end-to-end engine tests
+# ---------------------------------------------------------------------------
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _deterministic_vector(text: str) -> list[float]:
+    seed = int(hashlib.sha256(text.encode()).hexdigest()[:8], 16)
+    rng = np.random.default_rng(seed)
+    return rng.random(384).tolist()
+
+
+def _fake_embedder() -> MagicMock:
+    embedder = MagicMock()
+    embedder.encode.side_effect = lambda batch, **kwargs: np.array(
+        [_deterministic_vector(text) for text in batch]
+    )
+    return embedder
+
+
+def _seed_conversation(storage: UnifiedStorage, conversation_id: str, *, n_messages: int = 4) -> None:
+    now = datetime(2026, 1, 1, 12, 0, 0)
+    storage.upsert_conversation(
+        conversation_id=conversation_id,
+        project_id="proj1",
+        file_path=f"/fake/does/not/exist/{conversation_id}.jsonl",
+        title=f"Conversation {conversation_id}",
+        created_at=now,
+        updated_at=now,
+        message_count=n_messages,
+        full_text="hello world",
+        file_hash=f"hash-{conversation_id}",
+        indexed_at=now,
+    )
+    messages = [
+        {
+            "sequence": i,
+            "role": "user" if i % 2 == 0 else "assistant",
+            "content": f"{conversation_id} message {i} about sorting a python list",
+            "timestamp": now,
+            "has_code": False,
+            "code_blocks": None,
+        }
+        for i in range(n_messages)
+    ]
+    storage.insert_messages(conversation_id, messages)
+
+
+def _build_indexed_bloated_db(db_path: Path) -> None:
+    """A real conversation DB (exchanges/embeddings/FTS/HNSW all populated via
+    the same rebuild_derived() path M2 ships) with real reclaimable bloat
+    churned in on top, mirroring M1's synthetic-bloat fixture pattern."""
+    storage = UnifiedStorage(db_path)
+    _seed_conversation(storage, "conv-a")
+    _seed_conversation(storage, "conv-b")
+
+    config = Config.load()
+    indexer = UnifiedIndexer(db_path.parent, config, storage=storage)
+    with patch.object(indexer, "_get_embedder", return_value=_fake_embedder()):
+        indexer.rebuild_derived(force=True)
+    storage.close()
+
+    # Churn: insert a large padding table and update it across many
+    # checkpoints, matching the bloat fixture in
+    # tests/unit/services/test_storage_health.py. The table is never
+    # dropped: DuckDB's own checkpoint-time truncation only reclaims dead
+    # blocks trailing at the file's end, which is exactly what happens if
+    # this table were dropped (its blocks, being the newest, sit at the
+    # tail and get truncated away for free). Leaving it live scatters the
+    # blocks UPDATE orphans throughout the file, interleaved with the real
+    # conversation/exchange/embedding data -- the same "used blocks >> live
+    # footprint" pattern Appendix A's manual recovery reclaimed, and only a
+    # copy-compaction (not a checkpoint) can shrink.
+    con = duckdb.connect(str(db_path))
+    _prepare_connection(con)
+    con.execute("CREATE TABLE _bloat_padding(id INTEGER, payload VARCHAR)")
+    con.execute(
+        "INSERT INTO _bloat_padding SELECT i, md5(i::VARCHAR) || md5((i + 1)::VARCHAR) || "
+        "md5((i + 2)::VARCHAR) FROM range(20000) t(i)"
+    )
+    con.execute("CHECKPOINT")
+    con.close()
+
+    for cycle in range(15):
+        con = duckdb.connect(str(db_path))
+        _prepare_connection(con)
+        con.execute(
+            "UPDATE _bloat_padding SET payload = md5((? || id)::VARCHAR) WHERE id % 5 = ?",
+            [str(cycle), cycle % 5],
+        )
+        con.execute("CHECKPOINT")
+        con.close()
+
+
+class TestCompactDatabase:
+    def test_compacts_bloated_fixture_to_query_identical_file(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+
+        size_before = inspect_database_size(db_path)
+        live_before = estimate_live_data_size(db_path)
+        ratio_before = compute_bloat_ratio(size_before.total_bytes, live_before)
+        assert ratio_before > 1.5  # the churn pattern must have produced measurable bloat
+
+        # Snapshot pre-compaction query results to compare after.
+        con = duckdb.connect(str(db_path), read_only=True)
+        _prepare_connection(con)
+        exchanges_before = con.execute("SELECT * FROM exchanges ORDER BY exchange_id").fetchall()
+        bm25_before = con.execute(
+            "SELECT exchange_id, fts_main_exchanges.match_bm25(exchange_id, 'sorting') AS score "
+            "FROM exchanges WHERE score IS NOT NULL ORDER BY score DESC, exchange_id"
+        ).fetchall()
+        con.close()
+
+        result = compact_database(db_path)
+
+        assert result.success is True
+        assert result.error is None
+        assert result.preserved_original_path is None
+        assert result.verification is not None
+        assert result.verification.passed is True
+        assert result.bytes_reclaimed > 0
+        assert result.compacted_size_bytes < result.original_size_bytes
+
+        # No leftover temp/preserved files.
+        leftovers = list(db_path.parent.glob(f"{db_path.name}.*"))
+        assert leftovers == []
+
+        con = duckdb.connect(str(db_path), read_only=True)
+        _prepare_connection(con)
+        exchanges_after = con.execute("SELECT * FROM exchanges ORDER BY exchange_id").fetchall()
+        bm25_after = con.execute(
+            "SELECT exchange_id, fts_main_exchanges.match_bm25(exchange_id, 'sorting') AS score "
+            "FROM exchanges WHERE score IS NOT NULL ORDER BY score DESC, exchange_id"
+        ).fetchall()
+        hnsw_rows = con.execute(
+            "SELECT index_name FROM duckdb_indexes() WHERE index_name = 'verbatim_hnsw'"
+        ).fetchall()
+        con.close()
+
+        assert exchanges_after == exchanges_before
+        assert bm25_after == bm25_before
+        assert hnsw_rows == [("verbatim_hnsw",)]
+
+        size_after = inspect_database_size(db_path)
+        live_after = estimate_live_data_size(db_path)
+        ratio_after = compute_bloat_ratio(size_after.total_bytes, live_after)
+        assert ratio_after < ratio_before
+
+    def test_missing_database_returns_clear_failure(self, tmp_path: Path) -> None:
+        result = compact_database(tmp_path / "does-not-exist.duckdb")
+
+        assert result.success is False
+        assert result.original_size_bytes == 0
+        assert "No database found" in result.error
+
+    def test_locked_database_refuses_and_leaves_original_untouched(self, tmp_path: Path) -> None:
+        """A held write connection must be a genuinely separate OS process --
+        DuckDB de-duplicates same-process connections to one file, which
+        would mask the cross-process lock this guard exists for."""
+        db_path = tmp_path / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+        checksum_before = _sha256(db_path)
+        mtime_before = db_path.stat().st_mtime_ns
+
+        holder = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import duckdb, time, sys; con = duckdb.connect(sys.argv[1]); "
+                "print('locked', flush=True); time.sleep(10)",
+                str(db_path),
+            ],
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            ready_line = holder.stdout.readline()
+            assert ready_line.strip() == "locked"
+
+            result = compact_database(db_path)
+        finally:
+            holder.kill()
+            holder.wait(timeout=5)
+            holder.stdout.close()
+
+        assert result.success is False
+        assert "in use by another process" in result.error
+        assert _sha256(db_path) == checksum_before
+        assert db_path.stat().st_mtime_ns == mtime_before
+        assert not (db_path.parent / f"{db_path.name}.compact-tmp").exists()
+
+    def test_failed_verification_leaves_original_untouched_and_cleans_up_temp(
+        self, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+        checksum_before = _sha256(db_path)
+
+        failing = VerificationResult(
+            passed=False,
+            row_counts_match=False,
+            index_names_match=True,
+            fts_probe_match=True,
+            vector_probe_match=True,
+            symmetric_diff_match=True,
+            mismatches=("forced failure for test",),
+        )
+        with patch("searchat.services.compaction.verify_compaction", return_value=failing):
+            result = compact_database(db_path)
+
+        assert result.success is False
+        assert result.verification is failing
+        assert "forced failure for test" in result.error
+        assert _sha256(db_path) == checksum_before
+        assert not (db_path.parent / f"{db_path.name}.compact-tmp").exists()
+        assert list(db_path.parent.glob(f"{db_path.name}.pre-compact-*")) == []

--- a/tests/unit/services/test_compaction.py
+++ b/tests/unit/services/test_compaction.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import subprocess
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -153,8 +154,23 @@ class TestVerifyCompaction:
 # ---------------------------------------------------------------------------
 
 
-def _sha256(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+def _sha256(path: Path, *, retries: int = 20, delay: float = 0.1) -> str:
+    """Read and hash a file's bytes.
+
+    Retries briefly on PermissionError: on Windows, a just-killed
+    process's file handle can take a moment to actually release after
+    Process.wait() returns, and a read attempted in that window raises
+    PermissionError rather than succeeding or raising immediately.
+    """
+    last_error: PermissionError | None = None
+    for _ in range(retries):
+        try:
+            return hashlib.sha256(path.read_bytes()).hexdigest()
+        except PermissionError as exc:
+            last_error = exc
+            time.sleep(delay)
+    assert last_error is not None
+    raise last_error
 
 
 def _deterministic_vector(text: str) -> list[float]:

--- a/tests/unit/services/test_compaction.py
+++ b/tests/unit/services/test_compaction.py
@@ -148,6 +148,33 @@ class TestVerifyCompaction:
         assert result.fts_probe_match is None
         assert result.vector_probe_match is None
 
+    def test_symmetric_diff_detects_conversations_divergence(self, tmp_path: Path) -> None:
+        """Equal row counts alone must not be mistaken for identical
+        content: dst's conversations table here has the same row count as
+        src but a genuinely different row, which only the symmetric-diff
+        spot-check (not row_counts_match) can catch."""
+        src = tmp_path / "src.duckdb"
+        dst = tmp_path / "dst.duckdb"
+
+        def _seed_conversations(path: Path, conversation_id: str) -> None:
+            _seed_minimal_db(path, rows=())
+            con = duckdb.connect(str(path))
+            _prepare_connection(con)
+            con.execute("CREATE TABLE conversations(id VARCHAR PRIMARY KEY, title VARCHAR)")
+            con.execute("INSERT INTO conversations VALUES (?, 'title')", [conversation_id])
+            con.execute("CHECKPOINT")
+            con.close()
+
+        _seed_conversations(src, "conv-a")
+        _seed_conversations(dst, "conv-b")
+
+        result = verify_compaction(src, dst)
+
+        assert result.row_counts_match is True
+        assert result.symmetric_diff_match is False
+        assert result.passed is False
+        assert any("symmetric diff" in m for m in result.mismatches)
+
 
 # ---------------------------------------------------------------------------
 # Real, indexed conversation DB with synthetic bloat -- end-to-end engine tests
@@ -387,3 +414,51 @@ class TestCompactDatabase:
         assert _sha256(db_path) == checksum_before
         assert not (db_path.parent / f"{db_path.name}.compact-tmp").exists()
         assert list(db_path.parent.glob(f"{db_path.name}.pre-compact-*")) == []
+
+    def test_post_swap_smoke_test_failure_rolls_back_and_quarantines(
+        self, tmp_path: Path
+    ) -> None:
+        """The last line of defense: if the file that just got swapped
+        into db_path fails even a trivial open+query smoke test, roll
+        back -- restore the original content at db_path, quarantine the
+        broken swap-in under a forensic filename, and report failure.
+        Nothing is left half-swapped."""
+        db_path = tmp_path / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+        checksum_before = _sha256(db_path)
+
+        with patch("searchat.services.compaction._post_swap_smoke_test", return_value=False):
+            result = compact_database(db_path)
+
+        assert result.success is False
+        assert "Post-swap smoke test failed" in result.error
+        assert result.preserved_original_path is None
+        assert result.quarantined_path is not None
+        assert result.quarantined_path.exists()
+        assert list(db_path.parent.glob(f"{db_path.name}.post-swap-failed-*")) == [
+            result.quarantined_path
+        ]
+
+        # The original is back in place at db_path -- verified by content,
+        # not just by the field being None.
+        assert _sha256(db_path) == checksum_before
+        assert list(db_path.parent.glob(f"{db_path.name}.pre-compact-*")) == []
+
+    def test_compacts_database_in_directory_with_apostrophe_in_path(
+        self, tmp_path: Path
+    ) -> None:
+        """ATTACH has no bound-parameter form for its path argument, so
+        _sql_literal's manual SQL-literal escaping is what stands between
+        a real filesystem path (e.g. a macOS home directory like
+        /Users/O'Brien/...) and a broken or injectable ATTACH statement."""
+        odd_dir = tmp_path / "O'Brien's Data"
+        db_path = odd_dir / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+
+        result = compact_database(db_path)
+
+        assert result.success is True
+        assert result.verification is not None
+        assert result.verification.passed is True


### PR DESCRIPTION
## Stack

Stack-Id: `m3-compaction`
Base: `main`
Position: 1/3

1. `feat/compaction-engine` -> this PR
2. `feat/compaction-subprocess` -> #94
3. `feat/compaction-cli` -> #95

Depends on: (none - root)
Upstack: #94

## Summary

Part 1/3 of M3 (Safe copy-compaction with auto-trigger, DEVELOPMENT_PLAN.md §4 M3). Adds `services/compaction.py`: `compact_database()` and `verify_compaction()`, the checkpoint -> attach -> COPY FROM DATABASE -> verify -> atomic-rename engine codifying the Tier 0 manual recovery procedure recorded in `.docs/searchat-memory-management-enhancement-analysis.md` Appendix A.

- Every connection preloads `vss`/`fts` and enables HNSW persistence before any write op (the extension-load-order gotcha that produced a FATAL during the manual Tier 0 recovery).
- `verify_compaction` reuses M1's row-count/index verification pattern (`services/storage_health.py`) and extends it with functional `match_bm25` + `array_cosine_distance` probes and a symmetric-diff spot-check, matching Appendix A exactly.
- `db_path` is never mutated until verification passes; the pre-compaction original is kept as `<name>.pre-compact-<timestamp>` until a post-swap smoke test on the new file also passes, with a `quarantined_path` field pointing at the broken copy if that smoke test ever fails.
- This PR runs the engine **in-process** (no subprocess yet) — subprocess isolation for the FATAL failure mode lands in PR 2.

## Review round

An independent review pass (real diff read, tests run locally, ruff+mypy run manually since CI runs neither) found and this PR now fixes: a dangling `preserved_original_path` reference in the post-swap-rollback branch (now `None` there, with a new `quarantined_path` field carrying the broken copy's location instead), 5x unsound `fetchone()[0]` scalar reads (replaced with a `_scalar()` helper), and three test gaps — the post-swap rollback path had zero coverage, `_symmetric_diff`'s actual mismatch branch was never exercised with a genuine divergence, and `_sql_literal`'s SQL-literal escaping had no regression test despite real paths containing apostrophes.

## Validation

- `uv run pytest tests/unit/services/test_compaction.py -v --tb=short --no-cov` — 13 passed
- `uv run pytest -v --tb=short` — 2138 passed, 1 skipped, 81.79% coverage (>= 80% gate)
- `uv run ruff check` — clean
- CI green on ubuntu/macos/windows x py3.10/3.11/3.12 + build
