### PR TITLE
feat(connectors): implement omp connector for oh-my-pi sessions

### DIFF
--- a/src/searchat/config/constants.py
+++ b/src/searchat/config/constants.py
@@ -203,6 +203,11 @@ CONTINUE_SESSIONS_DIR_CANDIDATES = [
     Path.home() / ".continue" / "sessions",
 ]
 
+# oh-my-pi (omp) session directory locations
+OMP_DIR_CANDIDATES = [
+    Path.home() / ".omp" / "agent" / "sessions",
+]
+
 # WSL mount point patterns
 WSL_MOUNT_PREFIX = "/mnt/"
 WSL_UNC_PREFIX = "\\\\wsl$\\"
@@ -221,6 +226,7 @@ ENV_GEMINI_DATA_DIR = "SEARCHAT_GEMINI_DATA_DIR"
 ENV_CONTINUE_DATA_DIR = "SEARCHAT_CONTINUE_DATA_DIR"
 ENV_CURSOR_DATA_DIR = "SEARCHAT_CURSOR_DATA_DIR"
 ENV_AIDER_PROJECT_DIRS = "SEARCHAT_AIDER_PROJECT_DIRS"
+ENV_OMP_DATA_DIR = "SEARCHAT_OMP_DATA_DIR"
 
 ENV_PORT = "SEARCHAT_PORT"
 ENV_HOST = "SEARCHAT_HOST"

--- a/src/searchat/config/path_resolver.py
+++ b/src/searchat/config/path_resolver.py
@@ -32,6 +32,8 @@ from .constants import (
     CONTINUE_SESSIONS_DIR_CANDIDATES,
     ENV_CURSOR_DATA_DIR,
     ENV_AIDER_PROJECT_DIRS,
+    ENV_OMP_DATA_DIR,
+    OMP_DIR_CANDIDATES,
 )
 
 
@@ -405,6 +407,16 @@ class PathResolver:
         return PathResolver._deduplicate_paths(paths)
 
     @staticmethod
