### PR TITLE
feat(services): default backups to source-of-truth-only

### DIFF
--- a/src/searchat/services/backup.py
+++ b/src/searchat/services/backup.py
@@ -15,16 +15,19 @@ import logging
 import hashlib
 import tempfile
 
+from searchat.config.constants import DEFAULT_DATA_SUBDIR, DEFAULT_DUCKDB_FILENAME
 from searchat.services.backup_crypto import decrypt_file, encrypt_file, get_backup_key
 from searchat.services.backup_contracts import (
     inspect_backup_chain,
     inspect_legacy_full_backup,
     inspect_manifest_backup,
 )
+from searchat.services.backup_export import export_source_tables
 from searchat.services.storage_contracts import (
     BACKUP_MANIFEST_FILE,
     BACKUP_MANIFEST_VERSION,
     BACKUP_METADATA_FILE,
+    BACKUP_SOURCE_SCHEMA_VERSION,
     BackupManifest,
     BackupMetadata,
 )
@@ -363,25 +366,81 @@ class BackupManager:
         """Count all files in a directory."""
         return sum(1 for item in path.rglob("*") if item.is_file())
 
-    def _iter_live_backup_files(self) -> list[tuple[str, Path]]:
-        """Return (relative_path, absolute_path) for all files in backup scope."""
+    def _iter_live_backup_files(self, *, excludes_derived: bool = True) -> list[tuple[str, Path]]:
+        """Return (relative_path, absolute_path) for all files in backup scope.
+
+        excludes_derived=True (M4 default): source-of-truth-only. Skips the
+        legacy FAISS/metadata index (`data/indices/`) and the unified
+        engine's combined DuckDB file (`data/searchat.duckdb` + its
+        `.wal`) -- the latter's source-of-truth tables are exported
+        separately by `_iter_source_export_files`, which the caller
+        appends to this method's result. Adds the state that lives
+        outside `data/`: bookmarks, saved queries, dashboards, expertise,
+        knowledge graph, and analytics.
+
+        excludes_derived=False: legacy full-copy behavior -- every file
+        under `data/` and `config/` is backed up, including the
+        derivable index.
+        """
         items_to_backup: list[tuple[str, Path]] = [
             ("data", self.data_dir / "data"),
             ("config", self.data_dir / "config"),
         ]
+        if excludes_derived:
+            items_to_backup += [
+                ("bookmarks.json", self.data_dir / "bookmarks.json"),
+                ("saved_queries.json", self.data_dir / "saved_queries.json"),
+                ("dashboards.json", self.data_dir / "dashboards.json"),
+                ("expertise", self.data_dir / "expertise"),
+                ("knowledge_graph", self.data_dir / "knowledge_graph"),
+                ("analytics", self.data_dir / "analytics"),
+            ]
+
+        skip_dirs: list[Path] = []
+        skip_files: set[Path] = set()
+        if excludes_derived:
+            data_root = self.data_dir / "data"
+            skip_dirs.append((data_root / "indices").resolve())
+            skip_files.add((data_root / DEFAULT_DUCKDB_FILENAME).resolve())
+            skip_files.add((data_root / f"{DEFAULT_DUCKDB_FILENAME}.wal").resolve())
+
         files: list[tuple[str, Path]] = []
         for prefix, root in items_to_backup:
             if not root.exists():
                 continue
             if root.is_file():
+                if root.resolve() in skip_files:
+                    continue
                 files.append((prefix, root))
                 continue
             for src in root.rglob("*"):
                 if not src.is_file():
                     continue
+                resolved = src.resolve()
+                if resolved in skip_files:
+                    continue
+                if any(skip_dir in resolved.parents for skip_dir in skip_dirs):
+                    continue
                 rel_key = str(Path(prefix) / src.relative_to(root)).replace("\\", "/")
                 files.append((rel_key, src))
         return files
+
+    def _iter_source_export_files(self, export_dir: Path) -> list[tuple[str, Path]]:
+        """Export `searchat.duckdb`'s source-of-truth tables into `export_dir`.
+
+        Returns (relative_path, absolute_path) pairs rooted at
+        `data/duckdb_source/`, pointing at files freshly written under
+        `export_dir` -- never under the live data directory, so a backup
+        never leaves derived-export artifacts behind in `self.data_dir`.
+        Returns `[]` when no unified-engine database exists yet (a
+        legacy-engine dataset, or no index built at all).
+        """
+        db_path = self.data_dir / DEFAULT_DATA_SUBDIR / DEFAULT_DUCKDB_FILENAME
+        exported = export_source_tables(db_path, export_dir)
+        return [
+            (f"data/duckdb_source/{table}.parquet", export_dir / f"{table}.parquet")
+            for table in exported
+        ]
 
     def _effective_state_from_chain(self, chain: list[str]) -> dict[str, str]:
         """Compute effective file sha map for a chain.
@@ -422,11 +481,18 @@ class BackupManager:
         backup_name: str | None = None,
         backup_type: str = "manual",
         encrypted: bool = False,
+        excludes_derived: bool = True,
         max_chain_length: int = 10,
     ) -> BackupMetadata:
         """Create an incremental (delta) backup using parent chain manifests.
 
         Chain length counts total entries including the base full backup.
