### PR TITLE
feat(services): restore automatically rebuilds derived indexes

### DIFF
--- a/src/searchat/api/contracts.py
+++ b/src/searchat/api/contracts.py
@@ -399,11 +399,13 @@ def serialize_backup_restore_payload(
     *,
     restored_from: str,
     pre_restore_backup: dict[str, Any] | None = None,
+    rebuild_performed: bool = False,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "success": True,
         "restored_from": restored_from,
         "message": f"Successfully restored from backup: {restored_from}",
+        "rebuild_performed": rebuild_performed,
     }
     if pre_restore_backup is not None:
         payload["pre_restore_backup"] = pre_restore_backup

--- a/src/searchat/api/routers/backup.py
+++ b/src/searchat/api/routers/backup.py
@@ -183,15 +183,17 @@ async def restore_backup(
 
         logger.info(f"Restoring from backup: {backup_name}")
 
-        pre_restore_metadata = backup_manager.restore_from_backup(
+        result = backup_manager.restore_from_backup(
             backup_path=backup_path,
             create_pre_restore_backup=True
         )
 
         invalidate_search_index()
+        pre_restore_metadata = result.pre_restore_backup
         return serialize_backup_restore_payload(
             restored_from=backup_name,
             pre_restore_backup=None if pre_restore_metadata is None else pre_restore_metadata.to_dict(),
+            rebuild_performed=bool(result.rebuild_performed),
         )
 
     except HTTPException:

--- a/src/searchat/services/backup.py
+++ b/src/searchat/services/backup.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import shutil
 import json
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Callable, cast
 from datetime import datetime
 import logging
 import hashlib
@@ -22,13 +22,14 @@ from searchat.config.constants import (
 )
 from searchat.services.backup_crypto import decrypt_file, encrypt_file, get_backup_key
 from searchat.services.backup_contracts import (
+    RestoreResult,
     RetentionResult,
     inspect_backup_chain,
     inspect_legacy_full_backup,
     inspect_manifest_backup,
 )
 from searchat.services.backup_compression import compress_file, decompress_file
-from searchat.services.backup_export import export_source_tables
+from searchat.services.backup_export import export_source_tables, import_source_tables
 from searchat.services.storage_contracts import (
     BACKUP_MANIFEST_FILE,
     BACKUP_MANIFEST_VERSION,
@@ -972,7 +973,8 @@ class BackupManager:
         backup_path: Path,
         create_pre_restore_backup: bool = True,
         verify_hashes: bool = True,
-    ) -> BackupMetadata | None:
+        rebuild_derived: Callable[[Path], object] | None = None,
+    ) -> RestoreResult:
         """
         Restore data from a backup.
 
@@ -984,9 +986,19 @@ class BackupManager:
         Args:
             backup_path: Path to the backup directory to restore from
             create_pre_restore_backup: Create a backup before restoring (recommended)
+            rebuild_derived: called with `self.data_dir` after a
+                source-of-truth-only restore imports its exported
+                searchat.duckdb tables, to regenerate the derived
+                exchanges/embeddings/FTS/HNSW data (M2's
+                `UnifiedIndexer.rebuild_derived`). Defaults to the real
+                `UnifiedIndexer` when not given. Only invoked when the
+                restored backup's metadata has `excludes_derived=True` and
+                it actually exported source tables at backup time;
+                pre-M4 full backups restore unchanged, without this step.
 
         Returns:
-            Metadata of the pre-restore backup (if created)
+            RestoreResult: the pre-restore backup's metadata (if created)
+            and whether a derived-index rebuild was performed.
 
         Raises:
             FileNotFoundError: If backup doesn't exist
@@ -1007,6 +1019,15 @@ class BackupManager:
             raise ValueError(f"Backup validation failed: {errors}")
 
         manifest = self._load_manifest(backup_path) if (backup_path / BACKUP_MANIFEST_FILE).exists() else None
+
+        excludes_derived = False
+        metadata_path = backup_path / self.METADATA_FILE
+        if metadata_path.exists():
+            try:
+                with open(metadata_path, "r", encoding="utf-8") as f:
+                    excludes_derived = bool(BackupMetadata.from_dict(json.load(f)).excludes_derived)
+            except (ValueError, KeyError, OSError):
+                excludes_derived = False
 
         # Create pre-restore backup
         pre_restore_metadata = None
@@ -1067,9 +1088,46 @@ class BackupManager:
             if temp_dir_cm is not None:
                 temp_dir_cm.cleanup()
 
+        rebuild_performed = False
+        if excludes_derived:
+            rebuild_performed = self._rebuild_derived_after_restore(rebuild_derived)
+
         logger.info(f"Restore complete from: {backup_path.name}")
 
-        return pre_restore_metadata
+        return RestoreResult(
+            pre_restore_backup=pre_restore_metadata,
+            rebuild_performed=rebuild_performed,
+        )
+
+    def _rebuild_derived_after_restore(
+        self, rebuild_derived: Callable[[Path], object] | None
+    ) -> bool:
+        """Import exported source tables and regenerate derived data.
+
+        No-ops when the restored dataset never had a unified-engine
+        database at backup time (no `data/duckdb_source/` was exported --
+        a legacy-engine dataset or one with no index built yet), since
+        there is nothing to rebuild from. Returns whether a rebuild was
+        actually performed.
+        """
+        duckdb_source_dir = self.data_dir / "data" / "duckdb_source"
+        if not duckdb_source_dir.exists():
+            return False
+
+        db_path = self.data_dir / DEFAULT_DATA_SUBDIR / DEFAULT_DUCKDB_FILENAME
+        logger.info("Importing exported source-of-truth tables into a fresh searchat.duckdb...")
+        import_source_tables(db_path, duckdb_source_dir)
+        shutil.rmtree(duckdb_source_dir)
+
+        logger.info("Rebuilding derived exchanges/embeddings/FTS/HNSW from restored source tables...")
+        if rebuild_derived is not None:
+            rebuild_derived(self.data_dir)
+        else:
+            from searchat.config import Config
+            from searchat.core.unified_indexer import UnifiedIndexer
+
+            UnifiedIndexer(self.data_dir, Config.load()).rebuild_derived(force=True)
+        return True
 
     def delete_backup(self, backup_path: Path) -> None:
         """

--- a/src/searchat/services/backup_contracts.py
+++ b/src/searchat/services/backup_contracts.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from searchat.services.storage_contracts import BackupMetadata
+
 
 @dataclass(frozen=True)
 class BackupArtifactInspection:
@@ -122,4 +124,18 @@ class RetentionResult:
             "kept": list(self.kept),
             "pruned": list(self.pruned),
             "dry_run": self.dry_run,
+        }
+
+
+@dataclass(frozen=True)
+class RestoreResult:
+    """Outcome of `BackupManager.restore_from_backup`."""
+
+    pre_restore_backup: BackupMetadata | None
+    rebuild_performed: bool
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "pre_restore_backup": None if self.pre_restore_backup is None else self.pre_restore_backup.to_dict(),
+            "rebuild_performed": self.rebuild_performed,
         }

