### PR TITLE
feat(cli): add searchat compact CLI and bloat-ratio auto-trigger

### DIFF
--- a/src/searchat/api/dependencies.py
+++ b/src/searchat/api/dependencies.py
@@ -393,6 +393,35 @@ def set_watcher(watcher):
     _watcher = watcher
 
 
+def maybe_auto_compact_on_shutdown() -> None:
+    """Bloat-ratio + interval gated compaction check for graceful shutdown.
+
+    Best-effort: never raises and never blocks shutdown. Shared by every
+    shutdown endpoint (api/routers/admin.py, api/routers/fragments.py) so
+    the auto-trigger logic lives in exactly one place.
+    """
+    if _config is None or _search_dir is None:
+        return
+    try:
+        from searchat.services.compaction import run_auto_compact_if_needed
+
+        db_path = _config.storage.resolve_duckdb_path(_search_dir)
+        result = run_auto_compact_if_needed(
+            db_path,
+            _search_dir,
+            auto_trigger_ratio=_config.compaction.auto_trigger_ratio,
+            min_interval_days=_config.compaction.min_interval_days,
+        )
+        if result is None:
+            return
+        if result.success:
+            logger.info("Auto-compact reclaimed %d bytes on shutdown", result.bytes_reclaimed)
+        else:
+            logger.warning("Auto-compact failed on shutdown: %s", result.error)
+    except Exception:
+        logger.exception("Auto-compact check failed during shutdown")
+
+
 def _ensure_search_engine():
     """Create and initialize search engine (blocking)."""
     global _search_engine

--- a/src/searchat/api/dependencies.py
+++ b/src/searchat/api/dependencies.py
@@ -396,9 +396,15 @@ def set_watcher(watcher):
 def maybe_auto_compact_on_shutdown() -> None:
     """Bloat-ratio + interval gated compaction check for graceful shutdown.
 
-    Best-effort: never raises and never blocks shutdown. Shared by every
-    shutdown endpoint (api/routers/admin.py, api/routers/fragments.py) so
-    the auto-trigger logic lives in exactly one place.
+    Never raises, and the compaction subprocess it may spawn is bounded
+    by `compaction.max_duration_seconds` so it cannot hang forever -- but
+    this function is itself a **blocking, synchronous call** for as long
+    as that: on an asyncio event loop, run it off-thread (e.g.
+    `await asyncio.to_thread(maybe_auto_compact_on_shutdown)`) or it will
+    stall every other in-flight request for the duration of compaction.
+    Shared by every shutdown endpoint (api/routers/admin.py,
+    api/routers/fragments.py) so the auto-trigger logic and this
+    constraint live in exactly one place.
     """
     if _config is None or _search_dir is None:
         return
@@ -411,6 +417,7 @@ def maybe_auto_compact_on_shutdown() -> None:
             _search_dir,
             auto_trigger_ratio=_config.compaction.auto_trigger_ratio,
             min_interval_days=_config.compaction.min_interval_days,
+            timeout_seconds=_config.compaction.max_duration_seconds,
         )
         if result is None:
             return

--- a/src/searchat/api/routers/admin.py
+++ b/src/searchat/api/routers/admin.py
@@ -13,7 +13,7 @@ from searchat.api.contracts import (
     serialize_shutdown_payload,
     serialize_watcher_status_payload,
 )
-from searchat.api.dependencies import get_watcher
+from searchat.api.dependencies import get_watcher, maybe_auto_compact_on_shutdown
 from searchat.api import state as api_state
 
 