+
+        excludes_derived (M4 default True): the delta is computed against
+        the source-of-truth-only file set -- see `_iter_live_backup_files`
+        -- with `searchat.duckdb`'s source tables freshly exported and
+        diffed like any other file. Pass False to keep computing deltas
+        against the legacy full-copy file set.
         """
         parent_chain = self.resolve_backup_chain(parent_name, max_chain_length=max_chain_length)
         if len(parent_chain) + 1 > max_chain_length:
@@ -457,47 +523,55 @@ class BackupManager:
         if encrypted:
             key = get_backup_key()
 
-        live_files = self._iter_live_backup_files()
+        export_cm: tempfile.TemporaryDirectory[str] | None = None
+        try:
+            live_files = self._iter_live_backup_files(excludes_derived=excludes_derived)
+            if excludes_derived:
+                export_cm = tempfile.TemporaryDirectory(prefix="searchat_export_")
+                live_files = live_files + self._iter_source_export_files(Path(export_cm.name))
 
-        live_state: dict[str, str] = {}
-        changed_files: list[tuple[str, Path, str]] = []
-        for rel_key, src in live_files:
-            sha = _sha256_file(src)
-            live_state[rel_key] = sha
-            if parent_state.get(rel_key) != sha:
-                changed_files.append((rel_key, src, sha))
+            live_state: dict[str, str] = {}
+            changed_files: list[tuple[str, Path, str]] = []
+            for rel_key, src in live_files:
+                sha = _sha256_file(src)
+                live_state[rel_key] = sha
+                if parent_state.get(rel_key) != sha:
+                    changed_files.append((rel_key, src, sha))
 
-        deleted_files = sorted(set(parent_state.keys()) - set(live_state.keys()))
+            deleted_files = sorted(set(parent_state.keys()) - set(live_state.keys()))
 
-        file_count = 0
-        total_size = 0
-        manifest_files: dict[str, dict[str, object]] = {}
+            file_count = 0
+            total_size = 0
+            manifest_files: dict[str, dict[str, object]] = {}
 
-        for rel_key, src, sha in changed_files:
-            st = src.stat()
-            if encrypted:
-                stored_rel = f"{rel_key}.enc"
-                content_sha, stored_sha, stored_size = encrypt_file(src, backup_path / stored_rel, key=cast(bytes, key))
-                if content_sha != sha:
-                    raise RuntimeError("Content hash mismatch during encryption")
-            else:
-                stored_rel = rel_key
-                dest = backup_path / Path(rel_key)
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(src, dest)
-                stored_size = int(dest.stat().st_size)
-                stored_sha = sha
-                content_sha = sha
+            for rel_key, src, sha in changed_files:
+                st = src.stat()
+                if encrypted:
+                    stored_rel = f"{rel_key}.enc"
+                    content_sha, stored_sha, stored_size = encrypt_file(src, backup_path / stored_rel, key=cast(bytes, key))
+                    if content_sha != sha:
+                        raise RuntimeError("Content hash mismatch during encryption")
+                else:
+                    stored_rel = rel_key
+                    dest = backup_path / Path(rel_key)
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(src, dest)
+                    stored_size = int(dest.stat().st_size)
+                    stored_sha = sha
+                    content_sha = sha
 
-            file_count += 1
-            total_size += int(stored_size)
-            manifest_files[rel_key] = {
-                "content_sha256": content_sha,
-                "stored_sha256": stored_sha,
-                "stored_rel_path": stored_rel,
-                "size_bytes": int(stored_size),
-                "mtime_epoch": float(st.st_mtime),
-            }
+                file_count += 1
+                total_size += int(stored_size)
+                manifest_files[rel_key] = {
+                    "content_sha256": content_sha,
+                    "stored_sha256": stored_sha,
+                    "stored_rel_path": stored_rel,
+                    "size_bytes": int(stored_size),
+                    "mtime_epoch": float(st.st_mtime),
+                }
+        finally:
+            if export_cm is not None:
+                export_cm.cleanup()
 
         metadata = BackupMetadata(
             timestamp=timestamp,
@@ -506,6 +580,8 @@ class BackupManager:
             file_count=file_count,
             total_size_bytes=total_size,
             backup_type=backup_type,
+            excludes_derived=excludes_derived,
+            derived_schema_version=BACKUP_SOURCE_SCHEMA_VERSION if excludes_derived else 0,
         )
 
         metadata_path = backup_path / self.METADATA_FILE
@@ -623,6 +699,7 @@ class BackupManager:
         backup_type: str = "manual",
         *,
         encrypted: bool = False,
+        excludes_derived: bool = True,
     ) -> BackupMetadata:
         """
         Create a backup of the current index and data.
@@ -630,6 +707,17 @@ class BackupManager:
         Args:
             backup_name: Optional custom backup name. If not provided, uses timestamp.
             backup_type: Type of backup (manual, pre_restore, scheduled)
+            excludes_derived: M4 default True -- source-of-truth-only.
+                Backs up Parquet conversations/code, config, bookmarks,
+                saved queries, dashboards, expertise, knowledge graph, and
+                analytics state; excludes the legacy FAISS/metadata index
+                (data/indices/) and does not copy searchat.duckdb -- its
+                source-of-truth tables (conversations, messages,
+                source_file_state, code_blocks) are exported to Parquet
+                under data/duckdb_source/ instead, leaving out the
+                derivable exchanges/embeddings/FTS/HNSW data. Pass False
+                for the legacy full-copy behavior (includes the derivable
+                index verbatim, restorable without a rebuild step).
 
         Returns:
             BackupMetadata object with backup information