--- a/tests/api/test_stats_backup_routes.py
+++ b/tests/api/test_stats_backup_routes.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from searchat.api.app import app
 from searchat.api import state as api_state
+from searchat.services.backup_contracts import RestoreResult
 
 
 @pytest.fixture
@@ -54,7 +55,7 @@ def mock_backup_manager():
     mock.create_backup.return_value = mock_metadata
     mock.create_incremental_backup.return_value = mock_metadata
     mock.list_backups.return_value = [mock_metadata]
-    mock.restore_from_backup.return_value = None
+    mock.restore_from_backup.return_value = RestoreResult(pre_restore_backup=None, rebuild_performed=False)
     mock.get_backup_summary.return_value = {
         "name": "backup_20250120_100000",
         "backup_mode": "full",
@@ -461,7 +462,9 @@ class TestRestoreBackupEndpoint:
         backup_dir.mkdir()
 
         mock_backup_manager.backup_dir = tmp_path
-        mock_backup_manager.restore_from_backup.return_value = None
+        mock_backup_manager.restore_from_backup.return_value = RestoreResult(
+            pre_restore_backup=None, rebuild_performed=False
+        )
 
         with patch('searchat.api.routers.backup.get_backup_manager', return_value=mock_backup_manager):
             with patch('searchat.api.routers.backup.invalidate_search_index') as invalidate:
@@ -470,7 +473,7 @@ class TestRestoreBackupEndpoint:
             assert response.status_code == 200
             data = response.json()
 
-            assert list(data) == ["success", "restored_from", "message"]
+            assert list(data) == ["success", "restored_from", "message", "rebuild_performed"]
             assert data["success"] is True
             assert data["restored_from"] == "backup_20250120_100000"
             assert "Successfully restored" in data["message"]
@@ -498,7 +501,9 @@ class TestRestoreBackupEndpoint:
         # Mock pre-restore backup metadata
         pre_restore_meta = Mock()
         pre_restore_meta.to_dict.return_value = {"backup_path": "/backups/pre_restore"}
-        mock_backup_manager.restore_from_backup.return_value = pre_restore_meta
+        mock_backup_manager.restore_from_backup.return_value = RestoreResult(
+            pre_restore_backup=pre_restore_meta, rebuild_performed=True
+        )
 
         with patch('searchat.api.routers.backup.get_backup_manager', return_value=mock_backup_manager):
             with patch('searchat.api.routers.backup.invalidate_search_index'):
@@ -507,7 +512,10 @@ class TestRestoreBackupEndpoint:
                 assert response.status_code == 200
                 data = response.json()
 
-                assert list(data) == ["success", "restored_from", "message", "pre_restore_backup"]
+                assert list(data) == [
+                    "success", "restored_from", "message", "rebuild_performed", "pre_restore_backup"
+                ]
+                assert data["rebuild_performed"] is True
                 assert "pre_restore_backup" in data
                 assert data["pre_restore_backup"]["backup_path"] == "/backups/pre_restore"
 

--- a/tests/unit/api/test_api_contracts.py
+++ b/tests/unit/api/test_api_contracts.py
@@ -517,6 +517,18 @@ def test_serialize_backup_payloads_preserve_shapes() -> None:
         "success": True,
         "restored_from": "backup_20250120_100000",
         "message": "Successfully restored from backup: backup_20250120_100000",
+        "rebuild_performed": False,
+    }
+    assert serialize_backup_restore_payload(
+        restored_from="backup_20250120_100000",
+        pre_restore_backup=backup,
+        rebuild_performed=True,
+    ) == {
+        "success": True,
+        "restored_from": "backup_20250120_100000",
+        "message": "Successfully restored from backup: backup_20250120_100000",
+        "rebuild_performed": True,
+        "pre_restore_backup": backup,
     }
     assert serialize_backup_delete_payload(deleted="backup_20250120_100000") == {
         "success": True,

--- a/tests/unit/services/test_backup_restore_rebuild.py
+++ b/tests/unit/services/test_backup_restore_rebuild.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import shutil
+
+from pathlib import Path
+
+import pytest
+
+from searchat.services.backup import BackupManager
+
+
+def _write_bytes(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def _seed_duckdb_conversation(db_path: Path) -> None:
+    """Create a minimal, schema-valid unified DuckDB with one conversation."""
+    from searchat.storage.unified_storage import UnifiedStorage
+
+    storage = UnifiedStorage(db_path)
+    try:
+        storage.connection.execute(
+            "INSERT INTO conversations "
+            "(conversation_id, project_id, file_path, title, created_at, updated_at, "
+            "message_count, full_text, file_hash, indexed_at) "
+            "VALUES ('c1', 'p1', '/tmp/c1.jsonl', 'Conv 1', now(), now(), 1, 'hello world', 'h1', now())"
+        )
+    finally:
+        storage.close()
+
+
+@pytest.mark.unit
+def test_restore_imports_source_tables_and_invokes_rebuild_derived(temp_search_dir: Path) -> None:
+    live = temp_search_dir
+    mgr = BackupManager(live)
+
+    _write_bytes(live / "data" / "conversations" / "conv.parquet", b"PAR1\n")
+    _seed_duckdb_conversation(live / "data" / "searchat.duckdb")
+
+    meta = mgr.create_backup(backup_name="snap")
+    assert meta.excludes_derived is True
+
+    # Break the live dataset so restore has something to rebuild.
+    shutil.rmtree(live / "data")
+
+    calls: list[Path] = []
+
+    def _fake_rebuild(search_dir: Path) -> None:
+        calls.append(search_dir)
+
+    mgr.restore_from_backup(
+        meta.backup_path,
+        create_pre_restore_backup=False,
+        rebuild_derived=_fake_rebuild,
+    )
+
+    assert calls == [live]
+    assert (live / "data" / "searchat.duckdb").exists()
+    assert not (live / "data" / "duckdb_source").exists()
+
+    from searchat.storage.unified_storage import UnifiedStorage
+
+    storage = UnifiedStorage(live / "data" / "searchat.duckdb", read_only=True)
+    try:
+        row = storage.connection.execute(
+            "SELECT conversation_id, title FROM conversations"
+        ).fetchone()
+    finally:
+        storage.close()
+    assert row == ("c1", "Conv 1")
+
+
+@pytest.mark.unit
+def test_restore_skips_rebuild_when_no_duckdb_was_ever_exported(temp_search_dir: Path) -> None:
+    live = temp_search_dir
+    mgr = BackupManager(live)
+
+    _write_bytes(live / "data" / "conversations" / "conv.parquet", b"PAR1\n")
+    meta = mgr.create_backup(backup_name="snap")
+    assert meta.excludes_derived is True
+
+    calls: list[Path] = []
+    mgr.restore_from_backup(
+        meta.backup_path,
+        create_pre_restore_backup=False,
+        rebuild_derived=lambda search_dir: calls.append(search_dir),
+    )
+
+    assert calls == []
+    assert not (live / "data" / "searchat.duckdb").exists()
+
+
+@pytest.mark.unit
+def test_restore_skips_rebuild_for_pre_m4_full_backup(temp_search_dir: Path) -> None:
+    live = temp_search_dir
+    mgr = BackupManager(live)
+
+    _write_bytes(live / "data" / "conversations" / "conv.parquet", b"PAR1\n")
+    _seed_duckdb_conversation(live / "data" / "searchat.duckdb")
+
+    meta = mgr.create_backup(backup_name="full", excludes_derived=False, compressed=False)
+    assert meta.excludes_derived is False
+
+    calls: list[Path] = []
+    mgr.restore_from_backup(
+        meta.backup_path,
+        create_pre_restore_backup=False,
+        rebuild_derived=lambda search_dir: calls.append(search_dir),
+    )
+
+    assert calls == []
+    # A pre-M4-style full backup restores searchat.duckdb byte-for-byte -- no
+    # rebuild needed or triggered.
+    assert (live / "data" / "searchat.duckdb").exists()
+
+
+@pytest.mark.unit
+def test_restore_defaults_excludes_derived_false_for_legacy_metadata_missing_field(
+    temp_search_dir: Path,
+) -> None:
+    import json
+
+    live = temp_search_dir
+    mgr = BackupManager(live)
+
+    _write_bytes(live / "data" / "conversations" / "conv.parquet", b"PAR1\n")
+    _seed_duckdb_conversation(live / "data" / "searchat.duckdb")
+    meta = mgr.create_backup(backup_name="snap")
+
+    # Simulate a pre-M4 metadata file: strip the new field entirely.
+    metadata_path = meta.backup_path / mgr.METADATA_FILE
+    payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    payload.pop("excludes_derived", None)
+    payload.pop("derived_schema_version", None)
+    metadata_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    calls: list[Path] = []
+    mgr.restore_from_backup(
+        meta.backup_path,
+        create_pre_restore_backup=False,
+        rebuild_derived=lambda search_dir: calls.append(search_dir),
+    )
+
+    assert calls == []
+
+
+@pytest.mark.unit
+def test_restore_default_rebuild_derived_constructs_real_unified_indexer(
+    temp_search_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When no callback is injected, the default wires up the real
+    UnifiedIndexer.rebuild_derived -- verified via a patch rather than
+    actually running embeddings."""
+    live = temp_search_dir
+    mgr = BackupManager(live)
+
+    _write_bytes(live / "data" / "conversations" / "conv.parquet", b"PAR1\n")
+    _seed_duckdb_conversation(live / "data" / "searchat.duckdb")
+    meta = mgr.create_backup(backup_name="snap")
+
+    shutil.rmtree(live / "data")
+
+    calls: list[tuple[Path, bool]] = []
+
+    from searchat.core.unified_indexer import UnifiedIndexer
+
+    def _fake_rebuild_derived(self: UnifiedIndexer, force: bool = False, progress=None):
+        calls.append((self.search_dir, force))
+
+    monkeypatch.setattr(UnifiedIndexer, "rebuild_derived", _fake_rebuild_derived)
+
+    mgr.restore_from_backup(meta.backup_path, create_pre_restore_backup=False)
+
+    assert calls == [(live, True)]
+
+
+@pytest.mark.unit
+def test_restore_into_empty_sandbox_yields_working_hybrid_and_keyword_search(
+    temp_search_dir: Path,
+) -> None:
+    """End-to-end acceptance check: backup -> wipe -> restore -> automatic
+    rebuild -> both FTS keyword search and HNSW vector search work against
+    the restored data, matching M4's stated restore acceptance criterion."""
+    import hashlib
+    from datetime import datetime
+    from unittest.mock import MagicMock, patch
+
+    import numpy as np
+
+    from searchat.config import Config
+    from searchat.core.unified_indexer import UnifiedIndexer
+    from searchat.storage.unified_storage import UnifiedStorage
+
+    def _deterministic_vector(text: str) -> list[float]:
+        seed = int(hashlib.sha256(text.encode()).hexdigest()[:8], 16)
+        rng = np.random.default_rng(seed)
+        return rng.random(384).tolist()
+
+    def _fake_embedder() -> MagicMock:
+        embedder = MagicMock()
+        embedder.encode.side_effect = lambda batch, **kwargs: np.array(
+            [_deterministic_vector(text) for text in batch]
+        )
+        return embedder
+
+    live = temp_search_dir
+    db_path = live / "data" / "searchat.duckdb"
+
+    now = datetime(2026, 1, 1, 12, 0, 0)
+    storage = UnifiedStorage(db_path)
+    storage.upsert_conversation(
+        conversation_id="conv-a",
+        project_id="proj1",
+        file_path="/fake/does/not/exist/conv-a.jsonl",
+        title="Conversation conv-a",
+        created_at=now,
+        updated_at=now,
+        message_count=4,
+        full_text="hello world",
+        file_hash="hash-conv-a",
+        indexed_at=now,
+    )
+    storage.insert_messages(
+        "conv-a",
+        [
+            {
+                "sequence": i,
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"conv-a message {i} about sorting a python list quickly",
+                "timestamp": now,
+                "has_code": False,
+                "code_blocks": None,
+            }
+            for i in range(4)
+        ],
+    )
+    storage.close()
+
+    config = Config.load()
+    with patch.object(UnifiedIndexer, "_get_embedder", return_value=_fake_embedder()):
+        UnifiedIndexer(live, config).rebuild_derived(force=True)
+
+    mgr = BackupManager(live)
+    backup = mgr.create_backup(backup_name="snap")
+    assert backup.excludes_derived is True
+
+    # Simulate restoring into an empty sandbox SEARCHAT_HOME.
+    shutil.rmtree(live / "data")
+
+    with patch.object(UnifiedIndexer, "_get_embedder", return_value=_fake_embedder()):
+        result = mgr.restore_from_backup(backup.backup_path, create_pre_restore_backup=False)
+
+    assert result.rebuild_performed is True
+
+    restored = UnifiedStorage(db_path, read_only=True)
+    try:
+        con = restored.connection
+        assert con.execute("SELECT count(*) FROM conversations").fetchone()[0] == 1
+        assert con.execute("SELECT count(*) FROM exchanges").fetchone()[0] > 0
+        assert con.execute("SELECT count(*) FROM verbatim_embeddings").fetchone()[0] > 0
+
+        # Keyword search: FTS BM25 finds the seeded exchange by a real word.
+        keyword_hits = con.execute(
+            "SELECT exchange_id, fts_main_exchanges.match_bm25(exchange_id, 'sorting') AS score "
+            "FROM exchanges WHERE score IS NOT NULL"
+        ).fetchall()
+        assert keyword_hits, "expected FTS to find the seeded 'sorting' exchange after restore"
+
+        # Semantic search: HNSW-backed cosine similarity returns neighbors.
+        probe = con.execute(
+            "SELECT embedding FROM verbatim_embeddings ORDER BY exchange_id LIMIT 1"
+        ).fetchone()
+        neighbors = con.execute(
+            "SELECT exchange_id, array_cosine_distance(embedding, ?::FLOAT[384]) AS dist "
+            "FROM verbatim_embeddings ORDER BY dist LIMIT 5",
+            [probe[0]],
+        ).fetchall()
+        assert neighbors, "expected HNSW vector search to return neighbors after restore"
+    finally:
+        restored.close()
+


### PR DESCRIPTION
## Summary

Part 3/3 of M4 (Backup v2: source-of-truth-only with retention).

- `restore_from_backup` now imports `data/duckdb_source/` (M4's exported source-of-truth tables) into a fresh `searchat.duckdb` and calls `UnifiedIndexer.rebuild_derived(force=True)` whenever the restored backup's metadata has `excludes_derived=True` and it actually exported those tables at backup time. Injectable `rebuild_derived` callback for testability; default constructs the real `UnifiedIndexer`.
- Backward compatibility: no-ops for legacy-engine datasets that never had a unified-engine database (no `duckdb_source/` was ever exported), and for pre-M4 full backups -- `excludes_derived` defaults to `False` for metadata missing the field entirely, so those restore byte-for-byte exactly as before, with no rebuild triggered.
- New `RestoreResult` contract replacing the bare `BackupMetadata | None` return: carries `pre_restore_backup` and `rebuild_performed`.
- `POST /api/backup/restore` now reports `rebuild_performed` in its response.

## Stack

Position: 3/3 (top of stack)

1. `feat/backup-source-set` (#96)
2. `feat/backup-retention` (#97)
3. `feat/backup-restore-rebuild` -> this PR

Depends on: #97 (base branch)

## Acceptance evidence

`tests/unit/services/test_backup_restore_rebuild.py::test_restore_into_empty_sandbox_yields_working_hybrid_and_keyword_search` is a genuine end-to-end test (real `rebuild_derived`, deterministic fake embedder to avoid loading a real model, matching the existing pattern in `tests/unit/test_cli_rebuild.py`): seeds a conversation, runs `rebuild_derived` to populate real FTS/HNSW indexes, creates a source-of-truth-only backup, deletes `data/` entirely (simulating an empty sandbox `SEARCHAT_HOME`), restores, and asserts both FTS `match_bm25` keyword search and HNSW `array_cosine_distance` vector search return real hits against the rebuilt index -- directly exercising M4's stated restore acceptance criterion.

## Validation

- `uv run pytest tests/unit/services/test_backup_contracts.py tests/unit/services/test_backup_incremental.py tests/api/test_stats_backup_routes.py -v --tb=short --no-cov` — 63 passed
- `uv run pytest -v --tb=short` — 2172 passed, 1 skipped, 82.04% coverage (gate: 80%)