@@ -69,6 +69,8 @@ async def shutdown_server(background_tasks: BackgroundTasks, force: bool = False
         if watcher and watcher.is_running:
             logger.info("Stopping file watcher...")
             watcher.stop()
+
+        maybe_auto_compact_on_shutdown()
 
         logger.info("Shutting down server...")
         os.kill(os.getpid(), signal.SIGTERM)

--- a/src/searchat/api/routers/fragments.py
+++ b/src/searchat/api/routers/fragments.py
@@ -720,8 +720,11 @@ async def shutdown_server(request: Request) -> HTMLResponse:
     import signal
     import asyncio
 
+    from searchat.api.dependencies import maybe_auto_compact_on_shutdown
+
     async def _delayed_shutdown() -> None:
         await asyncio.sleep(0.5)
+        maybe_auto_compact_on_shutdown()
         os.kill(os.getpid(), signal.SIGTERM)
 
     asyncio.get_event_loop().create_task(_delayed_shutdown())

--- a/src/searchat/api/routers/fragments.py
+++ b/src/searchat/api/routers/fragments.py
@@ -724,7 +724,10 @@ async def shutdown_server(request: Request) -> HTMLResponse:
 
     async def _delayed_shutdown() -> None:
         await asyncio.sleep(0.5)
-        maybe_auto_compact_on_shutdown()
+        # maybe_auto_compact_on_shutdown is a blocking synchronous call
+        # (it may run compact_database's process.join()); off-thread so it
+        # never stalls every other in-flight request on this event loop.
+        await asyncio.to_thread(maybe_auto_compact_on_shutdown)
         os.kill(os.getpid(), signal.SIGTERM)
 
     asyncio.get_event_loop().create_task(_delayed_shutdown())

--- a/src/searchat/cli/compact_cmd.py
+++ b/src/searchat/cli/compact_cmd.py
@@ -1,0 +1,113 @@
+"""CLI command: searchat compact — verified copy-compaction of the DuckDB store.
+
+Reclaims dead blocks left behind by append-only checkpoint churn via the
+checkpoint -> attach -> COPY FROM DATABASE -> verify -> atomic-rename
+sequence in services/compaction.py. Runs unconditionally when invoked --
+no bloat-ratio gating, unlike the auto-trigger wired into graceful
+shutdown (see services.compaction.run_auto_compact_if_needed). Isolated
+in a subprocess by default so a DuckDB FATAL cannot corrupt the original
+file or take down this CLI process.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from searchat.services.compaction import CompactionResult
+
+
+def _format_bytes(num_bytes: int | float) -> str:
+    value = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(value) < 1024.0:
+            return f"{value:.1f} {unit}"
+        value /= 1024.0
+    return f"{value:.1f} PB"
+
+
+def _result_to_dict(result: "CompactionResult") -> dict[str, object]:
+    verification = None
+    if result.verification is not None:
+        verification = {
+            "passed": result.verification.passed,
+            "row_counts_match": result.verification.row_counts_match,
+            "index_names_match": result.verification.index_names_match,
+            "fts_probe_match": result.verification.fts_probe_match,
+            "vector_probe_match": result.verification.vector_probe_match,
+            "symmetric_diff_match": result.verification.symmetric_diff_match,
+            "mismatches": list(result.verification.mismatches),
+        }
+    return {
+        "success": result.success,
+        "original_path": str(result.original_path),
+        "original_size_bytes": result.original_size_bytes,
+        "compacted_size_bytes": result.compacted_size_bytes,
+        "bytes_reclaimed": result.bytes_reclaimed,
+        "preserved_original_path": (
+            str(result.preserved_original_path) if result.preserved_original_path else None
+        ),
+        "verification": verification,
+        "error": result.error,
+        "duration_seconds": result.duration_seconds,
+    }
+
+
+def run_compact(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="searchat compact",
+        description=(
+            "Reclaim dead DuckDB blocks via verified copy-compaction. Never "
+            "mutates the database until the compacted copy is proven "
+            "query-identical. Runs unconditionally -- for the bloat-ratio "
+            "gated check used on shutdown, see the auto-trigger."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Output raw JSON instead of a summary.")
+    parser.add_argument(
+        "--in-process",
+        action="store_true",
+        help=(
+            "Run compaction in this process instead of an isolated "
+            "subprocess. Debugging only -- a DuckDB FATAL would take down "
+            "this CLI process and skip the crash-safety guarantee."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    from searchat.config import Config, PathResolver
+    from searchat.services.compaction import compact_database, record_compaction_completed
+
+    config = Config.load()
+    search_dir = PathResolver.get_shared_search_dir(config)
+    db_path = config.storage.resolve_duckdb_path(search_dir)
+
+    try:
+        result = compact_database(db_path, subprocess_isolated=not args.in_process)
+    except Exception as exc:
+        print(f"Error: failed to compact database: {exc}", file=sys.stderr)
+        return 1
+
+    if result.success:
+        record_compaction_completed(search_dir)
+
+    if args.json:
+        print(json.dumps(_result_to_dict(result), indent=2))
+        return 0 if result.success else 1
+
+    from rich.console import Console
+
+    console = Console()
+    if not result.success:
+        console.print("[bold red]Compaction failed[/bold red]")
+        console.print(f"  {result.error}")
+        return 1
+
+    console.print("[bold green]Compaction complete[/bold green]")
+    console.print(f"  Original size:   {_format_bytes(result.original_size_bytes)}")
+    console.print(f"  Compacted size:  {_format_bytes(result.compacted_size_bytes)}")
+    console.print(f"  Bytes reclaimed: {_format_bytes(result.bytes_reclaimed)}")
+    console.print(f"  Time:            {result.duration_seconds:.2f}s")
+    return 0

--- a/src/searchat/cli/compact_cmd.py
+++ b/src/searchat/cli/compact_cmd.py
@@ -75,6 +75,18 @@ def run_compact(argv: list[str]) -> int:
             "this CLI process and skip the crash-safety guarantee."
         ),
     )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Seconds to wait for the compaction subprocess before "
+            "terminating it as hung. Defaults to "
+            "compaction.max_duration_seconds in config (the same bound "
+            "the shutdown auto-trigger uses). Pass 0 to wait indefinitely."
+        ),
+    )
     args = parser.parse_args(argv)
 
     from searchat.config import Config, PathResolver
@@ -84,8 +96,14 @@ def run_compact(argv: list[str]) -> int:
     search_dir = PathResolver.get_shared_search_dir(config)
     db_path = config.storage.resolve_duckdb_path(search_dir)
 
+    timeout_seconds = args.timeout if args.timeout is not None else config.compaction.max_duration_seconds
+    if timeout_seconds == 0:
+        timeout_seconds = None
+
     try:
-        result = compact_database(db_path, subprocess_isolated=not args.in_process)
+        result = compact_database(
+            db_path, subprocess_isolated=not args.in_process, timeout_seconds=timeout_seconds
+        )
     except Exception as exc:
         print(f"Error: failed to compact database: {exc}", file=sys.stderr)
         return 1

--- a/src/searchat/cli/main.py
+++ b/src/searchat/cli/main.py
@@ -455,6 +455,11 @@ def main():
 
             raise SystemExit(run_reingest_sources(argv[1:]))
 
+        if argv and argv[0] == "compact":
+            from searchat.cli.compact_cmd import run_compact
+
+            raise SystemExit(run_compact(argv[1:]))
+
         if argv and argv[0] == "ci-check":
             from searchat.cli.ci_check_cmd import run_ci_check
 
@@ -493,6 +498,7 @@ def main():
             print("  searchat doctor [--json]")
             print("  searchat rebuild-derived [--force] [--json]")
             print("  searchat reingest-sources [--force]")
+            print("  searchat compact [--json] [--in-process]")
             print("  searchat ci-check [--fail-on-contradictions] [--fail-on-staleness-threshold FLOAT]")
             print()
             return

--- a/src/searchat/config/constants.py
+++ b/src/searchat/config/constants.py
@@ -336,6 +336,17 @@ ENV_RERANKING_TOP_K = "SEARCHAT_RERANKING_TOP_K"
 ENV_CORS_ORIGINS = "SEARCHAT_CORS_ORIGINS"
 
 # ============================================================================
+# Compaction Defaults (M3 -- searchat compact)
+# ============================================================================
+
+DEFAULT_COMPACTION_AUTO_TRIGGER_RATIO = 3.0
+DEFAULT_COMPACTION_MIN_INTERVAL_DAYS = 7
+
+# Environment variable names for compaction
+ENV_COMPACTION_AUTO_TRIGGER_RATIO = "SEARCHAT_COMPACTION_AUTO_TRIGGER_RATIO"
+ENV_COMPACTION_MIN_INTERVAL_DAYS = "SEARCHAT_COMPACTION_MIN_INTERVAL_DAYS"
+
+# ============================================================================
 # Query Expansion / Synonyms
 # ============================================================================
 

--- a/src/searchat/config/constants.py
+++ b/src/searchat/config/constants.py
@@ -341,10 +341,15 @@ ENV_CORS_ORIGINS = "SEARCHAT_CORS_ORIGINS"
 
 DEFAULT_COMPACTION_AUTO_TRIGGER_RATIO = 3.0
 DEFAULT_COMPACTION_MIN_INTERVAL_DAYS = 7
+# Generous safety bound, not a normal-operation limit: large enough to never
+# trip during legitimate use on typical local stores, but bounds a genuinely
+# hung compaction subprocess so it cannot block graceful shutdown forever.
+DEFAULT_COMPACTION_MAX_DURATION_SECONDS = 1800.0
 
 # Environment variable names for compaction
 ENV_COMPACTION_AUTO_TRIGGER_RATIO = "SEARCHAT_COMPACTION_AUTO_TRIGGER_RATIO"
 ENV_COMPACTION_MIN_INTERVAL_DAYS = "SEARCHAT_COMPACTION_MIN_INTERVAL_DAYS"
+ENV_COMPACTION_MAX_DURATION_SECONDS = "SEARCHAT_COMPACTION_MAX_DURATION_SECONDS"
 
 # ============================================================================
 # Query Expansion / Synonyms

--- a/src/searchat/config/settings.default.toml
+++ b/src/searchat/config/settings.default.toml
@@ -116,3 +116,7 @@ min_query_length = 8
 # min_interval_days ago.
 auto_trigger_ratio = 3.0
 min_interval_days = 7
+# Safety bound on the isolated compaction subprocess: terminated (then
+# killed) if it runs longer than this, rather than blocking the CLI or
+# graceful shutdown forever.
+max_duration_seconds = 1800.0

--- a/src/searchat/config/settings.default.toml
+++ b/src/searchat/config/settings.default.toml
@@ -108,3 +108,11 @@ notifications_enabled = true
 notifications_backend = "auto"
 max_suggestions = 3
 min_query_length = 8
+
+[compaction]
+# searchat compact -- verified copy-compaction of the DuckDB store.
+# Auto-triggers on graceful shutdown when file_size / live_data exceeds
+# auto_trigger_ratio AND the last compaction was more than
+# min_interval_days ago.
+auto_trigger_ratio = 3.0
+min_interval_days = 7

--- a/src/searchat/config/settings.py
+++ b/src/searchat/config/settings.py
@@ -160,8 +160,10 @@ from .constants import (
     # Compaction
     DEFAULT_COMPACTION_AUTO_TRIGGER_RATIO,
     DEFAULT_COMPACTION_MIN_INTERVAL_DAYS,
+    DEFAULT_COMPACTION_MAX_DURATION_SECONDS,
     ENV_COMPACTION_AUTO_TRIGGER_RATIO,
     ENV_COMPACTION_MIN_INTERVAL_DAYS,
+    ENV_COMPACTION_MAX_DURATION_SECONDS,
 )
 
 if TYPE_CHECKING:
@@ -701,17 +703,37 @@ class CompactionConfig:
     """Auto-trigger thresholds for `searchat compact` (M3)."""
     auto_trigger_ratio: float
     min_interval_days: int
+    max_duration_seconds: float
 
     @classmethod
     def from_dict(cls, data: dict) -> "CompactionConfig":
         return cls(
-            auto_trigger_ratio=_get_env_float(
-                ENV_COMPACTION_AUTO_TRIGGER_RATIO,
-                float(data.get("auto_trigger_ratio", DEFAULT_COMPACTION_AUTO_TRIGGER_RATIO)),
+            # Floored, not raised: a misconfigured ratio below 1.0 (no
+            # such thing as "reclaimable" below the live-data floor) or a
+            # negative interval/duration would otherwise silently defeat
+            # the gate it's supposed to enforce rather than fail loudly --
+            # clamping is the safe direction here, and no other section in
+            # this file validates its TOML input either.
+            auto_trigger_ratio=max(
+                _get_env_float(
+                    ENV_COMPACTION_AUTO_TRIGGER_RATIO,
+                    float(data.get("auto_trigger_ratio", DEFAULT_COMPACTION_AUTO_TRIGGER_RATIO)),
+                ),
+                1.0,
             ),
-            min_interval_days=_get_env_int(
-                ENV_COMPACTION_MIN_INTERVAL_DAYS,
-                int(data.get("min_interval_days", DEFAULT_COMPACTION_MIN_INTERVAL_DAYS)),
+            min_interval_days=max(
+                _get_env_int(
+                    ENV_COMPACTION_MIN_INTERVAL_DAYS,
+                    int(data.get("min_interval_days", DEFAULT_COMPACTION_MIN_INTERVAL_DAYS)),
+                ),
+                0,
+            ),
+            max_duration_seconds=max(
+                _get_env_float(
+                    ENV_COMPACTION_MAX_DURATION_SECONDS,
+                    float(data.get("max_duration_seconds", DEFAULT_COMPACTION_MAX_DURATION_SECONDS)),
+                ),
+                1.0,
             ),
         )
 

--- a/src/searchat/config/settings.py
+++ b/src/searchat/config/settings.py
@@ -157,6 +157,11 @@ from .constants import (
     ENV_DISTILLATION_MAX_PLY_LENGTH,
     ENV_DISTILLATION_MIN_EXCHANGE_CHARS,
     ENV_PALACE_ENABLED,
+    # Compaction
+    DEFAULT_COMPACTION_AUTO_TRIGGER_RATIO,
+    DEFAULT_COMPACTION_MIN_INTERVAL_DAYS,
+    ENV_COMPACTION_AUTO_TRIGGER_RATIO,
+    ENV_COMPACTION_MIN_INTERVAL_DAYS,
 )
 
 if TYPE_CHECKING:
@@ -692,6 +697,26 @@ class RerankingConfig:
 
 
 @dataclass
+class CompactionConfig:
+    """Auto-trigger thresholds for `searchat compact` (M3)."""
+    auto_trigger_ratio: float
+    min_interval_days: int
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "CompactionConfig":
+        return cls(
+            auto_trigger_ratio=_get_env_float(
+                ENV_COMPACTION_AUTO_TRIGGER_RATIO,
+                float(data.get("auto_trigger_ratio", DEFAULT_COMPACTION_AUTO_TRIGGER_RATIO)),
+            ),
+            min_interval_days=_get_env_int(
+                ENV_COMPACTION_MIN_INTERVAL_DAYS,
+                int(data.get("min_interval_days", DEFAULT_COMPACTION_MIN_INTERVAL_DAYS)),
+            ),
+        )
+
+
+@dataclass
 class ExpertiseConfig:
     enabled: bool
     auto_extract: bool
@@ -912,6 +937,7 @@ class Config:
     snapshots: SnapshotsConfig
     daemon: DaemonConfig
     reranking: RerankingConfig
+    compaction: CompactionConfig
     storage: StorageConfig
     server: ServerConfig
     expertise: ExpertiseConfig
@@ -996,6 +1022,7 @@ class Config:
             snapshots=SnapshotsConfig.from_dict(data.get("snapshots", {})),
             daemon=DaemonConfig.from_dict(data.get("daemon", {})),
             reranking=RerankingConfig.from_dict(data.get("reranking", {})),
+            compaction=CompactionConfig.from_dict(data.get("compaction", {})),
             storage=StorageConfig.from_dict(data.get("storage", {})),
             server=ServerConfig.from_dict(data.get("server", {})),
             expertise=ExpertiseConfig.from_dict(data.get("expertise", {})),

--- a/src/searchat/services/compaction.py
+++ b/src/searchat/services/compaction.py
@@ -28,6 +28,7 @@ zero-row symmetric diff on `conversations`.
 """
 from __future__ import annotations
 
+import json
 import logging
 import multiprocessing
 import multiprocessing.synchronize
@@ -615,3 +616,125 @@ def compact_database(
         ),
         duration_seconds=time.perf_counter() - start,
     )