+    def resolve_omp_dirs(_config=None) -> list[Path]:
+        """Resolve oh-my-pi (omp) session directories.
+
+        omp stores conversation transcripts under `~/.omp/agent/sessions/<cwd-slug>/`.
+        """
+        return PathResolver._resolve_from_env_or_candidates(
+            ENV_OMP_DATA_DIR, OMP_DIR_CANDIDATES,
+        )
+
+    @staticmethod
     def resolve_all_agent_dirs(config=None) -> dict:
         """
         Resolve all supported AI coding agent directories.
@@ -425,4 +437,5 @@ class PathResolver:
             'continue': PathResolver.resolve_continue_dirs(config),
             'cursor': PathResolver.resolve_cursor_dirs(config),
             'aider': PathResolver.resolve_aider_dirs(config),
+            'omp': PathResolver.resolve_omp_dirs(config),
         }

--- a/src/searchat/core/connectors/omp.py
+++ b/src/searchat/core/connectors/omp.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from searchat.config import Config, PathResolver
+from searchat.core.connectors.base import AgentProviderBase
+from searchat.core.connectors.utils import (
+    MARKDOWN_CODE_BLOCK_RE,
+    parse_flexible_timestamp,
+    title_from_messages,
+)
+from searchat.core.logging_config import get_logger
+from searchat.models import ConversationRecord, MessageRecord
+
+logger = get_logger(__name__)
+
+# omp session files are named `<ISO8601-with-dashes>Z_<uuid>.jsonl`, e.g.
+# `2026-06-04T22-25-47-929Z_019e94be-1d99-7000-9ee7-c208ddf9d5ec.jsonl`, and live
+# directly under a per-cwd slug directory: `sessions/<cwd-slug>/<file>.jsonl`.
+# Per-tool-call logs and subagent transcripts live one level deeper, inside a
+# same-named companion directory (`sessions/<cwd-slug>/<file>/*.log`, occasional
+# `*.jsonl`) and never match this filename pattern -- keeping that noise out of
+# both discovery and the watcher's `detect_connector` filter without needing to
+# inspect file contents or directory depth.
+_SESSION_FILENAME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z_"
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$"
+)
+
+# omp message roles this connector treats as conversation content, normalized
+# to Searchat's role vocabulary (mirrors CodexConnector._normalize_role, which
+# maps "developer" -> "system" and accepts a "tool" role).
+_ROLE_MAP = {
+    "user": "user",
+    "assistant": "assistant",
+    "developer": "system",
+    "toolresult": "tool",
+    "bashexecution": "tool",
+}
+
+
+class OmpConnector(AgentProviderBase):
+    name: str = "omp"
+    supported_extensions: tuple[str, ...] = (".jsonl",)
+
+    def discover_files(self, config: Config) -> list[Path]:
+        files: list[Path] = []
+        for root in PathResolver.resolve_omp_dirs(config):
+            if not root.exists():
+                continue
+            for path in root.glob("*/*.jsonl"):
+                if _SESSION_FILENAME_RE.match(path.name):
+                    files.append(path)
+        return files
+
+    def watch_dirs(self, config: Config) -> list[Path]:
+        return [p for p in PathResolver.resolve_omp_dirs(config) if p.exists()]
+
+    def can_parse(self, path: Path) -> bool:
+        return path.suffix == ".jsonl" and bool(_SESSION_FILENAME_RE.match(path.name))
+
+    @staticmethod
+    def _normalize_role(value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        return _ROLE_MAP.get(value.strip().lower())
+
+    @staticmethod
+    def _extract_text(content: object) -> str:
+        """Concatenate `text`-type content blocks; skip thinking/toolCall/image."""
+        if isinstance(content, str):
+            return content.strip()
+        if not isinstance(content, list):
+            return ""
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n\n".join(parts)
+
+    def _iter_entries(self, path: Path) -> list[dict[str, Any]]:
+        """Parse each JSONL line, skipping and logging malformed ones.
+
+        omp rewrites some lines in place (e.g. padded `title` events), so a
+        line read mid-write can be truncated or invalid JSON; that must not
+        fail the whole file.
+        """
+        entries: list[dict[str, Any]] = []
+        with open(path, "r", encoding="utf-8") as f:
+            for line_no, raw_line in enumerate(f, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    logger.warning("Skipping malformed line %d in %s: %s", line_no, path, exc)
+                    continue
+                if isinstance(entry, dict):
+                    entries.append(entry)
+        return entries
+
+    def parse(self, path: Path, embedding_id: int) -> ConversationRecord:
+        entries = self._iter_entries(path)
+        fallback_timestamp = datetime.fromtimestamp(path.stat().st_mtime)
+
+        session_id: str | None = None
+        session_title: str | None = None
+        messages: list[MessageRecord] = []
+        full_text_parts: list[str] = []
+        created_at: datetime | None = None
+        updated_at: datetime | None = None
+
+        for entry in entries:
+            if entry.get("type") == "session":
+                if session_id is None and isinstance(entry.get("id"), str):
+                    session_id = entry["id"]
+                if session_title is None and isinstance(entry.get("title"), str) and entry["title"].strip():
+                    session_title = entry["title"].strip()
+                continue
+
+            if entry.get("type") != "message":
+                continue
+
+            message = entry.get("message")
+            if not isinstance(message, dict):
+                continue
+
+            role = self._normalize_role(message.get("role"))
+            if role is None:
+                continue
+
+            content = self._extract_text(message.get("content"))
+            if not content:
+                continue
+
+            timestamp = (
+                parse_flexible_timestamp(message.get("timestamp"))
+                or parse_flexible_timestamp(entry.get("timestamp"))
+                or fallback_timestamp
+            )
+
+            if created_at is None:
+                created_at = timestamp
+            updated_at = timestamp
+
+            code_blocks = MARKDOWN_CODE_BLOCK_RE.findall(content)
+            messages.append(
+                MessageRecord(
+                    sequence=len(messages),
+                    role=role,
+                    content=content,
+                    timestamp=timestamp,
+                    has_code=len(code_blocks) > 0,
+                    code_blocks=code_blocks,
+                )
+            )
+            full_text_parts.append(content)
+
+        file_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+        conversation_id = session_id or path.stem
+        title = session_title or title_from_messages(messages) or "Untitled omp Session"
+
+        return ConversationRecord(
+            conversation_id=conversation_id,
+            project_id=path.parent.name,
+            file_path=str(path),
+            title=title,
+            created_at=created_at or fallback_timestamp,
+            updated_at=updated_at or fallback_timestamp,
+            message_count=len(messages),
+            messages=messages,
+            full_text="\n\n".join(full_text_parts),
+            embedding_id=embedding_id,
+            file_hash=file_hash,
+            indexed_at=datetime.now(),
+        )
+
+    # -- V2: AgentProvider methods --
+
+    def load_messages(self, path: Path) -> list[dict[str, Any]]:
+        messages: list[dict[str, Any]] = []
+        for entry in self._iter_entries(path):
+            if entry.get("type") != "message":
+                continue
+            message = entry.get("message")
+            if not isinstance(message, dict):
+                continue
+            role = self._normalize_role(message.get("role"))
+            if role is None:
+                continue
+            content = self._extract_text(message.get("content"))
+            if content:
+                messages.append({"role": role, "content": content})
+        return messages
+
+    def extract_cwd(self, path: Path) -> str | None:
+        for entry in self._iter_entries(path):
+            if entry.get("type") == "session":
+                cwd = entry.get("cwd")
+                if isinstance(cwd, str) and cwd.strip():
+                    return cwd.strip()
+        return None
+
+    def build_resume_command(self, path: Path) -> str | None:
+        for entry in self._iter_entries(path):
+            if entry.get("type") == "session":
+                session_id = entry.get("id")
+                if isinstance(session_id, str) and session_id.strip():
+                    return f"omp --resume {session_id.strip()}"
+        return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,6 +192,7 @@ def _isolate_user_agent_dirs(monkeypatch):
     monkeypatch.setattr(PathResolver, "resolve_continue_dirs", staticmethod(lambda _cfg=None: []))
     monkeypatch.setattr(PathResolver, "resolve_cursor_dirs", staticmethod(lambda _cfg=None: []))
     monkeypatch.setattr(PathResolver, "resolve_aider_dirs", staticmethod(lambda _cfg=None: []))
+    monkeypatch.setattr(PathResolver, "resolve_omp_dirs", staticmethod(lambda _cfg=None: []))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures/connectors/omp/sessions/-tmp-demo-project/2026-03-29T10-00-00-000Z_01900000-0000-7000-8000-000000000001.jsonl
+++ b/tests/fixtures/connectors/omp/sessions/-tmp-demo-project/2026-03-29T10-00-00-000Z_01900000-0000-7000-8000-000000000001.jsonl
@@ -1,0 +1,7 @@
+{"type":"session","version":3,"id":"01900000-0000-7000-8000-000000000001","timestamp":"2026-03-29T10:00:00.000Z","cwd":"/tmp/demo-project","title":"Fix login bug","titleSource":"auto"}
+{"type":"model_change","id":"a1","parentId":null,"timestamp":"2026-03-29T10:00:01.000Z","model":"anthropic/claude-sonnet-5"}
+{"type":"thinking_level_change","id":"a2","parentId":"a1","timestamp":"2026-03-29T10:00:01.000Z","thinkingLevel":"medium"}
+{"type":"message","id":"m1","parentId":"a2","timestamp":"2026-03-29T10:00:05.000Z","message":{"role":"user","content":[{"type":"text","text":"Fix the login bug in auth.py"}],"attribution":"user","timestamp":1743235205000}}
+{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-03-29T10:00:10.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"Let's look at auth.py first."},{"type":"toolCall","id":"call_1","name":"read","arguments":{"path":"auth.py"}}],"attribution":"agent","timestamp":1743235210000}}
+{"type":"message","id":"m3","parentId":"m2","timestamp":"2026-03-29T10:00:12.000Z","message":{"role":"toolResult","toolCallId":"call_1","toolName":"read","content":[{"type":"text","text":"def login(user):\n    pass\n"}],"timestamp":1743235212000}}
+{"type":"message","id":"m4","parentId":"m3","timestamp":"2026-03-29T10:00:20.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Found the bug: login() is a stub. Implementing it now.\n\n```python\ndef login(user):\n    return authenticate(user)\n```"}],"attribution":"agent","timestamp":1743235220000}}

--- a/tests/fixtures/connectors/omp/sessions/-tmp-demo-project/2026-03-29T10-00-00-000Z_01900000-0000-7000-8000-000000000001/reviewer.jsonl
+++ b/tests/fixtures/connectors/omp/sessions/-tmp-demo-project/2026-03-29T10-00-00-000Z_01900000-0000-7000-8000-000000000001/reviewer.jsonl
@@ -1,0 +1,2 @@
+{"type":"session","version":3,"id":"01900000-0000-7000-8000-0000000000ff","timestamp":"2026-03-29T10:00:30.000Z","cwd":"/tmp/demo-project","title":"reviewer subagent","titleSource":"auto"}
+{"type":"message","id":"s1","parentId":null,"timestamp":"2026-03-29T10:00:31.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Subagent transcript -- must not be discovered as a top-level conversation."}],"attribution":"agent","timestamp":1743235231000}}

--- a/tests/fixtures/connectors/omp/sessions/-tmp-demo-project/2026-03-29T11-00-00-000Z_01900000-0000-7000-8000-000000000002.jsonl
+++ b/tests/fixtures/connectors/omp/sessions/-tmp-demo-project/2026-03-29T11-00-00-000Z_01900000-0000-7000-8000-000000000002.jsonl
@@ -1,0 +1,7 @@
+{"type":"title","v":1,"title":"Resume deploy script","source":"auto","updatedAt":"2026-03-29T11:05:00.000Z","pad":"                    "}
+{"type":"session","version":3,"id":"01900000-0000-7000-8000-000000000002","timestamp":"2026-03-29T11:00:00.000Z","cwd":"/tmp/demo-project","title":"Deploy script","titleSource":"auto"}
+{"type":"message","id":"n1","parentId":null,"timestamp":"2026-03-29T11:00:05.000Z","message":{"role":"developer","content":[{"type":"text","text":"Resume work on the deploy script."}],"attribution":"agent","timestamp":1743238805000}}
+{this is not valid json
+{"type":"message","id":"n2","parentId":"n1","timestamp":"2026-03-29T11:00:10.000Z","message":{"role":"user","content":[{"type":"text","text":"Run the deploy script and report the exit code"}],"attribution":"user","timestamp":1743238810000}}
+{"type":"message","id":"n3","parentId":"n2","timestamp":"2026-03-29T11:00:15.000Z","message":{"role":"bashExecution","content":[{"type":"text","text":"$ ./deploy.sh\nexit code: 0"}],"timestamp":1743238815000}}
+{"type":"message","id":"n4","parentId":"n3","timestamp":"2026-03-29T11:00:20.000Z","message":{"role":"assistant","content":[{"type":"image","data":"base64placeholder"}],"attribution":"agent","timestamp":1743238820000}}

--- a/tests/unit/config/test_path_resolver.py
+++ b/tests/unit/config/test_path_resolver.py
@@ -17,6 +17,7 @@ _orig_resolve_gemini = PathResolver.__dict__["resolve_gemini_dirs"]
 _orig_resolve_continue = PathResolver.__dict__["resolve_continue_dirs"]
 _orig_resolve_cursor = PathResolver.__dict__["resolve_cursor_dirs"]
 _orig_resolve_aider = PathResolver.__dict__["resolve_aider_dirs"]
+_orig_resolve_omp = PathResolver.__dict__["resolve_omp_dirs"]
 
 
 def _restore(monkeypatch, name: str, original: object) -> None:
@@ -270,6 +271,25 @@ class TestResolveContinueDirs:
         monkeypatch.setenv("SEARCHAT_CONTINUE_DATA_DIR", str(tmp_path))
         dirs = PathResolver.resolve_continue_dirs()
         assert tmp_path in dirs
+
+
+class TestResolveOmpDirs:
+    """Tests for PathResolver.resolve_omp_dirs."""
+
+    def test_env_var_overrides(self, monkeypatch, tmp_path):
+        _restore(monkeypatch, "resolve_omp_dirs", _orig_resolve_omp)
+        monkeypatch.setenv("SEARCHAT_OMP_DATA_DIR", str(tmp_path))
+        dirs = PathResolver.resolve_omp_dirs()
+        assert tmp_path in dirs
+
+    def test_no_env_var_no_candidate_returns_empty(self, monkeypatch, tmp_path):
+        _restore(monkeypatch, "resolve_omp_dirs", _orig_resolve_omp)
+        monkeypatch.delenv("SEARCHAT_OMP_DATA_DIR", raising=False)
+        monkeypatch.setattr(
+            "searchat.config.path_resolver.OMP_DIR_CANDIDATES",
+            [tmp_path / "does-not-exist"],
+        )
+        assert PathResolver.resolve_omp_dirs() == []
 
 
 class TestResolveCursorDirs:

--- a/tests/unit/connectors/test_v2_omp.py
+++ b/tests/unit/connectors/test_v2_omp.py
@@ -1,0 +1,164 @@
+"""Unit tests for OmpConnector V1 (discover/parse) and V2 methods."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from searchat.core.connectors.omp import OmpConnector
+
+FIXTURES_ROOT = Path("tests/fixtures/connectors/omp/sessions/-tmp-demo-project")
+SESSION_1 = FIXTURES_ROOT / "2026-03-29T10-00-00-000Z_01900000-0000-7000-8000-000000000001.jsonl"
+SESSION_2 = FIXTURES_ROOT / "2026-03-29T11-00-00-000Z_01900000-0000-7000-8000-000000000002.jsonl"
+NESTED_SUBAGENT = (
+    FIXTURES_ROOT
+    / "2026-03-29T10-00-00-000Z_01900000-0000-7000-8000-000000000001"
+    / "reviewer.jsonl"
+)
+
+
+@pytest.fixture
+def connector() -> OmpConnector:
+    return OmpConnector()
+
+
+def _write_session(tmp_path: Path, name: str, lines: list[dict]) -> Path:
+    slug_dir = tmp_path / "-tmp-demo-project"
+    slug_dir.mkdir(parents=True, exist_ok=True)
+    path = slug_dir / name
+    path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+    return path
+
+
+class TestOmpCanParse:
+    def test_can_parse_valid_session_filename(self, connector: OmpConnector) -> None:
+        assert connector.can_parse(SESSION_1) is True
+
+    def test_can_parse_rejects_non_jsonl(self, connector: OmpConnector, tmp_path: Path) -> None:
+        path = tmp_path / "2026-03-29T10-00-00-000Z_01900000-0000-7000-8000-000000000001.txt"
+        path.write_text("", encoding="utf-8")
+        assert connector.can_parse(path) is False
+
+    def test_can_parse_rejects_subagent_transcript_filename(self, connector: OmpConnector) -> None:
+        # Nested per-tool-call / subagent transcripts never match the
+        # `<timestamp>_<uuid>.jsonl` naming convention.
+        assert connector.can_parse(NESTED_SUBAGENT) is False
+
+    def test_can_parse_rejects_arbitrary_jsonl_name(self, connector: OmpConnector, tmp_path: Path) -> None:
+        path = tmp_path / "notes.jsonl"
+        path.write_text("{}", encoding="utf-8")
+        assert connector.can_parse(path) is False
+
+
+class TestOmpDiscoverFiles:
+    def test_discover_files_finds_top_level_sessions_only(
+        self, connector: OmpConnector, monkeypatch
+    ) -> None:
+        monkeypatch.setattr(
+            "searchat.core.connectors.omp.PathResolver.resolve_omp_dirs",
+            staticmethod(lambda _config=None: [FIXTURES_ROOT.parent]),
+        )
+        files = connector.discover_files(Mock())
+        assert set(files) == {SESSION_1, SESSION_2}
+        assert NESTED_SUBAGENT not in files
+
+    def test_discover_files_no_roots(self, connector: OmpConnector, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "searchat.core.connectors.omp.PathResolver.resolve_omp_dirs",
+            staticmethod(lambda _config=None: []),
+        )
+        assert connector.discover_files(Mock()) == []
+
+
+class TestOmpParse:
+    def test_parse_returns_conversation_record(self, connector: OmpConnector) -> None:
+        record = connector.parse(SESSION_1, embedding_id=0)
+
+        assert record.conversation_id == "01900000-0000-7000-8000-000000000001"
+        assert record.project_id == "-tmp-demo-project"
+        assert record.title == "Fix login bug"
+        # m1 (user), m2 (assistant thinking+toolCall only -> no text -> skipped),
+        # m3 (toolResult -> role "tool"), m4 (assistant with code block).
+        assert record.message_count == 3
+        roles = [m.role for m in record.messages]
+        assert roles == ["user", "tool", "assistant"]
+        assert record.messages[-1].has_code is True
+        assert "authenticate(user)" in record.full_text
+
+    def test_parse_skips_malformed_lines_and_maps_roles(self, connector: OmpConnector) -> None:
+        record = connector.parse(SESSION_2, embedding_id=1)
+
+        # n1 (developer -> system), n2 (user), n3 (bashExecution -> tool);
+        # n4 (assistant, image-only content -> no text -> skipped); the
+        # malformed raw line and the padded `title` event are both ignored.
+        assert record.message_count == 3
+        roles = [m.role for m in record.messages]
+        assert roles == ["system", "user", "tool"]
+        assert record.title == "Deploy script"
+
+    def test_parse_falls_back_to_stem_and_mtime_without_session_line(
+        self, connector: OmpConnector, tmp_path: Path
+    ) -> None:
+        path = _write_session(
+            tmp_path,
+            "2026-04-01T00-00-00-000Z_01900000-0000-7000-8000-0000000000aa.jsonl",
+            [{"type": "message", "id": "x1", "message": {"role": "user", "content": [{"type": "text", "text": "hi"}]}}],
+        )
+        record = connector.parse(path, embedding_id=2)
+        assert record.conversation_id == path.stem
+        assert record.title == "hi"
+        assert record.message_count == 1
+
+    def test_parse_empty_file(self, connector: OmpConnector, tmp_path: Path) -> None:
+        path = _write_session(tmp_path, "2026-04-01T00-00-00-000Z_01900000-0000-7000-8000-0000000000bb.jsonl", [])
+        record = connector.parse(path, embedding_id=3)
+        assert record.message_count == 0
+        assert record.messages == []
+        assert record.title == "Untitled omp Session"
+
+
+class TestOmpLoadMessages:
+    def test_load_messages_returns_normalized_roles(self, connector: OmpConnector) -> None:
+        messages = connector.load_messages(SESSION_1)
+        assert messages == [
+            {"role": "user", "content": "Fix the login bug in auth.py"},
+            {"role": "tool", "content": "def login(user):\n    pass"},
+            {
+                "role": "assistant",
+                "content": "Found the bug: login() is a stub. Implementing it now.\n\n"
+                "```python\ndef login(user):\n    return authenticate(user)\n```",
+            },
+        ]
+
+    def test_load_messages_empty_file(self, connector: OmpConnector, tmp_path: Path) -> None:
+        path = _write_session(tmp_path, "2026-04-01T00-00-00-000Z_01900000-0000-7000-8000-0000000000cc.jsonl", [])
+        assert connector.load_messages(path) == []
+
+
+class TestOmpExtractCwd:
+    def test_extract_cwd(self, connector: OmpConnector) -> None:
+        assert connector.extract_cwd(SESSION_1) == "/tmp/demo-project"
+
+    def test_extract_cwd_missing_session_line(self, connector: OmpConnector, tmp_path: Path) -> None:
+        path = _write_session(
+            tmp_path,
+            "2026-04-01T00-00-00-000Z_01900000-0000-7000-8000-0000000000dd.jsonl",
+            [{"type": "message", "id": "x1", "message": {"role": "user", "content": [{"type": "text", "text": "hi"}]}}],
+        )
+        assert connector.extract_cwd(path) is None
+
+
+class TestOmpBuildResumeCommand:
+    def test_build_resume_command(self, connector: OmpConnector) -> None:
+        cmd = connector.build_resume_command(SESSION_1)
+        assert cmd == "omp --resume 01900000-0000-7000-8000-000000000001"
+
+    def test_build_resume_command_no_session_line(self, connector: OmpConnector, tmp_path: Path) -> None:
+        path = _write_session(
+            tmp_path,
+            "2026-04-01T00-00-00-000Z_01900000-0000-7000-8000-0000000000ee.jsonl",
+            [{"type": "message", "id": "x1", "message": {"role": "user", "content": [{"type": "text", "text": "hi"}]}}],
+        )
+        assert connector.build_resume_command(path) is None