@@ -662,37 +750,45 @@ class BackupManager:
         if encrypted:
             key = get_backup_key()
 
-        files = self._iter_live_backup_files()
+        export_cm: tempfile.TemporaryDirectory[str] | None = None
+        try:
+            files = self._iter_live_backup_files(excludes_derived=excludes_derived)
+            if excludes_derived:
+                export_cm = tempfile.TemporaryDirectory(prefix="searchat_export_")
+                files = files + self._iter_source_export_files(Path(export_cm.name))
 
-        file_count = 0
-        total_size = 0
-        manifest_files: dict[str, dict[str, object]] = {}
+            file_count = 0
+            total_size = 0
+            manifest_files: dict[str, dict[str, object]] = {}
 
-        for rel_key, src in files:
-            st = src.stat()
-            if encrypted:
-                logger.info(f"  Encrypting file: {rel_key}")
-                stored_rel = f"{rel_key}.enc"
-                content_sha, stored_sha, stored_size = encrypt_file(src, backup_path / stored_rel, key=cast(bytes, key))
-            else:
-                # Copy plaintext.
-                dest = backup_path / Path(rel_key)
-                dest.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(src, dest)
-                stored_rel = rel_key
-                stored_size = int(dest.stat().st_size)
-                content_sha = _sha256_file(dest)
-                stored_sha = content_sha
+            for rel_key, src in files:
+                st = src.stat()
+                if encrypted:
+                    logger.info(f"  Encrypting file: {rel_key}")
+                    stored_rel = f"{rel_key}.enc"
+                    content_sha, stored_sha, stored_size = encrypt_file(src, backup_path / stored_rel, key=cast(bytes, key))
+                else:
+                    # Copy plaintext.
+                    dest = backup_path / Path(rel_key)
+                    dest.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(src, dest)
+                    stored_rel = rel_key
+                    stored_size = int(dest.stat().st_size)
+                    content_sha = _sha256_file(dest)
+                    stored_sha = content_sha
 
-            file_count += 1
-            total_size += int(stored_size)
-            manifest_files[rel_key] = {
-                "content_sha256": content_sha,
-                "stored_sha256": stored_sha,
-                "stored_rel_path": stored_rel,
-                "size_bytes": int(stored_size),
-                "mtime_epoch": float(st.st_mtime),
-            }
+                file_count += 1
+                total_size += int(stored_size)
+                manifest_files[rel_key] = {
+                    "content_sha256": content_sha,
+                    "stored_sha256": stored_sha,
+                    "stored_rel_path": stored_rel,
+                    "size_bytes": int(stored_size),
+                    "mtime_epoch": float(st.st_mtime),
+                }
+        finally:
+            if export_cm is not None:
+                export_cm.cleanup()
 
         # Create metadata
         metadata = BackupMetadata(
@@ -702,6 +798,8 @@ class BackupManager:
             file_count=file_count,
             total_size_bytes=total_size,
             backup_type=backup_type,
+            excludes_derived=excludes_derived,
+            derived_schema_version=BACKUP_SOURCE_SCHEMA_VERSION if excludes_derived else 0,
         )
 
         # Save metadata to backup directory