+
+
+# ---------------------------------------------------------------------------
+# Auto-trigger: bloat-ratio + interval gated compaction, wired into
+# graceful shutdown (M3 acceptance: fires only above ratio 3).
+# ---------------------------------------------------------------------------
+
+_COMPACTION_STATE_FILE = "compaction_state.json"
+
+
+@dataclass(frozen=True)
+class CompactionState:
+    """Persisted record of the most recent successful compaction."""
+
+    last_compaction_at: datetime | None
+
+
+def _compaction_state_path(search_dir: Path) -> Path:
+    return Path(search_dir) / "data" / _COMPACTION_STATE_FILE
+
+
+def read_compaction_state(search_dir: Path) -> CompactionState:
+    """Read the last-successful-compaction timestamp sidecar.
+
+    Missing, unreadable, or malformed state is treated as "never
+    compacted" -- the conservative choice that lets the auto-trigger
+    evaluate the ratio rather than silently never firing.
+    """
+    path = _compaction_state_path(search_dir)
+    if not path.exists():
+        return CompactionState(last_compaction_at=None)
+    try:
+        raw = json.loads(path.read_text())
+        stamp = raw.get("last_compaction_at")
+        if not stamp:
+            return CompactionState(last_compaction_at=None)
+        return CompactionState(last_compaction_at=datetime.fromisoformat(stamp))
+    except (OSError, ValueError) as exc:
+        log.warning("Failed to read compaction state at %s: %s", path, exc)
+        return CompactionState(last_compaction_at=None)
+
+
+def record_compaction_completed(search_dir: Path, *, at: datetime | None = None) -> None:
+    """Record a successful compaction's completion time.
+
+    Called after every successful `compact_database` run, whether
+    triggered manually (`searchat compact`) or automatically on shutdown,
+    so either resets the auto-trigger's `min_interval_days` clock.
+    """
+    path = _compaction_state_path(search_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stamp = (at or datetime.now(timezone.utc)).isoformat()
+    path.write_text(json.dumps({"last_compaction_at": stamp}))
+
+
+def should_auto_compact(
+    *,
+    bloat_ratio: float,
+    last_compaction_at: datetime | None,
+    auto_trigger_ratio: float,
+    min_interval_days: int,
+    now: datetime | None = None,
+) -> bool:
+    """Pure decision function: fire only when the file is bloated beyond
+    `auto_trigger_ratio` AND the last compaction (if any) was more than
+    `min_interval_days` ago."""
+    if bloat_ratio <= auto_trigger_ratio:
+        return False
+    if last_compaction_at is None:
+        return True
+    elapsed_days = ((now or datetime.now(timezone.utc)) - last_compaction_at).total_seconds() / 86400
+    return elapsed_days >= min_interval_days
+
+
+def run_auto_compact_if_needed(
+    db_path: Path,
+    search_dir: Path,
+    *,
+    auto_trigger_ratio: float,
+    min_interval_days: int,
+) -> CompactionResult | None:
+    """Consult M1's bloat ratio and the compaction-state sidecar; compact
+    only when both thresholds are exceeded.
+
+    Returns `None` when the auto-trigger does not fire, including when
+    `db_path` does not exist yet. Never raises: intended for a shutdown
+    path where a compaction check must never prevent shutdown.
+    """
+    from searchat.services.storage_health import (
+        compute_bloat_ratio,
+        estimate_live_data_size,
+        inspect_database_size,
+    )
+
+    db_path = Path(db_path)
+    if not db_path.exists():
+        return None
+
+    try:
+        size_info = inspect_database_size(db_path)
+        live_bytes = estimate_live_data_size(db_path)
+        ratio = compute_bloat_ratio(size_info.total_bytes, live_bytes)
+        state = read_compaction_state(search_dir)
+        if not should_auto_compact(
+            bloat_ratio=ratio,
+            last_compaction_at=state.last_compaction_at,
+            auto_trigger_ratio=auto_trigger_ratio,
+            min_interval_days=min_interval_days,
+        ):
+            return None
+
+        log.info(
+            "Auto-compact triggered for %s: bloat ratio %.2f > %.2f (last compaction: %s)",
+            db_path, ratio, auto_trigger_ratio, state.last_compaction_at or "never",
+        )
+        result = compact_database(db_path)
+        if result.success:
+            record_compaction_completed(search_dir)
+        return result
+    except Exception:  # noqa: BLE001 - a shutdown-path check must never raise
+        log.exception("Auto-compact check failed for %s; leaving database untouched", db_path)
+        return None

--- a/src/searchat/services/compaction.py
+++ b/src/searchat/services/compaction.py
@@ -696,6 +696,7 @@ def run_auto_compact_if_needed(
     *,
     auto_trigger_ratio: float,
     min_interval_days: int,
+    timeout_seconds: float | None = None,
 ) -> CompactionResult | None:
     """Consult M1's bloat ratio and the compaction-state sidecar; compact
     only when both thresholds are exceeded.
@@ -703,6 +704,10 @@ def run_auto_compact_if_needed(
     Returns `None` when the auto-trigger does not fire, including when
     `db_path` does not exist yet. Never raises: intended for a shutdown
     path where a compaction check must never prevent shutdown.
+
+    `timeout_seconds` is forwarded to `compact_database` -- bounding a
+    hung child here matters even more than usual, since this function is
+    called from the graceful-shutdown path.
     """
     from searchat.services.storage_health import (
         compute_bloat_ratio,
@@ -731,7 +736,7 @@ def run_auto_compact_if_needed(
             "Auto-compact triggered for %s: bloat ratio %.2f > %.2f (last compaction: %s)",
             db_path, ratio, auto_trigger_ratio, state.last_compaction_at or "never",
         )
-        result = compact_database(db_path)
+        result = compact_database(db_path, timeout_seconds=timeout_seconds)
         if result.success:
             record_compaction_completed(search_dir)
         return result

--- a/tests/unit/services/test_compaction.py
+++ b/tests/unit/services/test_compaction.py
@@ -7,7 +7,7 @@ import queue
 import subprocess
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -631,3 +631,159 @@ class TestSubprocessIsolation:
         assert "subprocess exited abnormally" in result.error
         assert "-9" in result.error
         assert _sha256(db_path) == checksum_before
+
+
+# ---------------------------------------------------------------------------
+# Auto-trigger: should_auto_compact (pure), compaction-state sidecar, and
+# run_auto_compact_if_needed (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestShouldAutoCompact:
+    def test_ratio_at_or_below_threshold_never_fires(self) -> None:
+        assert comp.should_auto_compact(
+            bloat_ratio=3.0, last_compaction_at=None, auto_trigger_ratio=3.0, min_interval_days=7
+        ) is False
+        assert comp.should_auto_compact(
+            bloat_ratio=2.9, last_compaction_at=None, auto_trigger_ratio=3.0, min_interval_days=7
+        ) is False
+
+    def test_ratio_above_threshold_fires_when_never_compacted(self) -> None:
+        assert comp.should_auto_compact(
+            bloat_ratio=3.1, last_compaction_at=None, auto_trigger_ratio=3.0, min_interval_days=7
+        ) is True
+
+    def test_ratio_above_threshold_blocked_by_recent_compaction(self) -> None:
+        now = datetime(2026, 7, 2, tzinfo=timezone.utc)
+        recent = now - timedelta(days=1)
+        assert comp.should_auto_compact(
+            bloat_ratio=10.0,
+            last_compaction_at=recent,
+            auto_trigger_ratio=3.0,
+            min_interval_days=7,
+            now=now,
+        ) is False
+
+    def test_ratio_above_threshold_fires_after_interval_elapses(self) -> None:
+        now = datetime(2026, 7, 2, tzinfo=timezone.utc)
+        old = now - timedelta(days=8)
+        assert comp.should_auto_compact(
+            bloat_ratio=10.0,
+            last_compaction_at=old,
+            auto_trigger_ratio=3.0,
+            min_interval_days=7,
+            now=now,
+        ) is True
+
+    def test_exact_interval_boundary_fires(self) -> None:
+        now = datetime(2026, 7, 2, tzinfo=timezone.utc)
+        exactly_seven_days_ago = now - timedelta(days=7)
+        assert comp.should_auto_compact(
+            bloat_ratio=10.0,
+            last_compaction_at=exactly_seven_days_ago,
+            auto_trigger_ratio=3.0,
+            min_interval_days=7,
+            now=now,
+        ) is True
+
+
+class TestCompactionState:
+    def test_missing_state_returns_none(self, tmp_path: Path) -> None:
+        state = comp.read_compaction_state(tmp_path)
+        assert state.last_compaction_at is None
+
+    def test_record_then_read_round_trips(self, tmp_path: Path) -> None:
+        at = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+        comp.record_compaction_completed(tmp_path, at=at)
+
+        state = comp.read_compaction_state(tmp_path)
+
+        assert state.last_compaction_at == at
+
+    def test_malformed_state_file_degrades_to_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "data" / "compaction_state.json"
+        path.parent.mkdir(parents=True)
+        path.write_text("not json")
+
+        state = comp.read_compaction_state(tmp_path)
+
+        assert state.last_compaction_at is None
+
+
+class TestRunAutoCompactIfNeeded:
+    """Bloat ratio is controlled by patching compute_bloat_ratio's return
+    value rather than depending on a fixture's exact (variable) real
+    bloat, so ratio-threshold behavior is tested deterministically while
+    inspect_database_size/estimate_live_data_size still run for real
+    against a real fixture, exercising the actual integration wiring."""
+
+    def test_missing_database_returns_none(self, tmp_path: Path) -> None:
+        result = comp.run_auto_compact_if_needed(
+            tmp_path / "missing.duckdb", tmp_path, auto_trigger_ratio=3.0, min_interval_days=7
+        )
+        assert result is None
+
+    def test_fires_and_records_state_above_threshold_never_compacted(self, tmp_path: Path) -> None:
+        search_dir = tmp_path
+        db_path = search_dir / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+
+        with patch("searchat.services.storage_health.compute_bloat_ratio", return_value=3.5):
+            result = comp.run_auto_compact_if_needed(
+                db_path, search_dir, auto_trigger_ratio=3.0, min_interval_days=7
+            )
+
+        assert result is not None
+        assert result.success is True
+        state = comp.read_compaction_state(search_dir)
+        assert state.last_compaction_at is not None
+
+    def test_does_not_fire_at_or_below_threshold(self, tmp_path: Path) -> None:
+        search_dir = tmp_path
+        db_path = search_dir / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+        checksum_before = _sha256(db_path)
+
+        for ratio in (3.0, 2.5):
+            with patch("searchat.services.storage_health.compute_bloat_ratio", return_value=ratio):
+                result = comp.run_auto_compact_if_needed(
+                    db_path, search_dir, auto_trigger_ratio=3.0, min_interval_days=7
+                )
+            assert result is None, f"must not fire at ratio={ratio}"
+
+        assert _sha256(db_path) == checksum_before
+        assert comp.read_compaction_state(search_dir).last_compaction_at is None
+
+    def test_does_not_fire_when_recently_compacted_even_if_bloated(self, tmp_path: Path) -> None:
+        search_dir = tmp_path
+        db_path = search_dir / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+        comp.record_compaction_completed(search_dir, at=datetime.now(timezone.utc))
+        checksum_before = _sha256(db_path)
+
+        with patch("searchat.services.storage_health.compute_bloat_ratio", return_value=10.0):
+            result = comp.run_auto_compact_if_needed(
+                db_path, search_dir, auto_trigger_ratio=3.0, min_interval_days=7
+            )
+
+        assert result is None
+        assert _sha256(db_path) == checksum_before
+
+    def test_never_raises_on_internal_error(self, tmp_path: Path) -> None:
+        search_dir = tmp_path
+        db_path = search_dir / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+
+        with patch(
+            "searchat.services.storage_health.inspect_database_size",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = comp.run_auto_compact_if_needed(
+                db_path, search_dir, auto_trigger_ratio=3.0, min_interval_days=7
+            )
+
+        assert result is None

--- a/tests/unit/test_cli_compact.py
+++ b/tests/unit/test_cli_compact.py
@@ -1,0 +1,189 @@
+"""Unit tests for `searchat compact` CLI command."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from searchat.services.compaction import CompactionResult, VerificationResult
+
+
+def _cfg(search_dir: Path) -> SimpleNamespace:
+    """Minimal Config stand-in exposing only what run_compact touches."""
+    return SimpleNamespace(
+        storage=SimpleNamespace(resolve_duckdb_path=lambda _search_dir: search_dir / "data" / "searchat.duckdb")
+    )
+
+
+def _success_result(db_path: Path) -> CompactionResult:
+    return CompactionResult(
+        success=True,
+        original_path=db_path,
+        original_size_bytes=6_000_000,
+        compacted_size_bytes=1_500_000,
+        bytes_reclaimed=4_500_000,
+        preserved_original_path=None,
+        verification=VerificationResult(
+            passed=True,
+            row_counts_match=True,
+            index_names_match=True,
+            fts_probe_match=True,
+            vector_probe_match=True,
+            symmetric_diff_match=True,
+            mismatches=(),
+        ),
+        error=None,
+        duration_seconds=1.23,
+    )
+
+
+def _failure_result(db_path: Path) -> CompactionResult:
+    return CompactionResult(
+        success=False,
+        original_path=db_path,
+        original_size_bytes=6_000_000,
+        compacted_size_bytes=0,
+        bytes_reclaimed=0,
+        preserved_original_path=None,
+        verification=None,
+        error="Database is in use by another process; refusing to compact",
+        duration_seconds=0.05,
+    )
+
+
+def test_compact_help_text(capsys) -> None:
+    from searchat.cli.compact_cmd import run_compact
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_compact(["--help"])
+    assert exc_info.value.code == 0
+
+    captured = capsys.readouterr()
+    assert "compact" in captured.out.lower()
+    assert "--json" in captured.out
+    assert "--in-process" in captured.out
+
+
+def test_compact_success_summary_output(temp_search_dir: Path, capsys) -> None:
+    from searchat.cli.compact_cmd import run_compact
+
+    db_path = temp_search_dir / "data" / "searchat.duckdb"
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch(
+            "searchat.services.compaction.compact_database", return_value=_success_result(db_path)
+        ) as mock_compact,
+        patch("searchat.services.compaction.record_compaction_completed") as mock_record,
+    ):
+        result = run_compact([])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Compaction complete" in captured.out
+    assert "Bytes reclaimed" in captured.out
+    mock_compact.assert_called_once_with(db_path, subprocess_isolated=True)
+    mock_record.assert_called_once_with(temp_search_dir)
+
+
+def test_compact_success_json_output(temp_search_dir: Path, capsys) -> None:
+    from searchat.cli.compact_cmd import run_compact
+
+    db_path = temp_search_dir / "data" / "searchat.duckdb"
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch("searchat.services.compaction.compact_database", return_value=_success_result(db_path)),
+        patch("searchat.services.compaction.record_compaction_completed"),
+    ):
+        result = run_compact(["--json"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    payload = json.loads(captured.out)
+    assert payload["success"] is True
+    assert payload["bytes_reclaimed"] == 4_500_000
+    assert payload["verification"]["passed"] is True
+    assert payload["error"] is None
+
+
+def test_compact_failure_summary_output_does_not_record_state(
+    temp_search_dir: Path, capsys
+) -> None:
+    from searchat.cli.compact_cmd import run_compact
+
+    db_path = temp_search_dir / "data" / "searchat.duckdb"
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch("searchat.services.compaction.compact_database", return_value=_failure_result(db_path)),
+        patch("searchat.services.compaction.record_compaction_completed") as mock_record,
+    ):
+        result = run_compact([])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "Compaction failed" in captured.out
+    assert "in use by another process" in captured.out
+    mock_record.assert_not_called()
+
+
+def test_compact_failure_json_output(temp_search_dir: Path, capsys) -> None:
+    from searchat.cli.compact_cmd import run_compact
+
+    db_path = temp_search_dir / "data" / "searchat.duckdb"
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch("searchat.services.compaction.compact_database", return_value=_failure_result(db_path)),
+        patch("searchat.services.compaction.record_compaction_completed"),
+    ):
+        result = run_compact(["--json"])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    payload = json.loads(captured.out)
+    assert payload["success"] is False
+    assert "in use by another process" in payload["error"]
+
+
+def test_compact_returns_one_and_prints_error_on_exception(
+    temp_search_dir: Path, capsys
+) -> None:
+    from searchat.cli.compact_cmd import run_compact
+
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch(
+            "searchat.services.compaction.compact_database",
+            side_effect=RuntimeError("disk read failed"),
+        ),
+    ):
+        result = run_compact([])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert "disk read failed" in captured.err
+
+
+def test_compact_in_process_flag_disables_subprocess_isolation(
+    temp_search_dir: Path, capsys
+) -> None:
+    from searchat.cli.compact_cmd import run_compact
+
+    db_path = temp_search_dir / "data" / "searchat.duckdb"
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch(
+            "searchat.services.compaction.compact_database", return_value=_success_result(db_path)
+        ) as mock_compact,
+        patch("searchat.services.compaction.record_compaction_completed"),
+    ):
+        run_compact(["--in-process"])
+
+    mock_compact.assert_called_once_with(db_path, subprocess_isolated=False)

--- a/tests/unit/test_cli_compact.py
+++ b/tests/unit/test_cli_compact.py
@@ -14,7 +14,8 @@ from searchat.services.compaction import CompactionResult, VerificationResult
 def _cfg(search_dir: Path) -> SimpleNamespace:
     """Minimal Config stand-in exposing only what run_compact touches."""
     return SimpleNamespace(
-        storage=SimpleNamespace(resolve_duckdb_path=lambda _search_dir: search_dir / "data" / "searchat.duckdb")
+        storage=SimpleNamespace(resolve_duckdb_path=lambda _search_dir: search_dir / "data" / "searchat.duckdb"),
+        compaction=SimpleNamespace(max_duration_seconds=1800.0),
     )
 
 
@@ -26,6 +27,7 @@ def _success_result(db_path: Path) -> CompactionResult:
         compacted_size_bytes=1_500_000,
         bytes_reclaimed=4_500_000,
         preserved_original_path=None,
+        quarantined_path=None,
         verification=VerificationResult(
             passed=True,
             row_counts_match=True,
@@ -48,6 +50,7 @@ def _failure_result(db_path: Path) -> CompactionResult:
         compacted_size_bytes=0,
         bytes_reclaimed=0,
         preserved_original_path=None,
+        quarantined_path=None,
         verification=None,
         error="Database is in use by another process; refusing to compact",
         duration_seconds=0.05,
@@ -65,6 +68,7 @@ def test_compact_help_text(capsys) -> None:
     assert "compact" in captured.out.lower()
     assert "--json" in captured.out
     assert "--in-process" in captured.out
+    assert "--timeout" in captured.out
 
 
 def test_compact_success_summary_output(temp_search_dir: Path, capsys) -> None:
@@ -85,7 +89,7 @@ def test_compact_success_summary_output(temp_search_dir: Path, capsys) -> None:
     assert result == 0
     assert "Compaction complete" in captured.out
     assert "Bytes reclaimed" in captured.out
-    mock_compact.assert_called_once_with(db_path, subprocess_isolated=True)
+    mock_compact.assert_called_once_with(db_path, subprocess_isolated=True, timeout_seconds=1800.0)
     mock_record.assert_called_once_with(temp_search_dir)
 
 
@@ -186,4 +190,40 @@ def test_compact_in_process_flag_disables_subprocess_isolation(
     ):
         run_compact(["--in-process"])
 
-    mock_compact.assert_called_once_with(db_path, subprocess_isolated=False)
+    mock_compact.assert_called_once_with(db_path, subprocess_isolated=False, timeout_seconds=1800.0)
+
+
+def test_compact_timeout_flag_overrides_config_default(
+    temp_search_dir: Path, capsys
+) -> None:
+    from searchat.cli.compact_cmd import run_compact
+
+    db_path = temp_search_dir / "data" / "searchat.duckdb"
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch(
+            "searchat.services.compaction.compact_database", return_value=_success_result(db_path)
+        ) as mock_compact,
+        patch("searchat.services.compaction.record_compaction_completed"),
+    ):
+        run_compact(["--timeout", "45"])
+
+    mock_compact.assert_called_once_with(db_path, subprocess_isolated=True, timeout_seconds=45.0)
+
+
+def test_compact_timeout_zero_means_unbounded(temp_search_dir: Path, capsys) -> None:
+    from searchat.cli.compact_cmd import run_compact
+
+    db_path = temp_search_dir / "data" / "searchat.duckdb"
+    with (
+        patch("searchat.config.Config.load", return_value=_cfg(temp_search_dir)),
+        patch("searchat.config.PathResolver.get_shared_search_dir", return_value=temp_search_dir),
+        patch(
+            "searchat.services.compaction.compact_database", return_value=_success_result(db_path)
+        ) as mock_compact,
+        patch("searchat.services.compaction.record_compaction_completed"),
+    ):
+        run_compact(["--timeout", "0"])
+
+    mock_compact.assert_called_once_with(db_path, subprocess_isolated=True, timeout_seconds=None)


### PR DESCRIPTION
## Stack

Stack-Id: `m3-compaction`
Base: `feat/compaction-subprocess` (#94)
Position: 3/3 (leaf)

1. `feat/compaction-engine` -> #93
2. `feat/compaction-subprocess` -> #94
3. `feat/compaction-cli` -> this PR

Depends on: #94
Upstack: none (leaf)

## Summary

Part 3/3 of M3 — completes the milestone.

- **`searchat compact` CLI** (`cli/compact_cmd.py`): runs `compact_database()` unconditionally when invoked (manual intent — no bloat-ratio gating). `--json` for scripting, `--in-process` to bypass subprocess isolation for debugging, `--timeout SECONDS` (default: config, `0` = unbounded). Wired into `cli/main.py` dispatch + help text.
- **Auto-trigger** (`services/compaction.py`): `should_auto_compact()` is a pure decision function — fires only when the bloat ratio exceeds `auto_trigger_ratio` (default 3.0, strict `>`) AND the last compaction was more than `min_interval_days` ago (default 7). Last-compaction time is tracked in a `compaction_state.json` sidecar rather than a DuckDB table, since it must survive independently of the file compaction replaces. `run_auto_compact_if_needed()` ties this to M1's bloat helpers and never raises.
- **Config** (`config/settings.py`, `settings.default.toml`): new `[compaction]` section — `auto_trigger_ratio`, `min_interval_days`, `max_duration_seconds` (the subprocess timeout bound, see PR 2).
- **Shutdown wiring** (`api/dependencies.py`, `api/routers/admin.py`, `api/routers/fragments.py`): `maybe_auto_compact_on_shutdown()` is the single shared implementation both shutdown endpoints call.

A manual `searchat compact` run also records completion state, resetting the auto-trigger's interval clock.

## Review round

An independent review pass found a **real event-loop-blocking bug**: `api/routers/fragments.py`'s HTMX shutdown handler called the blocking `maybe_auto_compact_on_shutdown()` directly inside an `asyncio.create_task`-scheduled coroutine, stalling every other in-flight request on the server for the duration of any auto-triggered compaction. The sibling REST `/api/shutdown` endpoint was unaffected (FastAPI's `BackgroundTasks` already offloads sync functions to a threadpool) — the two endpoints looked like twins but weren't. Fixed by wrapping the call in `asyncio.to_thread`. Also added `compaction.max_duration_seconds` (see PR 2) and wired it into both the CLI (new `--timeout` flag) and the auto-trigger, since a hung compaction would otherwise block the shutdown path this fix was written to unblock.

## Validation

- `uv run pytest tests/unit/services/test_compaction.py tests/unit/test_cli_compact.py -v --tb=short --no-cov` — 56 passed
- `uv run pytest -v --tb=short` — 2138 passed, 1 skipped, 81.79% coverage (>= 80% gate)
- `uv run ruff check` — clean
- Manual smoke test: `searchat compact --json` against a real fixture DB (real subprocess, real verification) — success, verification all-pass, `compaction_state.json` written
- `Config.load().compaction.{auto_trigger_ratio,min_interval_days,max_duration_seconds}` verified to resolve from `settings.default.toml`
- CI green on ubuntu/macos/windows x py3.10/3.11/3.12 + build

## M3 acceptance (DEVELOPMENT_PLAN.md §4)

- Fixture DB with synthetic bloat compacts to a byte-different but query-identical file (row counts, index list, `match_bm25`/HNSW probes all match) — PR 1's `test_compacts_bloated_fixture_to_query_identical_file`.
- Killing the compaction subprocess mid-run leaves the original file's mtime and checksum unchanged — PR 2's `test_kill_subprocess_mid_compaction_leaves_original_untouched`.
- Auto-trigger fires only above ratio 3, confirmed by both a >3 and a <3 fixture — this PR's `TestShouldAutoCompact` + `TestRunAutoCompactIfNeeded::test_does_not_fire_at_or_below_threshold`.
- Compaction never mutates the original file until the replacement is fully verified — traced through every failure branch of `_compact_database_in_process`/`compact_database`, including the post-swap-rollback and subprocess-timeout paths added in the review round.
