### PR TITLE
feat(services): run compaction as an isolated subprocess

### DIFF
--- a/src/searchat/config/settings.py
+++ b/src/searchat/config/settings.py
@@ -11,13 +11,12 @@ Configuration precedence (highest to lowest):
 from __future__ import annotations
 
 import os
-from typing import overload
+from typing import TYPE_CHECKING, overload
 from dataclasses import dataclass
 from pathlib import Path
 import tomli
 from dotenv import load_dotenv
 
-from ..core.logging_config import LogConfig
 from .constants import (
     DEFAULT_DATA_DIR,
     DEFAULT_CONFIG_SUBDIR,
@@ -159,6 +158,9 @@ from .constants import (
     ENV_DISTILLATION_MIN_EXCHANGE_CHARS,
     ENV_PALACE_ENABLED,
 )
+
+if TYPE_CHECKING:
+    from ..core.logging_config import LogConfig
 
 
 # Load .env file at module import time
@@ -975,6 +977,8 @@ class Config:
                 )
             # Otherwise, use empty dict and rely on constants.py
             data = {}
+
+        from ..core.logging_config import LogConfig
 
         # Build config objects with environment variable overrides
         return cls(

--- a/src/searchat/services/compaction.py
+++ b/src/searchat/services/compaction.py
@@ -534,7 +534,9 @@ def _compact_worker(
     result_queue.put(result)
 
 
-def compact_database(db_path: Path, *, subprocess_isolated: bool = True) -> CompactionResult:
+def compact_database(
+    db_path: Path, *, subprocess_isolated: bool = True, timeout_seconds: float | None = None
+) -> CompactionResult:
     """Reclaim dead blocks in `db_path` via verified copy-compaction.
 
     By default, runs the checkpoint -> attach -> COPY FROM DATABASE ->
@@ -549,7 +551,13 @@ def compact_database(db_path: Path, *, subprocess_isolated: bool = True) -> Comp
     `subprocess_isolated=False` runs the sequence directly in the
     caller's process instead -- for tests exercising the compaction logic
     itself rather than its process isolation.
+
+    `timeout_seconds`, when given, bounds how long the isolated child may
+    run: a hung (not crashed) child is terminated -- then killed if it
+    doesn't exit -- rather than blocking the caller forever. `None` (the
+    default) waits indefinitely, matching the original behavior.
     """
+    start = time.perf_counter()
     db_path = Path(db_path)
     if not subprocess_isolated:
         return _compact_database_in_process(db_path)
@@ -558,7 +566,32 @@ def compact_database(db_path: Path, *, subprocess_isolated: bool = True) -> Comp
     result_queue: multiprocessing.Queue = ctx.Queue()
     process = ctx.Process(target=_compact_worker, args=(str(db_path), result_queue))
     process.start()
-    process.join()
+    process.join(timeout=timeout_seconds)
+
+    if process.is_alive():
+        # Hung, not crashed -- terminate/kill rather than block forever.
+        # Reached from the shutdown path (via run_auto_compact_if_needed),
+        # where blocking here would also block SIGTERM from ever firing.
+        process.terminate()
+        process.join(timeout=5)
+        if process.is_alive():
+            process.kill()
+            process.join()
+        return CompactionResult(
+            success=False,
+            original_path=db_path,
+            original_size_bytes=db_path.stat().st_size if db_path.exists() else 0,
+            compacted_size_bytes=0,
+            bytes_reclaimed=0,
+            preserved_original_path=None,
+            quarantined_path=None,
+            verification=None,
+            error=(
+                f"Compaction subprocess timed out after {timeout_seconds}s and was "
+                "terminated; original database untouched."
+            ),
+            duration_seconds=time.perf_counter() - start,
+        )
 
     if not result_queue.empty():
         return result_queue.get()
@@ -573,11 +606,12 @@ def compact_database(db_path: Path, *, subprocess_isolated: bool = True) -> Comp
         compacted_size_bytes=0,
         bytes_reclaimed=0,
         preserved_original_path=None,
+        quarantined_path=None,
         verification=None,
         error=(
             "Compaction subprocess exited abnormally "
             f"(exit code {process.exitcode}) before reporting a result; "
             "original database untouched."
         ),
-        duration_seconds=0.0,
+        duration_seconds=time.perf_counter() - start,
     )

--- a/src/searchat/services/compaction.py
+++ b/src/searchat/services/compaction.py
@@ -14,10 +14,11 @@ this can make CHECKPOINT / COPY FROM DATABASE fail with FATAL "unknown
 index type 'HNSW'" when the on-disk catalog references an index whose
 extension has not been loaded in this connection yet -- the failure
 observed during the Tier 0 recovery. A FATAL error aborts the DuckDB
-process outright and no Python `except` clause can catch it -- callers
-that must survive that failure mode isolate `compact_database` in a
-subprocess so a FATAL there can never take down the parent process or
-leave the original file half-written.
+process outright and no Python `except` clause can catch it, which is
+why `compact_database` runs the whole sequence in an isolated child
+process by default (`subprocess_isolated=True`): a FATAL there kills
+only the child, never the caller, and `db_path` is left exactly as it
+was.
 
 `compact_database` never mutates `db_path` until `verify_compaction` has
 proven the compacted copy is query-identical: same row counts across
@@ -28,6 +29,8 @@ zero-row symmetric diff on `conversations`.
 from __future__ import annotations
 
 import logging
+import multiprocessing
+import multiprocessing.synchronize
 import re
 import time
 from dataclasses import dataclass
@@ -370,8 +373,12 @@ def _post_swap_smoke_test(db_path: Path) -> bool:
         return False
 
 
-def compact_database(db_path: Path) -> CompactionResult:
-    """Reclaim dead blocks in `db_path` via verified copy-compaction.
+def _compact_database_in_process(
+    db_path: Path,
+    *,
+    _ready_event: multiprocessing.synchronize.Event | None = None,
+) -> CompactionResult:
+    """Run the full copy-compaction sequence in the CURRENT process.
 
     `db_path` is never mutated until `verify_compaction` proves the
     compacted copy is query-identical, and the pre-compaction original is
@@ -379,6 +386,13 @@ def compact_database(db_path: Path) -> CompactionResult:
     smoke test on the new file also passes -- only then is it removed. Any
     failure at any stage leaves `db_path` exactly as it was before the
     call.
+
+    `_ready_event`, when given, is set once copy-compaction finishes and
+    verification is about to begin -- the synchronization point the
+    fault-injection test uses to kill the subprocess running this
+    function deterministically mid-run, proving the swap that follows
+    never executes. `compact_database` never passes it; production
+    callers only reach this function through `compact_database`.
     """
     start = time.perf_counter()
     db_path = Path(db_path)
@@ -431,6 +445,9 @@ def compact_database(db_path: Path) -> CompactionResult:
             error=f"Copy-compaction failed: {exc}",
             duration_seconds=time.perf_counter() - start,
         )
+
+    if _ready_event is not None:
+        _ready_event.set()
 
     verification = verify_compaction(db_path, dst_path)
     if not verification.passed:
@@ -493,4 +510,74 @@ def compact_database(db_path: Path) -> CompactionResult:
         verification=verification,
         error=None,
         duration_seconds=time.perf_counter() - start,
+    )
+
+
+def _compact_worker(
+    db_path: str,
+    result_queue: multiprocessing.Queue,
+    ready_event: multiprocessing.synchronize.Event | None = None,
+) -> None:
+    """Subprocess entry point.
+
+    Runs the full compact-verify-swap sequence in this (isolated) process
+    and posts the `CompactionResult` back to the parent via
+    `result_queue`. If this process is killed or aborts -- including a
+    DuckDB FATAL, a hard process abort no Python `except` clause can catch
+    -- before reaching the `result_queue.put` below, nothing is posted;
+    `compact_database` treats an empty queue as a failed run. `db_path` is
+    guaranteed untouched either way, since every mutation inside
+    `_compact_database_in_process` happens only after verification
+    passes.
+    """
+    result = _compact_database_in_process(Path(db_path), _ready_event=ready_event)
+    result_queue.put(result)
+
+
+def compact_database(db_path: Path, *, subprocess_isolated: bool = True) -> CompactionResult:
+    """Reclaim dead blocks in `db_path` via verified copy-compaction.
+
+    By default, runs the checkpoint -> attach -> COPY FROM DATABASE ->
+    verify -> atomic-rename sequence (`_compact_database_in_process`)
+    inside an isolated child process, so a DuckDB FATAL -- observed during
+    the Tier 0 recovery when an index's extension had not been loaded yet
+    -- kills only the child. `db_path` is left exactly as it was in every
+    case: every mutation the sequence performs happens only after
+    verification passes, so a process that dies before then has made
+    none.
+
+    `subprocess_isolated=False` runs the sequence directly in the
+    caller's process instead -- for tests exercising the compaction logic
+    itself rather than its process isolation.
+    """
+    db_path = Path(db_path)
+    if not subprocess_isolated:
+        return _compact_database_in_process(db_path)
+
+    ctx = multiprocessing.get_context("spawn")
+    result_queue: multiprocessing.Queue = ctx.Queue()
+    process = ctx.Process(target=_compact_worker, args=(str(db_path), result_queue))
+    process.start()
+    process.join()
+
+    if not result_queue.empty():
+        return result_queue.get()
+
+    # The worker died before it could report a result (crash, FATAL abort,
+    # or an external kill). db_path was never touched: every mutation in
+    # _compact_database_in_process happens only after verification passes.
+    return CompactionResult(
+        success=False,
+        original_path=db_path,
+        original_size_bytes=db_path.stat().st_size if db_path.exists() else 0,
+        compacted_size_bytes=0,
+        bytes_reclaimed=0,
+        preserved_original_path=None,
+        verification=None,
+        error=(
+            "Compaction subprocess exited abnormally "
+            f"(exit code {process.exitcode}) before reporting a result; "
+            "original database untouched."
+        ),
+        duration_seconds=0.0,
     )

--- a/tests/unit/services/test_compaction.py
+++ b/tests/unit/services/test_compaction.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import hashlib
+import multiprocessing
+import queue
 import subprocess
 import sys
 import time
@@ -14,6 +16,7 @@ import numpy as np
 
 from searchat.config import Config
 from searchat.core.unified_indexer import UnifiedIndexer
+from searchat.services import compaction as comp
 from searchat.services.compaction import (
     VerificationResult,
     _prepare_connection,
@@ -289,6 +292,10 @@ def _build_indexed_bloated_db(db_path: Path) -> None:
 
 
 class TestCompactDatabase:
+    """subprocess_isolated=False throughout: these tests exercise the
+    compact-verify-swap engine directly. Process isolation itself
+    (subprocess_isolated=True, the default) is covered separately."""
+
     def test_compacts_bloated_fixture_to_query_identical_file(self, tmp_path: Path) -> None:
         db_path = tmp_path / "data" / "searchat.duckdb"
         db_path.parent.mkdir(parents=True)
@@ -309,7 +316,7 @@ class TestCompactDatabase:
         ).fetchall()
         con.close()
 
-        result = compact_database(db_path)
+        result = compact_database(db_path, subprocess_isolated=False)
 
         assert result.success is True
         assert result.error is None
@@ -345,7 +352,7 @@ class TestCompactDatabase:
         assert ratio_after < ratio_before
 
     def test_missing_database_returns_clear_failure(self, tmp_path: Path) -> None:
-        result = compact_database(tmp_path / "does-not-exist.duckdb")
+        result = compact_database(tmp_path / "does-not-exist.duckdb", subprocess_isolated=False)
 
         assert result.success is False
         assert result.original_size_bytes == 0
@@ -376,7 +383,7 @@ class TestCompactDatabase:
             ready_line = holder.stdout.readline()
             assert ready_line.strip() == "locked"
 
-            result = compact_database(db_path)
+            result = compact_database(db_path, subprocess_isolated=False)
         finally:
             holder.kill()
             holder.wait(timeout=5)
@@ -406,7 +413,7 @@ class TestCompactDatabase:
             mismatches=("forced failure for test",),
         )
         with patch("searchat.services.compaction.verify_compaction", return_value=failing):
-            result = compact_database(db_path)
+            result = compact_database(db_path, subprocess_isolated=False)
 
         assert result.success is False
         assert result.verification is failing
@@ -462,3 +469,107 @@ class TestCompactDatabase:
         assert result.success is True
         assert result.verification is not None
         assert result.verification.passed is True
+
+
+class TestSubprocessIsolation:
+    """subprocess_isolated=True (the default): compaction runs in a real,
+    isolated child process."""
+
+    def test_default_runs_in_subprocess_and_produces_identical_result(
+        self, tmp_path: Path
+    ) -> None:
+        db_path = tmp_path / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+
+        result = compact_database(db_path)
+
+        assert result.success is True
+        assert result.verification is not None
+        assert result.verification.passed is True
+        assert result.bytes_reclaimed > 0
+
+        con = duckdb.connect(str(db_path), read_only=True)
+        _prepare_connection(con)
+        row = con.execute("SELECT COUNT(*) FROM exchanges").fetchone()
+        con.close()
+        assert row == (4,)
+
+    def test_kill_subprocess_mid_compaction_leaves_original_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        """The fault-injection case: kill the compaction subprocess right
+        after it finishes copying but before it verifies/swaps -- the
+        window where a real DuckDB FATAL was observed during Tier 0
+        (Appendix A). The original file must be untouched: no swap, no
+        preserved-original rename, unchanged checksum and mtime."""
+        db_path = tmp_path / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+        checksum_before = _sha256(db_path)
+        mtime_before = db_path.stat().st_mtime_ns
+
+        ctx = multiprocessing.get_context("spawn")
+        ready_event = ctx.Event()
+        result_queue: multiprocessing.Queue = ctx.Queue()
+        process = ctx.Process(
+            target=comp._compact_worker,
+            args=(str(db_path), result_queue, ready_event),
+        )
+        process.start()
+        try:
+            signaled = ready_event.wait(timeout=15)
+            assert signaled, "worker never reached the pre-verify checkpoint"
+            process.kill()
+            process.join(timeout=5)
+        finally:
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+
+        assert process.exitcode != 0
+        assert result_queue.empty()
+        assert _sha256(db_path) == checksum_before
+        assert db_path.stat().st_mtime_ns == mtime_before
+        assert list(db_path.parent.glob(f"{db_path.name}.pre-compact-*")) == []
+
+    def test_worker_death_without_result_reported_as_clean_failure(self, tmp_path: Path) -> None:
+        """compact_database()'s own orchestration: when its child process
+        exits without posting a result to the queue (crash, FATAL abort,
+        external kill -- all indistinguishable from here), the failure is
+        surfaced as a plain CompactionResult, never an exception, and
+        db_path is never touched. Exercised via a fake multiprocessing
+        context targeting this branch directly, rather than racing a real
+        crash (already covered by the kill test above, which proves the
+        file-safety property against a genuine subprocess)."""
+        db_path = tmp_path / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+        checksum_before = _sha256(db_path)
+
+        class _DeadProcess:
+            exitcode = -9
+
+            def __init__(self, target=None, args=()) -> None:
+                del target, args
+
+            def start(self) -> None:
+                pass
+
+            def join(self) -> None:
+                pass
+
+        class _FakeContext:
+            def Queue(self):
+                return queue.Queue()  # always empty: the "worker" never posted
+
+            def Process(self, target=None, args=()):
+                return _DeadProcess(target=target, args=args)
+
+        with patch.object(comp.multiprocessing, "get_context", return_value=_FakeContext()):
+            result = compact_database(db_path)
+
+        assert result.success is False
+        assert "subprocess exited abnormally" in result.error
+        assert "-9" in result.error
+        assert _sha256(db_path) == checksum_before

--- a/tests/unit/services/test_compaction.py
+++ b/tests/unit/services/test_compaction.py
@@ -436,7 +436,7 @@ class TestCompactDatabase:
         checksum_before = _sha256(db_path)
 
         with patch("searchat.services.compaction._post_swap_smoke_test", return_value=False):
-            result = compact_database(db_path)
+            result = compact_database(db_path, subprocess_isolated=False)
 
         assert result.success is False
         assert "Post-swap smoke test failed" in result.error
@@ -494,6 +494,61 @@ class TestSubprocessIsolation:
         row = con.execute("SELECT COUNT(*) FROM exchanges").fetchone()
         con.close()
         assert row == (4,)
+
+    def test_hung_subprocess_is_terminated_after_timeout(self, tmp_path: Path) -> None:
+        """A subprocess that neither crashes nor completes within
+        timeout_seconds is terminated rather than blocking the caller
+        forever -- this branch is what keeps a hung compaction from also
+        blocking graceful shutdown (SIGTERM never fires while
+        compact_database blocks). Uses a fake process double rather than
+        racing a real hang, matching the fault-injection style already
+        used for the crash case above."""
+        db_path = tmp_path / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+        checksum_before = _sha256(db_path)
+
+        class _HungProcess:
+            exitcode = None
+            terminate_called = False
+            kill_called = False
+
+            def __init__(self, target=None, args=()) -> None:
+                del target, args
+                self._alive = True
+
+            def start(self) -> None:
+                pass
+
+            def join(self, timeout=None) -> None:
+                del timeout  # never finishes on its own
+
+            def is_alive(self) -> bool:
+                return self._alive
+
+            def terminate(self) -> None:
+                type(self).terminate_called = True
+                self._alive = False
+
+            def kill(self) -> None:
+                type(self).kill_called = True
+                self._alive = False
+
+        class _FakeContext:
+            def Queue(self):
+                return queue.Queue()
+
+            def Process(self, target=None, args=()):
+                return _HungProcess(target=target, args=args)
+
+        with patch.object(comp.multiprocessing, "get_context", return_value=_FakeContext()):
+            result = compact_database(db_path, timeout_seconds=0.01)
+
+        assert result.success is False
+        assert "timed out" in result.error
+        assert _HungProcess.terminate_called is True
+        assert _HungProcess.kill_called is False
+        assert _sha256(db_path) == checksum_before
 
     def test_kill_subprocess_mid_compaction_leaves_original_untouched(
         self, tmp_path: Path
@@ -556,8 +611,11 @@ class TestSubprocessIsolation:
             def start(self) -> None:
                 pass
 
-            def join(self) -> None:
-                pass
+            def join(self, timeout=None) -> None:
+                del timeout
+
+            def is_alive(self) -> bool:
+                return False
 
         class _FakeContext:
             def Queue(self):


### PR DESCRIPTION
## Stack

Stack-Id: `m3-compaction`
Base: `feat/compaction-engine` (#93)
Position: 2/3

1. `feat/compaction-engine` -> #93
2. `feat/compaction-subprocess` -> this PR
3. `feat/compaction-cli` -> #95

Depends on: #93
Upstack: #95

## Summary

Part 2/3 of M3. `compact_database()` now spawns `_compact_database_in_process` (PR 1's engine, renamed) inside an isolated child process by default (`subprocess_isolated: bool = True`), using `multiprocessing`'s `spawn` context (cross-platform, including Windows). A DuckDB FATAL — a hard process abort no Python `except` clause can catch, the exact failure mode observed during the manual Tier 0 recovery — now kills only the child. The parent reads the `CompactionResult` back through a queue, or synthesizes a clean failure when the child dies before posting one; `db_path` is guaranteed untouched either way, since every mutation in the engine happens only after verification passes.

**Bugfix required to make this work at all:** `multiprocessing`'s `spawn` start method re-imports the target module fresh in the child, which exposed a pre-existing circular import (`config.settings` → `core.logging_config` → forces `core/__init__.py` → `core.watcher` → `config`, still mid-init). Every subprocess-isolated compaction call crashed on import before this fix — deferring the one runtime use into `Config.load()` and using `TYPE_CHECKING` for the dataclass field annotation. Verified the full suite is unaffected.

Fault-injection test (`test_kill_subprocess_mid_compaction_leaves_original_untouched`) kills the real subprocess right after it finishes copying but before it verifies/swaps — synchronized via an internal `_ready_event` hook rather than racing a sleep against however long `COPY FROM DATABASE` takes — and asserts the original file's checksum/mtime are unchanged and no `.pre-compact-*` file exists.

Existing PR-1 engine tests are pinned to `subprocess_isolated=False` (one of them patches `verify_compaction`, which only works same-process — a spawned child never sees it).

## Review round

An independent review pass found `process.join()` had no timeout: a hung (not crashed) child would block `compact_database()` forever, including from the graceful-shutdown path where it would prevent `SIGTERM` from ever firing. Added `timeout_seconds: float | None = None`: when set and exceeded, the child is `terminate()`'d, given a 5s grace period, then `kill()`'d if still alive, and a clean `CompactionResult(success=False)` is returned — `db_path` untouched either way. New test covers the termination path via a fake process double (matching the fault-injection style already used for the crash case).

## Validation

- `uv run pytest tests/unit/services/test_compaction.py -v --tb=short --no-cov` — 17 passed
- `uv run pytest -v --tb=short` — 2138 passed, 1 skipped, 81.79% coverage (>= 80% gate)
- `uv run ruff check` — clean
- CI green on ubuntu/macos/windows x py3.10/3.11/3.12 + build