--- a/src/searchat/services/backup_export.py
+++ b/src/searchat/services/backup_export.py
@@ -1,0 +1,122 @@
+"""Selective DuckDB table export/import for source-of-truth-only backups.
+
+`searchat.duckdb` (the unified engine's single storage file) mixes
+source-of-truth tables (`conversations`, `messages`, `source_file_state`,
+`code_blocks`) with derived tables (`exchanges`, `verbatim_embeddings`)
+plus their FTS/HNSW indexes. A source-of-truth-only backup must not copy
+that file wholesale -- doing so would either lose the source tables (if
+excluded outright) or keep the bulk of the derivable index (if included).
+This module exports just the source-of-truth tables to Parquet, and
+re-imports them into a fresh database on restore, leaving `rebuild_derived`
+(M2's `UnifiedIndexer.rebuild_derived`) to regenerate everything else.
+
+Every connection loads the `vss`/`fts` extensions before running any query,
+mirroring `services/compaction.py::_prepare_connection`: a DuckDB catalog
+referencing an HNSW/FTS index FATALs the whole process on first use if the
+owning extension isn't loaded yet, and a FATAL error cannot be caught by a
+Python `except` clause.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+
+from searchat.storage.schema import install_fts, install_vss
+
+SOURCE_OF_TRUTH_TABLES: tuple[str, ...] = (
+    "conversations",
+    "messages",
+    "source_file_state",
+    "code_blocks",
+)
+
+
+def _sql_literal(path: Path) -> str:
+    return "'" + str(path).replace("'", "''") + "'"
+
+
+def _quote_ident(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def export_source_tables(db_path: Path, dest_dir: Path) -> list[str]:
+    """Export each source-of-truth table found in `db_path` to Parquet.
+
+    Read-only: never mutates `db_path`. Writes `dest_dir/<table>.parquet`
+    for every table in `SOURCE_OF_TRUTH_TABLES` that actually exists in
+    the database, skipping any that don't (an older or partial schema).
+
+    Returns the list of table names actually exported. Returns `[]`
+    without touching the filesystem when `db_path` doesn't exist.
+    """
+    db_path = Path(db_path)
+    if not db_path.exists():
+        return []
+
+    con = duckdb.connect(str(db_path), read_only=True)
+    exported: list[str] = []
+    try:
+        install_vss(con)
+        install_fts(con)
+
+        existing = {
+            row[0]
+            for row in con.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'main'"
+            ).fetchall()
+        }
+
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        for table in SOURCE_OF_TRUTH_TABLES:
+            if table not in existing:
+                continue
+            dest_file = dest_dir / f"{table}.parquet"
+            con.execute(
+                f"COPY (SELECT * FROM {_quote_ident(table)}) "
+                f"TO {_sql_literal(dest_file)} (FORMAT PARQUET)"
+            )
+            exported.append(table)
+    finally:
+        con.close()
+
+    return exported
+
+
+def import_source_tables(db_path: Path, source_dir: Path) -> list[str]:
+    """Load exported source-of-truth Parquet files into a fresh database.
+
+    Creates `db_path` (and the full Phase 1 schema, via `UnifiedStorage`)
+    if it doesn't already exist. Refuses to run against an existing
+    database -- restore always targets a clean file, never a merge, so a
+    pre-existing file at `db_path` is a caller bug, not a state to repair.
+
+    Returns the list of table names actually imported (a table absent
+    from `source_dir` -- an older backup, or one exported before that
+    table existed -- is skipped, not an error).
+    """
+    db_path = Path(db_path)
+    if db_path.exists():
+        raise FileExistsError(
+            f"Refusing to import source tables into an existing database: {db_path}"
+        )
+
+    from searchat.storage.unified_storage import UnifiedStorage
+
+    storage = UnifiedStorage(db_path)
+    imported: list[str] = []
+    try:
+        con = storage.connection
+        for table in SOURCE_OF_TRUTH_TABLES:
+            src_file = Path(source_dir) / f"{table}.parquet"
+            if not src_file.exists():
+                continue
+            con.execute(
+                f"INSERT INTO {_quote_ident(table)} "
+                f"SELECT * FROM read_parquet({_sql_literal(src_file)})"
+            )
+            imported.append(table)
+    finally:
+        storage.close()
+
+    return imported

--- a/src/searchat/services/storage_contracts.py
+++ b/src/searchat/services/storage_contracts.py
@@ -20,6 +20,13 @@ BACKUP_METADATA_FILE = "backup_metadata.json"
 BACKUP_MANIFEST_VERSION = 1
 BACKUP_METADATA_VERSION = 1
 
+# Schema version of the source-of-truth DuckDB tables (conversations,
+# messages, source_file_state, code_blocks) that a source-of-truth-only
+# backup's exported Parquet files conform to. Recorded on `BackupMetadata`
+# at backup time so restore can tell whether `rebuild_derived` (M2) knows
+# how to reconstruct derived data from a given backup's exported tables.
+BACKUP_SOURCE_SCHEMA_VERSION = 1
+
 
 class StorageCompatibilityError(ValueError):
     """Raised when persisted storage artifacts are incompatible."""
@@ -197,6 +204,15 @@ class BackupMetadata:
     total_size_bytes: int
     backup_type: str = "manual"
     metadata_version: int = BACKUP_METADATA_VERSION
+    # M4: True when this backup deliberately excludes the derivable
+    # DuckDB/FAISS index (rebuildable via `rebuild_derived`). False for
+    # every pre-M4 backup and for any backup explicitly requested in
+    # legacy full-copy mode.
+    excludes_derived: bool = False
+    # Schema version of the exported source-of-truth tables, valid only
+    # when `excludes_derived` is True. 0 means "not applicable" (a
+    # full-copy backup already contains its own derived index).
+    derived_schema_version: int = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -208,6 +224,8 @@ class BackupMetadata:
             "total_size_bytes": self.total_size_bytes,
             "total_size_mb": round(self.total_size_bytes / (1024 * 1024), 2),
             "backup_type": self.backup_type,
+            "excludes_derived": self.excludes_derived,
+            "derived_schema_version": self.derived_schema_version,
         }
 
     @classmethod
@@ -226,6 +244,8 @@ class BackupMetadata:
             total_size_bytes=int(data["total_size_bytes"]),
             backup_type=str(data.get("backup_type", "manual")),
             metadata_version=metadata_version,
+            excludes_derived=bool(data.get("excludes_derived", False)),
+            derived_schema_version=int(data.get("derived_schema_version", 0)),
         )
 
     def normalized(self) -> "BackupMetadata":
@@ -237,4 +257,6 @@ class BackupMetadata:
             total_size_bytes=self.total_size_bytes,
             backup_type=self.backup_type,
             metadata_version=BACKUP_METADATA_VERSION,
+            excludes_derived=self.excludes_derived,
+            derived_schema_version=self.derived_schema_version,
         )

--- a/tests/unit/services/test_backup_contracts.py
+++ b/tests/unit/services/test_backup_contracts.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from searchat.services.backup_contracts import inspect_legacy_full_backup, inspect_manifest_backup
+from searchat.services.storage_contracts import BACKUP_SOURCE_SCHEMA_VERSION, BackupMetadata
 
 
 def test_inspect_legacy_full_backup_without_hash_verification_is_valid(tmp_path) -> None:
@@ -46,3 +49,39 @@ def test_inspect_manifest_backup_keeps_chain_contract_fields() -> None:
     assert inspection.parent_name == "base_20260315"
     assert inspection.chain_length == 2
     assert inspection.errors == ("Backup manifest missing: base_20260315",)
+
+
+def test_backup_metadata_roundtrips_excludes_derived_fields() -> None:
+    metadata = BackupMetadata(
+        timestamp="20260703_000000",
+        backup_path=Path("/backups/snap_20260703_000000"),
+        source_path=Path("/data"),
+        file_count=3,
+        total_size_bytes=1024,
+        excludes_derived=True,
+        derived_schema_version=BACKUP_SOURCE_SCHEMA_VERSION,
+    )
+
+    restored = BackupMetadata.from_dict(metadata.to_dict())
+
+    assert restored.excludes_derived is True
+    assert restored.derived_schema_version == BACKUP_SOURCE_SCHEMA_VERSION
+
+
+def test_backup_metadata_from_dict_defaults_excludes_derived_for_legacy_payload() -> None:
+    """Pre-M4 metadata JSON never wrote these keys -- from_dict must default them
+    to "full-copy" values rather than raising, so old backups stay listable."""
+    legacy_payload = {
+        "metadata_version": 1,
+        "timestamp": "20260101_000000",
+        "backup_path": "/backups/legacy_20260101_000000",
+        "source_path": "/data",
+        "file_count": 5,
+        "total_size_bytes": 2048,
+        "backup_type": "manual",
+    }
+
+    restored = BackupMetadata.from_dict(legacy_payload)
+
+    assert restored.excludes_derived is False
+    assert restored.derived_schema_version == 0

--- a/tests/unit/services/test_backup_encryption.py
+++ b/tests/unit/services/test_backup_encryption.py
@@ -54,8 +54,8 @@ def test_encrypted_incremental_backup_restore(monkeypatch: pytest.MonkeyPatch, t
 
     parquet = live / "data" / "conversations" / "conv.parquet"
     settings = live / "config" / "settings.toml"
-    removed = live / "data" / "indices" / "removed.bin"
-    added = live / "data" / "indices" / "added.bin"
+    removed = live / "data" / "code" / "removed.bin"
+    added = live / "data" / "code" / "added.bin"
 
     _write_bytes(parquet, b"PAR1\n")
     _write_bytes(settings, b"a = 1\n")
@@ -78,7 +78,7 @@ def test_encrypted_incremental_backup_restore(monkeypatch: pytest.MonkeyPatch, t
 
     assert settings.read_bytes() == b"a = 2\n"
     assert not removed.exists()
-    assert (live / "data" / "indices" / "added.bin").read_bytes() == b"new\n"
+    assert (live / "data" / "code" / "added.bin").read_bytes() == b"new\n"
     assert parquet.read_bytes() == b"PAR1\n"
 
 

--- a/tests/unit/services/test_backup_export.py
+++ b/tests/unit/services/test_backup_export.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from searchat.services.backup_export import (
+    SOURCE_OF_TRUTH_TABLES,
+    export_source_tables,
+    import_source_tables,
+)
+from searchat.storage.unified_storage import UnifiedStorage
+
+
+def _seed_unified_storage(db_path: Path) -> None:
+    """Populate every Phase 1 table -- both source-of-truth and derived."""
+    storage = UnifiedStorage(db_path)
+    try:
+        con = storage.connection
+        con.execute(
+            "INSERT INTO conversations "
+            "(conversation_id, project_id, file_path, title, created_at, updated_at, "
+            "message_count, full_text, file_hash, indexed_at) "
+            "VALUES ('c1', 'p1', '/tmp/c1.jsonl', 'Conv 1', now(), now(), 1, 'hello world', 'h1', now())"
+        )
+        con.execute(
+            "INSERT INTO messages (conversation_id, sequence, role, content) "
+            "VALUES ('c1', 0, 'user', 'hello')"
+        )
+        con.execute(
+            "INSERT INTO source_file_state (file_path, conversation_id, project_id, file_size, updated_at) "
+            "VALUES ('/tmp/c1.jsonl', 'c1', 'p1', 42, now())"
+        )
+        con.execute(
+            "INSERT INTO code_blocks "
+            "(conversation_id, project_id, message_index, block_index, code, code_hash, lines) "
+            "VALUES ('c1', 'p1', 0, 0, 'print(1)', 'ch1', 1)"
+        )
+        con.execute(
+            "INSERT INTO exchanges (exchange_id, conversation_id, ply_start, ply_end, exchange_text, created_at) "
+            "VALUES ('e1', 'c1', 0, 0, 'hello', now())"
+        )
+        con.execute(
+            "INSERT INTO verbatim_embeddings (exchange_id, embedding) VALUES ('e1', ?)",
+            [[0.1] * 384],
+        )
+    finally:
+        storage.close()
+
+
+@pytest.mark.unit
+def test_export_source_tables_returns_empty_for_missing_database(tmp_path: Path) -> None:
+    assert export_source_tables(tmp_path / "missing.duckdb", tmp_path / "export") == []
+
+
+@pytest.mark.unit
+def test_export_source_tables_writes_only_source_of_truth_parquet(tmp_path: Path) -> None:
+    db_path = tmp_path / "searchat.duckdb"
+    _seed_unified_storage(db_path)
+
+    export_dir = tmp_path / "export"
+    exported = export_source_tables(db_path, export_dir)
+
+    assert sorted(exported) == sorted(SOURCE_OF_TRUTH_TABLES)
+    for table in SOURCE_OF_TRUTH_TABLES:
+        assert (export_dir / f"{table}.parquet").exists()
+    # Derived tables never get exported.
+    assert not (export_dir / "exchanges.parquet").exists()
+    assert not (export_dir / "verbatim_embeddings.parquet").exists()
+
+    con = duckdb.connect()
+    try:
+        row = con.execute(
+            "SELECT conversation_id, title FROM read_parquet(?)",
+            [str(export_dir / "conversations.parquet")],
+        ).fetchone()
+    finally:
+        con.close()
+    assert row == ("c1", "Conv 1")
+
+
+@pytest.mark.unit
+def test_export_source_tables_skips_absent_tables(tmp_path: Path) -> None:
+    db_path = tmp_path / "partial.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE TABLE conversations(conversation_id VARCHAR)")
+    con.execute("INSERT INTO conversations VALUES ('c1')")
+    con.execute("CHECKPOINT")
+    con.close()
+
+    export_dir = tmp_path / "export"
+    exported = export_source_tables(db_path, export_dir)
+
+    assert exported == ["conversations"]
+    assert (export_dir / "conversations.parquet").exists()
+    assert not (export_dir / "messages.parquet").exists()
+
+
+@pytest.mark.unit
+def test_export_source_tables_does_not_mutate_source_database(tmp_path: Path) -> None:
+    db_path = tmp_path / "searchat.duckdb"
+    _seed_unified_storage(db_path)
+    before = db_path.stat().st_mtime_ns
+
+    export_source_tables(db_path, tmp_path / "export")
+
+    assert db_path.stat().st_mtime_ns == before
+
+
+@pytest.mark.unit
+def test_import_source_tables_roundtrips_into_fresh_database_without_derived_data(tmp_path: Path) -> None:
+    src_db = tmp_path / "searchat.duckdb"
+    _seed_unified_storage(src_db)
+    export_dir = tmp_path / "export"
+    export_source_tables(src_db, export_dir)
+
+    dest_db = tmp_path / "restored" / "searchat.duckdb"
+    imported = import_source_tables(dest_db, export_dir)
+
+    assert sorted(imported) == sorted(SOURCE_OF_TRUTH_TABLES)
+
+    storage = UnifiedStorage(dest_db)
+    try:
+        con = storage.connection
+        conv_row = con.execute("SELECT conversation_id, title FROM conversations").fetchone()
+        assert conv_row == ("c1", "Conv 1")
+        assert con.execute("SELECT count(*) FROM messages").fetchone()[0] == 1
+        assert con.execute("SELECT count(*) FROM source_file_state").fetchone()[0] == 1
+        assert con.execute("SELECT count(*) FROM code_blocks").fetchone()[0] == 1
+        # Derived tables exist (schema created) but stay empty -- rebuild_derived's job.
+        assert con.execute("SELECT count(*) FROM exchanges").fetchone()[0] == 0
+        assert con.execute("SELECT count(*) FROM verbatim_embeddings").fetchone()[0] == 0
+    finally:
+        storage.close()
+
+
+@pytest.mark.unit
+def test_import_source_tables_refuses_existing_database(tmp_path: Path) -> None:
+    dest_db = tmp_path / "searchat.duckdb"
+    UnifiedStorage(dest_db).close()
+
+    with pytest.raises(FileExistsError):
+        import_source_tables(dest_db, tmp_path / "export")
+
+
+@pytest.mark.unit
+def test_import_source_tables_skips_absent_parquet_files(tmp_path: Path) -> None:
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    # No parquet files at all -- an empty/legacy-engine export.
+
+    dest_db = tmp_path / "restored" / "searchat.duckdb"
+    imported = import_source_tables(dest_db, export_dir)
+
+    assert imported == []
+    assert dest_db.exists()

--- a/tests/unit/services/test_backup_incremental.py
+++ b/tests/unit/services/test_backup_incremental.py
@@ -20,8 +20,8 @@ def test_incremental_backup_materialize_roundtrip(tmp_path: Path, temp_search_di
 
     parquet = live / "data" / "conversations" / "conv.parquet"
     settings = live / "config" / "settings.toml"
-    removed = live / "data" / "indices" / "removed.bin"
-    added = live / "data" / "indices" / "added.bin"
+    removed = live / "data" / "code" / "removed.bin"
+    added = live / "data" / "code" / "added.bin"
 
     _write_bytes(parquet, b"PAR1\n")
     _write_bytes(settings, b"a = 1\n")
@@ -42,8 +42,8 @@ def test_incremental_backup_materialize_roundtrip(tmp_path: Path, temp_search_di
     mgr.materialize_backup(backup_name=inc_name, dest_dir=out, verify_hashes=True)
 
     assert (out / "config" / "settings.toml").read_bytes() == b"a = 2\n"
-    assert not (out / "data" / "indices" / "removed.bin").exists()
-    assert (out / "data" / "indices" / "added.bin").read_bytes() == b"new\n"
+    assert not (out / "data" / "code" / "removed.bin").exists()
+    assert (out / "data" / "code" / "added.bin").read_bytes() == b"new\n"
     assert (out / "data" / "conversations" / "conv.parquet").read_bytes() == b"PAR1\n"
 
     assert mgr.resolve_backup_chain(inc_name) == [base_name, inc_name]
@@ -80,7 +80,7 @@ def test_restore_from_incremental_backup(temp_search_dir: Path):
 
     _write_bytes(live / "data" / "conversations" / "conv.parquet", b"PAR1\n")
     settings = live / "config" / "settings.toml"
-    removed = live / "data" / "indices" / "removed.bin"
+    removed = live / "data" / "code" / "removed.bin"
     _write_bytes(settings, b"a = 1\n")
     _write_bytes(removed, b"old\n")
 
@@ -325,3 +325,112 @@ def test_restore_from_backup_invalid_manifest_fixture_fails_closed(temp_search_d
             create_pre_restore_backup=False,
             verify_hashes=False,
         )
+
+
+def _seed_duckdb_conversation(db_path: Path) -> None:
+    """Create a minimal, schema-valid unified DuckDB with one conversation."""
+    from searchat.storage.unified_storage import UnifiedStorage
+
+    storage = UnifiedStorage(db_path)
+    try:
+        storage.connection.execute(
+            "INSERT INTO conversations "
+            "(conversation_id, project_id, file_path, title, created_at, updated_at, "
+            "message_count, full_text, file_hash, indexed_at) "
+            "VALUES ('c1', 'p1', '/tmp/c1.jsonl', 'Conv 1', now(), now(), 1, 'hello world', 'h1', now())"
+        )
+    finally:
+        storage.close()
+
+
+@pytest.mark.unit
+def test_create_backup_default_excludes_derivable_index(temp_search_dir: Path) -> None:
+    live = temp_search_dir
+    mgr = BackupManager(live)
+
+    _write_bytes(live / "data" / "conversations" / "conv.parquet", b"PAR1\n")
+    _write_bytes(live / "data" / "indices" / "embeddings.faiss", b"FAISSSTUB")
+    _seed_duckdb_conversation(live / "data" / "searchat.duckdb")
+
+    from searchat.services.storage_contracts import BACKUP_SOURCE_SCHEMA_VERSION
+
+    meta = mgr.create_backup(backup_name="snap")
+
+    assert meta.excludes_derived is True
+    assert meta.derived_schema_version == BACKUP_SOURCE_SCHEMA_VERSION
+
+    manifest = mgr._load_manifest(meta.backup_path)
+    assert manifest is not None
+    assert "data/conversations/conv.parquet" in manifest.files
+    assert "data/duckdb_source/conversations.parquet" in manifest.files
+    assert "data/indices/embeddings.faiss" not in manifest.files
+    assert not any(rel.startswith("data/searchat.duckdb") for rel in manifest.files)
+    assert not (meta.backup_path / "data" / "indices").exists()
+    assert not (meta.backup_path / "data" / "searchat.duckdb").exists()
+
+
+@pytest.mark.unit
+def test_create_backup_backs_up_new_state_directories_when_present(temp_search_dir: Path) -> None:
+    live = temp_search_dir
+    mgr = BackupManager(live)
+
+    _write_bytes(live / "data" / "conversations" / "conv.parquet", b"PAR1\n")
+    _write_bytes(live / "bookmarks.json", b"{}")
+    _write_bytes(live / "saved_queries.json", b"{}")
+    _write_bytes(live / "dashboards.json", b"{}")
+    _write_bytes(live / "expertise" / "expertise.duckdb", b"stub")
+    _write_bytes(live / "knowledge_graph" / "knowledge_graph.duckdb", b"stub")
+    _write_bytes(live / "analytics" / "analytics.duckdb", b"stub")
+
+    meta = mgr.create_backup(backup_name="snap")
+
+    manifest = mgr._load_manifest(meta.backup_path)
+    assert manifest is not None
+    for rel in (
+        "bookmarks.json",
+        "saved_queries.json",
+        "dashboards.json",
+        "expertise/expertise.duckdb",
+        "knowledge_graph/knowledge_graph.duckdb",
+        "analytics/analytics.duckdb",
+    ):
+        assert rel in manifest.files, rel
+
+
+@pytest.mark.unit
+def test_create_backup_excludes_derived_false_keeps_legacy_full_copy(temp_search_dir: Path) -> None:
+    live = temp_search_dir
+    mgr = BackupManager(live)
+
+    _write_bytes(live / "data" / "conversations" / "conv.parquet", b"PAR1\n")
+    _write_bytes(live / "data" / "indices" / "embeddings.faiss", b"FAISSSTUB")
+    _seed_duckdb_conversation(live / "data" / "searchat.duckdb")
+
+    meta = mgr.create_backup(backup_name="snap", excludes_derived=False)
+
+    assert meta.excludes_derived is False
+    assert meta.derived_schema_version == 0
+
+    manifest = mgr._load_manifest(meta.backup_path)
+    assert manifest is not None
+    assert "data/indices/embeddings.faiss" in manifest.files
+    assert "data/searchat.duckdb" in manifest.files
+    assert (meta.backup_path / "data" / "indices" / "embeddings.faiss").read_bytes() == b"FAISSSTUB"
+    assert (meta.backup_path / "data" / "searchat.duckdb").exists()
+
+
+@pytest.mark.unit
+def test_source_of_truth_backup_is_materially_smaller_than_full_copy(temp_search_dir: Path) -> None:
+    live = temp_search_dir
+    mgr = BackupManager(live)
+
+    _write_bytes(live / "data" / "conversations" / "conv.parquet", b"PAR1\n" * 100)
+    # Inflate the derivable legacy index to >= 5x the source-of-truth payload.
+    _write_bytes(live / "data" / "indices" / "embeddings.faiss", b"X" * (5 * 500 * 5))
+    _write_bytes(live / "data" / "indices" / "embeddings.metadata.parquet", b"Y" * (5 * 500 * 5))
+
+    source_of_truth = mgr.create_backup(backup_name="lean")
+    full_copy = mgr.create_backup(backup_name="full", excludes_derived=False)
+
+    assert source_of_truth.total_size_bytes < full_copy.total_size_bytes * 0.3
+

--- a/tests/unit/services/test_storage_health.py
+++ b/tests/unit/services/test_storage_health.py
@@ -411,8 +411,8 @@ def test_build_storage_doctor_report_assembles_all_sections(
 
     db_path = data_root / "searchat.duckdb"
     con = duckdb.connect(str(db_path))
-    con.execute("CREATE TABLE conversations(id INTEGER)")
-    con.execute("INSERT INTO conversations SELECT * FROM range(10)")
+    con.execute("CREATE TABLE dummy_bloat(id INTEGER)")
+    con.execute("INSERT INTO dummy_bloat SELECT * FROM range(10)")
     con.execute("CHECKPOINT")
     con.close()
 

--- a/tests/unit/services/test_storage_migrations.py
+++ b/tests/unit/services/test_storage_migrations.py
@@ -94,7 +94,9 @@ def test_plan_backup_metadata_migration_marks_missing_version_repairable() -> No
 
     assert plan.has_changes is True
     assert "metadata_version" in plan.changed_fields
-    assert set(plan.changed_fields).issubset({"metadata_version", "backup_path", "source_path"})
+    assert set(plan.changed_fields).issubset(
+        {"metadata_version", "backup_path", "source_path", "excludes_derived", "derived_schema_version"}
+    )
     assert plan.migrated_payload["metadata_version"] == 1
 
 

--- a/tests/unit/test_cli_doctor.py
+++ b/tests/unit/test_cli_doctor.py
@@ -53,8 +53,8 @@ def test_doctor_table_output_shows_bloat_ratio_and_backups(temp_search_dir: Path
     data_dir.mkdir(parents=True, exist_ok=True)
     db_path = data_dir / "searchat.duckdb"
     con = duckdb.connect(str(db_path))
-    con.execute("CREATE TABLE conversations(id INTEGER)")
-    con.execute("INSERT INTO conversations SELECT * FROM range(5)")
+    con.execute("CREATE TABLE dummy_bloat(id INTEGER)")
+    con.execute("INSERT INTO dummy_bloat SELECT * FROM range(5)")
     con.execute("CHECKPOINT")
     con.close()
 
@@ -85,8 +85,8 @@ def test_doctor_json_output_matches_documented_schema(temp_search_dir: Path, cap
     data_dir.mkdir(parents=True, exist_ok=True)
     db_path = data_dir / "searchat.duckdb"
     con = duckdb.connect(str(db_path))
-    con.execute("CREATE TABLE conversations(id INTEGER)")
-    con.execute("INSERT INTO conversations SELECT * FROM range(5)")
+    con.execute("CREATE TABLE dummy_bloat(id INTEGER)")
+    con.execute("INSERT INTO dummy_bloat SELECT * FROM range(5)")
     con.execute("CHECKPOINT")
     con.close()
 


### PR DESCRIPTION
## Summary

Part 1/3 of M4 (Backup v2: source-of-truth-only with retention).

- `BackupMetadata` gains `excludes_derived: bool` and `derived_schema_version: int` (backward-compatible defaults for pre-M4 metadata JSON).
- New `services/backup_export.py`: `export_source_tables`/`import_source_tables` selectively move `searchat.duckdb`'s source-of-truth tables (`conversations`, `messages`, `source_file_state`, `code_blocks`) to/from Parquet, leaving the derivable `exchanges`/`verbatim_embeddings`/FTS/HNSW data out.
- `BackupManager.create_backup`/`create_incremental_backup` default to `excludes_derived=True`: backs up Parquet `conversations/`, `code/`, `config/`, plus the state that previously wasn't backed up at all (`bookmarks.json`, `saved_queries.json`, `dashboards.json`, `expertise/`, `knowledge_graph/`, `analytics/`). Excludes the legacy FAISS/metadata index (`data/indices/`) and `searchat.duckdb`/`.wal` directly, exporting the latter's source tables under `data/duckdb_source/` instead. `excludes_derived=False` keeps the exact pre-M4 full-copy behavior.

## Stack

Position: 1/3

1. `feat/backup-source-set` -> this PR
2. `feat/backup-retention` -> next
3. `feat/backup-restore-rebuild` -> last

Depends on: none (root, targets `main`)

## Notes

Restore does not yet rebuild the derived index from `data/duckdb_source/` -- that lands in PR 3/3. This PR only changes what a backup captures and records the mode in its metadata.

A few existing tests demonstrated backup/incremental mechanics using paths that now fall under the new exclusion (`data/indices/*.bin`, a dummy table literally named `conversations`); relocated those fixtures without changing what they actually verify.

## Validation

- `uv run pytest tests/unit/services/test_backup_contracts.py tests/unit/services/test_backup_incremental.py tests/api/test_stats_backup_routes.py -v --tb=short --no-cov` — 51 passed
- `uv run pytest -v --tb=short` — 2151 passed, 1 skipped, 81.91% coverage (gate: 80%)