### PR DESCRIPTION
## Stack

Stack-Id: `omp-connector-m5`
Base: `main`
Position: 1/3

1. `feat/omp-connector` -> this PR
2. `feat/omp-connector-registration` -> PR-2 (registration + watch-dir wiring)
3. `feat/omp-connector-integration-tests` -> PR-3 (integration tests)

Depends on: (none - root)
Upstack: PR-2

## Summary

Part of M5 (omp connector, DEVELOPMENT_PLAN.md §4). Implements `OmpConnector`
(`core/connectors/omp.py`), the `AgentProviderBase` contract for
`~/.omp/agent/sessions/<cwd-slug>/<timestamp>_<uuid>.jsonl` transcripts —
measured as the largest unindexed conversation store on the machine (9.1 GB).

- `discover_files`/`can_parse` key off the session filename convention
  (`<ISO8601>Z_<uuid>.jsonl`), which per-tool-call logs and subagent
  transcripts nested one level deeper never match — verified against the
  real `~/.omp/agent/sessions` tree (251/251 top-level files match, 0/527
  nested files match).
- `parse()` normalizes omp's `user`/`assistant`/`developer`/`toolResult`/
  `bashExecution` roles to Searchat's role vocabulary (mirrors
  `CodexConnector._normalize_role`) and extracts only `text`-type content
  blocks, skipping `thinking`/`toolCall`/`image` blocks.
