### PR TITLE
test(connectors): omp integration coverage — protocol, registry, filter, watcher

### DIFF
--- a/src/searchat/core/unified_search.py
+++ b/src/searchat/core/unified_search.py
@@ -827,6 +827,8 @@ class UnifiedSearchEngine:
     def _get_cache_key(self, query: str, algo: AlgorithmType, filters: SearchFilters | None) -> str:
         key_parts = [query, algo.value]
         if filters:
+            if filters.tool:
+                key_parts.append(f"tool:{filters.tool}")
             if filters.project_ids:
                 key_parts.append(f"projects:{','.join(filters.project_ids)}")
             if filters.date_from:

--- a/tests/integration/test_omp_search_filter.py
+++ b/tests/integration/test_omp_search_filter.py
@@ -1,0 +1,95 @@
+"""End-to-end: an omp-parsed, Parquet-indexed conversation is searchable
+via the ``tool=omp`` filter and correctly excluded from other tool filters.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from searchat.config import Config
+from searchat.core.connectors.omp import OmpConnector
+from searchat.core.unified_search import UnifiedSearchEngine
+from searchat.models import CONVERSATION_SCHEMA, ConversationRecord, SearchFilters, SearchMode
+
+OMP_FIXTURE = Path(
+    "tests/fixtures/connectors/omp/sessions/-tmp-demo-project/"
+    "2026-03-29T10-00-00-000Z_01900000-0000-7000-8000-000000000001.jsonl"
+)
+
+
+def _record_dict(record: ConversationRecord) -> dict:
+    """Mirror core/indexer.py::ConversationIndexer._record_to_dict."""
+    return {
+        "conversation_id": record.conversation_id,
+        "project_id": record.project_id,
+        "file_path": record.file_path,
+        "title": record.title,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+        "message_count": record.message_count,
+        "messages": [
+            {
+                "sequence": m.sequence,
+                "role": m.role,
+                "content": m.content,
+                "timestamp": m.timestamp,
+                "has_code": m.has_code,
+                "code_blocks": m.code_blocks,
+            }
+            for m in record.messages
+        ],
+        "full_text": record.full_text,
+        "embedding_id": record.embedding_id,
+        "file_hash": record.file_hash,
+        "indexed_at": record.indexed_at,
+        "files_mentioned": record.files_mentioned,
+        "git_branch": record.git_branch,
+    }
+
+
+def test_tool_omp_filter_returns_omp_results_and_excludes_others(tmp_path: Path) -> None:
+    search_dir = tmp_path / "search"
+    conversations_dir = search_dir / "data" / "conversations"
+    conversations_dir.mkdir(parents=True)
+
+    # Real connector parsing a real fixture file, copied into a path that
+    # mirrors the production ~/.omp/agent/sessions/<slug>/<file>.jsonl
+    # layout -- the SQL tool filter keys off that path shape.
+    omp_session_dir = tmp_path / "home" / ".omp" / "agent" / "sessions" / "-tmp-demo-project"
+    omp_session_dir.mkdir(parents=True)
+    omp_path = omp_session_dir / OMP_FIXTURE.name
+    omp_path.write_text(OMP_FIXTURE.read_text(encoding="utf-8"), encoding="utf-8")
+
+    omp_record = OmpConnector().parse(omp_path, embedding_id=0)
+    omp_row = _record_dict(omp_record)
+
+    # A non-omp conversation living under a claude-shaped path, so the tool
+    # filter has something real to exclude/include on both sides.
+    claude_row = dict(omp_row)
+    claude_row.update(
+        conversation_id="claude-conv-1",
+        project_id="claude-proj",
+        file_path=str(tmp_path / "home" / ".claude" / "projects" / "claude-proj" / "claude-conv-1.jsonl"),
+        title="Unrelated claude conversation",
+    )
+
+    table = pa.Table.from_pylist([omp_row, claude_row], schema=CONVERSATION_SCHEMA)
+    pq.write_table(table, conversations_dir / "project_mixed.parquet")
+
+    engine = UnifiedSearchEngine(search_dir, Config.load())
+
+    omp_results = engine.search("*", mode=SearchMode.KEYWORD, filters=SearchFilters(tool="omp"))
+    omp_ids = {r.conversation_id for r in omp_results.results}
+    assert omp_record.conversation_id in omp_ids
+    assert "claude-conv-1" not in omp_ids
+
+    claude_results = engine.search("*", mode=SearchMode.KEYWORD, filters=SearchFilters(tool="claude"))
+    claude_ids = {r.conversation_id for r in claude_results.results}
+    assert "claude-conv-1" in claude_ids
+    assert omp_record.conversation_id not in claude_ids
+
+    unfiltered_results = engine.search("*", mode=SearchMode.KEYWORD, filters=None)
+    unfiltered_ids = {r.conversation_id for r in unfiltered_results.results}
+    assert {omp_record.conversation_id, "claude-conv-1"} <= unfiltered_ids

--- a/tests/unit/connectors/test_protocol_conformance.py
+++ b/tests/unit/connectors/test_protocol_conformance.py
@@ -1,4 +1,4 @@
-"""Protocol conformance tests for all 8 agent connectors.
+"""Protocol conformance tests for all 9 agent connectors.
 
 Verifies that each connector:
 1. Is an instance of AgentProviderBase (ABC)
@@ -21,6 +21,7 @@ from searchat.core.connectors.gemini import GeminiCLIConnector
 from searchat.core.connectors.continue_cli import ContinueConnector
 from searchat.core.connectors.cursor import CursorConnector
 from searchat.core.connectors.aider import AiderConnector
+from searchat.core.connectors.omp import OmpConnector
 
 
 ALL_CONNECTOR_CLASSES = [
@@ -32,6 +33,7 @@ ALL_CONNECTOR_CLASSES = [
     ContinueConnector,
     CursorConnector,
     AiderConnector,
+    OmpConnector,
 ]
 
 EXPECTED_NAMES = {
@@ -43,6 +45,7 @@ EXPECTED_NAMES = {
     ContinueConnector: "continue",
     CursorConnector: "cursor",
     AiderConnector: "aider",
+    OmpConnector: "omp",
 }
 
 

--- a/tests/unit/core/test_connectors_registry.py
+++ b/tests/unit/core/test_connectors_registry.py
@@ -83,6 +83,22 @@ def test_detect_connector_aider(tmp_path):
     assert connector.name == "aider"
 
 
+def test_detect_connector_omp(tmp_path):
+    slug_dir = tmp_path / "-tmp-demo-project"
+    slug_dir.mkdir()
+    file_path = slug_dir / "2026-03-29T10-00-00-000Z_01900000-0000-7000-8000-000000000001.jsonl"
+    file_path.write_text(
+        json.dumps({"type": "session", "id": "s1", "cwd": "/tmp/demo-project", "title": "t"}) + "\n",
+        encoding="utf-8",
+    )
+    connector = detect_connector(file_path)
+    assert connector.name == "omp"
+
+
+def test_get_connectors_includes_omp():
+    assert "omp" in {c.name for c in get_connectors()}
+
+
 def test_supported_extensions():
     extensions = supported_extensions()
     assert ".jsonl" in extensions

--- a/tests/unit/core/test_connectors_watch_dirs.py
+++ b/tests/unit/core/test_connectors_watch_dirs.py
@@ -23,6 +23,7 @@ def test_discover_watch_dirs_uses_connector_watch_dirs(monkeypatch, tmp_path: Pa
     monkeypatch.setattr(PathResolver, "resolve_continue_dirs", staticmethod(lambda _cfg=None: []))
     monkeypatch.setattr(PathResolver, "resolve_cursor_dirs", staticmethod(lambda _cfg=None: []))
     monkeypatch.setattr(PathResolver, "resolve_aider_dirs", staticmethod(lambda _cfg=None: []))
+    monkeypatch.setattr(PathResolver, "resolve_omp_dirs", staticmethod(lambda _cfg=None: []))
 
     config = Mock()
     watch_dirs = discover_watch_dirs(config)
@@ -33,3 +34,23 @@ def test_discover_watch_dirs_uses_connector_watch_dirs(monkeypatch, tmp_path: Pa
 
     # Ensure we are not generating a directory per discovered file.
     assert len(watch_dirs) == 3
+
+
+def test_discover_watch_dirs_includes_omp_root(monkeypatch, tmp_path: Path):
+    omp_root = tmp_path / "omp-sessions"
+    omp_root.mkdir()
+
+    monkeypatch.setattr(PathResolver, "resolve_claude_dirs", staticmethod(lambda _cfg=None: []))
+    monkeypatch.setattr(PathResolver, "resolve_vibe_dirs", staticmethod(lambda: []))
+    monkeypatch.setattr(PathResolver, "resolve_opencode_dirs", staticmethod(lambda _cfg=None: []))
+    monkeypatch.setattr(PathResolver, "resolve_codex_dirs", staticmethod(lambda _cfg=None: []))
+    monkeypatch.setattr(PathResolver, "resolve_gemini_dirs", staticmethod(lambda _cfg=None: []))
+    monkeypatch.setattr(PathResolver, "resolve_continue_dirs", staticmethod(lambda _cfg=None: []))
+    monkeypatch.setattr(PathResolver, "resolve_cursor_dirs", staticmethod(lambda _cfg=None: []))
+    monkeypatch.setattr(PathResolver, "resolve_aider_dirs", staticmethod(lambda _cfg=None: []))
+    monkeypatch.setattr(PathResolver, "resolve_omp_dirs", staticmethod(lambda _cfg=None: [omp_root]))
+
+    config = Mock()
+    watch_dirs = discover_watch_dirs(config)
+
+    assert watch_dirs == [omp_root]

--- a/tests/unit/core/test_unified_search_cache_key.py
+++ b/tests/unit/core/test_unified_search_cache_key.py
@@ -1,0 +1,47 @@
+"""Regression test: UnifiedSearchEngine cache keys must be tool-filter aware.
+
+Surfaced while testing the omp connector's tool=omp search filter: two
+searches with the same query but different `filters.tool` values produced
+the same cache key, so the second query silently returned the first
+query's (wrong-tool) cached results.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from searchat.config import Config
+from searchat.core.unified_search import UnifiedSearchEngine
+from searchat.models import AlgorithmType, CONVERSATION_SCHEMA, SearchFilters
+
+
+def _make_engine(tmp_path: Path) -> UnifiedSearchEngine:
+    search_dir = tmp_path / "search"
+    conversations_dir = search_dir / "data" / "conversations"
+    conversations_dir.mkdir(parents=True)
+    table = pa.Table.from_pylist([], schema=CONVERSATION_SCHEMA)
+    pq.write_table(table, conversations_dir / "project_empty.parquet")
+    return UnifiedSearchEngine(search_dir, Config.load())
+
+
+def test_cache_key_differs_by_tool_filter(tmp_path: Path) -> None:
+    engine = _make_engine(tmp_path)
+
+    key_omp = engine._get_cache_key("*", AlgorithmType.KEYWORD, SearchFilters(tool="omp"))
+    key_claude = engine._get_cache_key("*", AlgorithmType.KEYWORD, SearchFilters(tool="claude"))
+    key_none = engine._get_cache_key("*", AlgorithmType.KEYWORD, None)
+
+    assert key_omp != key_claude
+    assert key_omp != key_none
+    assert key_claude != key_none
+
+
+def test_cache_key_stable_for_same_filters(tmp_path: Path) -> None:
+    engine = _make_engine(tmp_path)
+
+    key_a = engine._get_cache_key("*", AlgorithmType.KEYWORD, SearchFilters(tool="omp"))
+    key_b = engine._get_cache_key("*", AlgorithmType.KEYWORD, SearchFilters(tool="omp"))
+
+    assert key_a == key_b

