### PR TITLE
feat(connectors): register omp and wire tool filtering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ gemini = "searchat.core.connectors.gemini:GeminiCLIConnector"
 continue = "searchat.core.connectors.continue_cli:ContinueConnector"
 cursor = "searchat.core.connectors.cursor:CursorConnector"
 aider = "searchat.core.connectors.aider:AiderConnector"
+omp = "searchat.core.connectors.omp:OmpConnector"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/searchat"]

--- a/src/searchat/api/utils.py
+++ b/src/searchat/api/utils.py
@@ -31,7 +31,7 @@ def detect_tool_from_path(file_path: str) -> str:
         file_path: Path to conversation file
 
     Returns:
-        Tool name: 'claude', 'vibe', 'opencode', 'codex', 'gemini', 'continue', 'cursor', or 'aider'
+        Tool name: 'claude', 'vibe', 'opencode', 'codex', 'gemini', 'continue', 'cursor', 'aider', or 'omp'
     """
     normalized = file_path.lower().replace("\\", "/")
 
@@ -52,6 +52,9 @@ def detect_tool_from_path(file_path: str) -> str:
 
     if normalized.endswith("/.aider.chat.history.md") or normalized.endswith(".aider.chat.history.md"):
         return "aider"
+
+    if "/.omp/agent/sessions/" in normalized:
+        return "omp"
 
     if "/.claude/" in normalized and normalized.endswith(".jsonl"):
         return "claude"

--- a/src/searchat/config/constants.py
+++ b/src/searchat/config/constants.py
@@ -48,7 +48,7 @@ PORT_SCAN_RANGE = (8000, 8010)  # Will try ports in this range
 
 VALID_TOOL_NAMES: frozenset[str] = frozenset({
     "claude", "vibe", "opencode", "codex",
-    "gemini", "continue", "cursor", "aider",
+    "gemini", "continue", "cursor", "aider", "omp",
 })
 
 # ============================================================================

--- a/src/searchat/core/connectors/__init__.py
+++ b/src/searchat/core/connectors/__init__.py
@@ -11,6 +11,7 @@ from .registry import (
     has_v2_support,
 )
 from .codex import CodexConnector
+from .omp import OmpConnector
 from .claude import ClaudeConnector
 from .vibe import VibeConnector
 from .opencode import OpenCodeConnector
@@ -20,6 +21,7 @@ from .cursor import CursorConnector
 from .aider import AiderConnector
 
 register_connector(CodexConnector())
+register_connector(OmpConnector())
 register_connector(ClaudeConnector())
 register_connector(VibeConnector())
 register_connector(OpenCodeConnector())

--- a/src/searchat/core/filters.py
+++ b/src/searchat/core/filters.py
@@ -21,6 +21,10 @@ _TOOL_INCLUDE: dict[str, list[str]] = {
     "continue":  ["project_id LIKE 'continue-%'", "file_path ILIKE '%/.continue/sessions/%'"],
     "cursor":    ["project_id LIKE 'cursor-%'", "file_path ILIKE '%.vscdb.cursor/%'"],
     "aider":     ["project_id LIKE 'aider-%'", "file_path ILIKE '%/.aider.chat.history.md'"],
+    "omp":       [
+        "file_path ILIKE '%/.omp/agent/sessions/%'",
+        "file_path ILIKE '%\\.omp\\agent\\sessions\\%'",
+    ],
 }
 
 # Tools whose project_id patterns must be excluded when filtering for "claude".
@@ -31,6 +35,8 @@ _NON_CLAUDE_LIKE_PATTERNS: list[str] = [
     "project_id NOT LIKE 'continue-%'",
     "project_id NOT LIKE 'cursor-%'",
     "project_id NOT LIKE 'aider-%'",
+    "file_path NOT ILIKE '%/.omp/agent/sessions/%'",
+    "file_path NOT ILIKE '%\\.omp\\agent\\sessions\\%'",
     "project_id != 'gemini'",
     "project_id != 'codex'",
 ]

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -11,3 +11,7 @@ def test_detect_tool_from_path_opencode():
 
 def test_detect_tool_from_path_vibe_default():
     assert detect_tool_from_path("/home/user/.vibe/logs/session/session.json") == "vibe"
+
+
+def test_detect_tool_from_path_omp():
+    assert detect_tool_from_path("/home/user/.omp/agent/sessions/-my-project/s1.jsonl") == "omp"

--- a/tests/unit/api/test_utils.py
+++ b/tests/unit/api/test_utils.py
@@ -27,6 +27,11 @@ class TestDetectToolFromPath:
     def test_aider(self):
         assert detect_tool_from_path("/project/.aider.chat.history.md") == "aider"
 
+    def test_omp(self):
+        assert detect_tool_from_path(
+            "/home/user/.omp/agent/sessions/-my-project/2026-03-29T10-00-00-000Z_uuid.jsonl"
+        ) == "omp"
+
     def test_claude_jsonl(self):
         assert detect_tool_from_path("/home/user/.claude/projects/conv.jsonl") == "claude"
 

--- a/tests/unit/core/test_filters.py
+++ b/tests/unit/core/test_filters.py
@@ -12,7 +12,8 @@ class TestToolSqlConditions:
     def test_claude_returns_exclusion_conditions(self):
         conditions = tool_sql_conditions("claude")
         assert len(conditions) > 0
-        assert all("NOT LIKE" in c or "!=" in c for c in conditions)
+        assert all("NOT LIKE" in c or "NOT ILIKE" in c or "!=" in c for c in conditions)
+        assert any("omp" in c for c in conditions)
 
     def test_claude_with_prefix(self):
         conditions = tool_sql_conditions("claude", prefix="c")
@@ -42,9 +43,49 @@ class TestToolSqlConditions:
         with pytest.raises(ValueError, match="Unknown tool"):
             tool_sql_conditions("unknown_tool")
 
+    def test_omp_uses_file_path_condition(self):
+        conditions = tool_sql_conditions("omp")
+        assert len(conditions) == 1
+        assert "ILIKE" in conditions[0]
+        assert ".omp/agent/sessions" in conditions[0]
+
+    def test_omp_also_matches_windows_backslash_path(self):
+        # file_path is stored with native OS separators; on Windows that's
+        # backslashes, which the forward-slash-only pattern would miss.
+        conditions = tool_sql_conditions("omp")
+        assert len(conditions) == 1
+        assert ".omp\\agent\\sessions" in conditions[0]
+
+    def test_omp_condition_prefix_applied_to_both_alternatives(self):
+        conditions = tool_sql_conditions("omp", prefix="c")
+        assert len(conditions) == 1
+        assert conditions[0].count("c.file_path") == 2
+
     def test_all_valid_tools(self):
         from searchat.config.constants import VALID_TOOL_NAMES
         for tool in VALID_TOOL_NAMES:
             conditions = tool_sql_conditions(tool)
             assert isinstance(conditions, list)
             assert len(conditions) > 0
+
+
+class TestOmpConditionAgainstDuckDB:
+    """Executes the generated SQL against real DuckDB to prove semantics,
+    not just string shape -- both POSIX and Windows-separator paths must
+    match the omp condition, and a claude-style path must not.
+    """
+
+    def test_condition_matches_both_path_styles(self):
+        import duckdb
+
+        condition = tool_sql_conditions("omp")[0]
+        con = duckdb.connect(":memory:")
+
+        posix_path = "/home/user/.omp/agent/sessions/-proj/2026-01-01T00-00-00-000Z_uuid.jsonl"
+        windows_path = r"C:\Users\user\.omp\agent\sessions\-proj\2026-01-01T00-00-00-000Z_uuid.jsonl"
+        claude_path = r"C:\Users\user\.claude\projects\proj\conv.jsonl"
+
+        for path, expected in ((posix_path, True), (windows_path, True), (claude_path, False)):
+            row = con.execute(f"SELECT ({condition}) FROM (SELECT ? AS file_path)", [path]).fetchone()
+            assert row is not None
+            assert row[0] is expected, f"{path!r} expected {expected}, got {row[0]}"


### PR DESCRIPTION
## Stack

Stack-Id: `omp-connector-m5`
Base: `feat/omp-connector` (#99)
Position: 2/3

1. `feat/omp-connector` -> #99
2. `feat/omp-connector-registration` -> this PR
3. `feat/omp-connector-integration-tests` -> PR-3 (integration tests)

Depends on: #99
Upstack: PR-3

## Summary

Part of M5 (omp connector). Registers `OmpConnector` from #99 as an active
connector and wires it into the tool-filtering/detection surfaces that
`VALID_TOOL_NAMES` touches:

- `pyproject.toml`: `omp` entry point under `[project.entry-points."searchat.connectors"]`.
- `core/connectors/__init__.py`: direct registration (matching every other
  built-in connector — the entry point is a redundant safety net for
  third-party installs, same as the existing 8).
- `config/constants.py`: `"omp"` added to `VALID_TOOL_NAMES`.
- `core/filters.py`: omp conversations get a `project_id` that's just the
  raw cwd-slug (no tool-prefixed marker), so without a positive SQL
  condition they fell through to the catch-all `claude` exclusion branch —
  every omp result would have been misfiltered as claude. Added a
  `file_path ILIKE '%/.omp/agent/sessions/%'` condition and excluded it
  from claude's NOT-LIKE set.
- `api/utils.py`: `detect_tool_from_path()` had the same gap — omp paths
  fell through to the `.jsonl` → `claude` fallback used by every search
  result's displayed `tool` label. Added an omp branch.

No `registry.py` change needed: `discover_watch_dirs()` already dispatches
through each connector's `watch_dirs()` generically.

## Validation

- `uv run pytest tests/unit/core/test_filters.py tests/api/test_utils.py tests/unit/api/test_utils.py tests/unit/connectors/ -v --tb=short --no-cov` — all passed
- `uv run pytest -v --tb=short` (full suite) — 2193 passed, 1 skipped, 82.15% coverage
- Verified end-to-end: `importlib.metadata.entry_points(group="searchat.connectors")` includes `omp`, and `get_connectors()` includes it after normal package import (both direct-registration and entry-point-discovery paths confirmed working).
- `uv run mypy src/searchat/core/filters.py src/searchat/api/utils.py src/searchat/core/connectors/__init__.py --strict` / `uv run ruff check` on changed files — no new diagnostics.