- Malformed JSONL lines are skipped and logged per-line — omp rewrites some
  lines in place (e.g. padded `title` events), so a line read mid-write can
  be invalid JSON without invalidating the rest of the file.
- V2 methods (`load_messages`, `extract_cwd`, `build_resume_command`)
  implement the `AgentProvider` contract; `build_resume_command` uses the
  real `omp --resume <session-id>` CLI flag.
- New `PathResolver.resolve_omp_dirs()` (env var `SEARCHAT_OMP_DATA_DIR` +
  `~/.omp/agent/sessions` candidate), following the codex/gemini/continue
  pattern.
- Fixture omp session files under `tests/fixtures/connectors/omp/`.
- Added `resolve_omp_dirs` to the autouse test-isolation fixture so the
  suite never scans the real `~/.omp/agent/sessions` directory.

Not yet registered as an active connector (no entry point / `__init__.py`
registration) — that lands in PR-2, so this PR is reviewable in isolation
without changing indexing/search behavior for any existing installation.

## Validation

- `uv run pytest tests/unit/connectors/ tests/unit/core/test_connectors_registry.py tests/unit/core/test_connectors_watch_dirs.py tests/unit/config/test_path_resolver.py -v --tb=short --no-cov` — 185 passed
- `uv run pytest -v --tb=short` (full suite, matches CI) — 2190 passed, 1 skipped, 82.14% coverage
- `uv run mypy src/searchat/core/connectors/omp.py --strict` — 0 diagnostics
- `uv run ruff check src/searchat/core/connectors/omp.py tests/unit/connectors/test_v2_omp.py` — 0 diagnostics