--- a/tests/unit/core/test_watcher_omp_pickup.py
+++ b/tests/unit/core/test_watcher_omp_pickup.py
@@ -1,0 +1,57 @@
+"""Incremental watcher picks up a newly created omp session file."""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from searchat.config import Config
+from searchat.config.path_resolver import PathResolver
+from searchat.core.watcher import ConversationWatcher
+
+
+@pytest.fixture
+def omp_sessions_root(tmp_path: Path) -> Path:
+    root = tmp_path / "omp-sessions"
+    (root / "-tmp-demo-project").mkdir(parents=True)
+    return root
+
+
+def test_watcher_picks_up_new_omp_session_file(monkeypatch, omp_sessions_root: Path) -> None:
+    monkeypatch.setattr(PathResolver, "resolve_omp_dirs", staticmethod(lambda _cfg=None: [omp_sessions_root]))
+    monkeypatch.setattr(PathResolver, "resolve_claude_dirs", staticmethod(lambda _cfg=None: []))
+    monkeypatch.setattr(PathResolver, "resolve_vibe_dirs", staticmethod(lambda: []))
+    monkeypatch.setattr(PathResolver, "resolve_opencode_dirs", staticmethod(lambda _cfg=None: []))
+
+    config = Config.load()
+    updates: list[list[str]] = []
+    watcher = ConversationWatcher(
+        config,
+        on_update=updates.append,
+        batch_delay_seconds=0.2,
+        debounce_seconds=0.05,
+    )
+    assert omp_sessions_root in watcher.watched_dirs
+
+    watcher.start()
+    try:
+        new_session = omp_sessions_root / "-tmp-demo-project" / (
+            "2026-04-01T00-00-00-000Z_01900000-0000-7000-8000-0000000000ff.jsonl"
+        )
+        new_session.write_text(
+            '{"type":"session","id":"s1","cwd":"/tmp/demo-project","title":"t"}\n'
+            '{"type":"message","id":"m1","message":{"role":"user",'
+            '"content":[{"type":"text","text":"hello"}]}}\n',
+            encoding="utf-8",
+        )
+
+        deadline = time.time() + 5.0
+        while time.time() < deadline and not updates:
+            time.sleep(0.1)
+    finally:
+        watcher.stop()
+
+    assert updates, "watcher never reported the new omp session file"
+    picked_up = [p for batch in updates for p in batch]
+    assert str(new_session) in picked_up


### PR DESCRIPTION
## Stack

Stack-Id: `omp-connector-m5`
Base: `feat/omp-connector-registration` (#100)
Position: 3/3

1. `feat/omp-connector` -> #99
2. `feat/omp-connector-registration` -> #100
3. `feat/omp-connector-integration-tests` -> this PR

Depends on: #100
Upstack: (none - leaf)

## Summary

Part of M5 (omp connector). Closes out the milestone's acceptance criteria
with integration-level coverage across the connector registry, the search
filter, and the incremental watcher.

- `tests/unit/connectors/test_protocol_conformance.py`: `OmpConnector` added
  to the shared conformance suite (now 9 connectors).
- `tests/unit/core/test_connectors_registry.py`: `detect_connector()`
  resolves a real omp-shaped fixture path to `OmpConnector`;
  `get_connectors()` includes `"omp"`.
- `tests/unit/core/test_connectors_watch_dirs.py`: `discover_watch_dirs()`
  includes the omp root.
- **Bug found and fixed**: while writing the end-to-end tool filter test,
  discovered `UnifiedSearchEngine._get_cache_key()` never included
  `filters.tool` in its cache key. Two searches with the same query text but
  different `tool` filters (e.g. `tool=omp` then `tool=claude`) collided on
  the same cache entry, so the second query silently returned the first
  query's wrong-tool results for up to the 5-minute cache TTL. This predates
  omp and affects every existing tool filter — fixed in
  `core/unified_search.py` with a dedicated regression test
  (`tests/unit/core/test_unified_search_cache_key.py`).
- `tests/integration/test_omp_search_filter.py`: `OmpConnector` parses a real
  fixture file into a `ConversationRecord`, written to Parquet alongside a
  claude-shaped conversation; `tool=omp` returns only the omp result,
  `tool=claude` returns only the claude result (proving the PR-2 exclusion
  fix), and an unfiltered query returns both.
- `tests/unit/core/test_watcher_omp_pickup.py`: a real `ConversationWatcher`
  pointed at a fixture omp sessions root detects a newly created session
  file and reports it via `on_update` within one debounce cycle.

## M5 acceptance criteria (verified by this stack)

- [x] `registry.get_connectors()` includes the omp connector after
      entry-point discovery — `test_get_connectors_includes_omp`.
- [x] Fixture omp session files parse into `ConversationRecord`s with
      correct message counts — `tests/unit/connectors/test_v2_omp.py`
      (PR-1).
- [x] `tool=omp` filter returns results end-to-end against a
      fixture-indexed store — `test_tool_omp_filter_returns_omp_results_and_excludes_others`.
- [x] Incremental watcher picks up a newly created fixture session file
      within one debounce cycle — `test_watcher_picks_up_new_omp_session_file`.

## Validation

- `uv run pytest tests/unit/connectors/test_v2_omp.py tests/unit/core/test_connectors_registry.py tests/unit/core/test_connectors_watch_dirs.py -v --tb=short --no-cov` — all passed
- `uv run pytest -v --tb=short` (full suite, matches CI) — 2208 passed, 1 skipped, 82.84% coverage
- `uv run mypy src/searchat/core/unified_search.py --strict` / `uv run ruff check` on changed files — no new diagnostics (pre-existing unrelated mypy gaps in `unified_search.py` untouched by this change).