### PR TITLE
feat(services): add per-connector disk accounting with du-equivalent sizing

### DIFF
--- a/src/searchat/services/disk_accounting.py
+++ b/src/searchat/services/disk_accounting.py
@@ -1,0 +1,145 @@
+"""Read-only disk accounting for registered connectors and Searchat's own footprint.
+
+M6 -- Disk manager dashboard. Aggregates per-connector on-disk usage (a
+`du`-equivalent walk of each connector's watch directories) plus the
+indexed-vs-unindexed delta sourced from `source_file_state`, and Searchat's
+own `~/.searchat` subdirectory footprint (index, backups, models, expertise,
+and any other subdirectory found).
+
+Every function in this module only reads the filesystem and the DuckDB
+store opened read-only -- there is no mutation code path here, matching the
+"report first" ordering from the enhancement catalog (M7 cruft advisor and
+M11 dedup detection build on this module but stay report-only too).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from searchat.config import Config
+
+
+@dataclass(frozen=True)
+class _DirectoryUsage:
+    """`du`-equivalent size/count for one directory tree, walked recursively."""
+
+    total_size_bytes: int
+    file_count: int
+
+
+def _walk_directory(path: Path) -> _DirectoryUsage:
+    """Recursively sum file sizes and counts under `path`, `du`-style.
+
+    Symlinks are not followed (matches `du`'s default POSIX behavior) and
+    unreadable entries are skipped rather than raised, so one permission
+    error or a file removed mid-walk never fails the whole report.
+    """
+    if not path.exists():
+        return _DirectoryUsage(total_size_bytes=0, file_count=0)
+    total_size = 0
+    file_count = 0
+    stack = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = list(current.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                if entry.is_symlink():
+                    continue
+                if entry.is_dir():
+                    stack.append(entry)
+                    continue
+                size = entry.stat().st_size
+            except OSError:
+                continue
+            total_size += size
+            file_count += 1
+    return _DirectoryUsage(total_size_bytes=total_size, file_count=file_count)
+
+
+def _connector_watch_dirs(connector: Any, config: Config) -> list[Path]:
+    """Per-connector watch directories, deduplicated.
+
+    Mirrors `registry.discover_watch_dirs`'s per-connector resolution (a
+    `watch_dirs(config)` method when the connector defines one, else the
+    deduplicated parent directories of `discover_files(config)`) but keeps
+    the result scoped to one connector instead of flattening across all of
+    them, which per-agent accounting requires.
+    """
+    watch_dirs_fn = getattr(connector, "watch_dirs", None)
+    if callable(watch_dirs_fn):
+        try:
+            return [d for d in watch_dirs_fn(config) if d.exists()]
+        except Exception:
+            return []
+    try:
+        files = connector.discover_files(config)
+    except Exception:
+        return []
+    seen: set[str] = set()
+    dirs: list[Path] = []
+    for file_path in files:
+        parent = file_path.parent
+        key = str(parent.resolve()) if parent.exists() else str(parent)
+        if key in seen:
+            continue
+        seen.add(key)
+        dirs.append(parent)
+    return dirs
+
+
+@dataclass(frozen=True)
+class AgentDiskUsage:
+    """Read-only disk-usage summary for one registered connector."""
+
+    connector: str
+    watch_dirs: tuple[str, ...]
+    total_size_bytes: int
+    total_file_count: int
+    conversation_file_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "connector": self.connector,
+            "watch_dirs": list(self.watch_dirs),
+            "total_size_bytes": self.total_size_bytes,
+            "total_file_count": self.total_file_count,
+            "conversation_file_count": self.conversation_file_count,
+        }
+
+
+def compute_agent_disk_usage(connector: Any, config: Config) -> AgentDiskUsage:
+    """Build the size/count summary for one connector.
+
+    `total_size_bytes`/`total_file_count` walk every file under the
+    connector's watch directories (the `du`-equivalent figure the M6
+    acceptance criterion is measured against), independent of whether a
+    given file is a conversation the connector recognizes.
+    `conversation_file_count` is scoped to `discover_files` results only --
+    non-conversation files in the same directory (harness state, caches)
+    are counted toward the size total but not toward this count.
+    """
+    watch_dirs = _connector_watch_dirs(connector, config)
+    total_size = 0
+    total_count = 0
+    for watch_dir in watch_dirs:
+        usage = _walk_directory(watch_dir)
+        total_size += usage.total_size_bytes
+        total_count += usage.file_count
+
+    try:
+        conversation_files = connector.discover_files(config)
+    except Exception:
+        conversation_files = []
+
+    return AgentDiskUsage(
+        connector=connector.name,
+        watch_dirs=tuple(str(d) for d in watch_dirs),
+        total_size_bytes=total_size,
+        total_file_count=total_count,
+        conversation_file_count=len(conversation_files),
+    )

--- a/src/searchat/services/disk_accounting.py
+++ b/src/searchat/services/disk_accounting.py
@@ -124,14 +124,37 @@ def _connector_watch_dirs(connector: Any, config: Config) -> list[Path]:
     return dirs
 
 
-def _read_indexed_paths_by_connector(db_path: Path) -> dict[str, set[str]]:
+def _read_indexed_paths_by_connector(
+    db_path: Path, *, connection: duckdb.DuckDBPyConnection | None = None
+) -> dict[str, set[str]]:
     """Return `{connector_name: {file_path, ...}}` for `status = 'indexed'` rows.
 
     Rows written before `connector_name` was threaded through (or by legacy
     code paths) have a null/empty `connector_name`; those are routed to the
     correct connector by re-running `detect_connector` on the stored path
     rather than being fanned out into every connector's set.
+
+    When `connection` is given (the live server's own open `UnifiedStorage`
+    connection), a fresh cursor on it is used instead of opening a second
+    file handle -- DuckDB refuses a second same-process connection to the
+    same file once the first has non-default config (e.g. `memory_limit`
+    set by `UnifiedStorage.__init__`), which a bare
+    `duckdb.connect(db_path, read_only=True)` would hit whenever this runs
+    inside the running `searchat-web` process. The CLI path (no live
+    connection) keeps opening its own short-lived read-only connection.
     """
+    if connection is not None:
+        cur = connection.cursor()
+        try:
+            rows = cur.execute(
+                "SELECT connector_name, file_path FROM source_file_state WHERE status = 'indexed'"
+            ).fetchall()
+        except duckdb.Error:
+            return {}
+        finally:
+            cur.close()
+        return _group_indexed_rows(rows)
+
     if not db_path.exists():
         return {}
     con = duckdb.connect(str(db_path), read_only=True)
@@ -143,7 +166,10 @@ def _read_indexed_paths_by_connector(db_path: Path) -> dict[str, set[str]]:
         return {}
     finally:
         con.close()
+    return _group_indexed_rows(rows)
 
+
+def _group_indexed_rows(rows: list[tuple[str | None, str]]) -> dict[str, set[str]]:
     by_connector: dict[str, set[str]] = {}
     for connector_name, file_path in rows:
         name = connector_name
@@ -349,15 +375,21 @@ class DiskAccountingReport:
         }
 
 
-def build_disk_accounting_report(search_dir: Path, config: Config) -> DiskAccountingReport:
+def build_disk_accounting_report(
+    search_dir: Path, config: Config, *, connection: duckdb.DuckDBPyConnection | None = None
+) -> DiskAccountingReport:
     """Assemble the full read-only disk-accounting report for `search_dir`.
 
     A connector whose accounting raises is skipped so one bad harness never
     fails the whole report -- the same resilience contract `storage_health`
     already applies to `estimate_harness_source_sizes` (M1).
+
+    `connection`: pass the live server's own `UnifiedStorage.connection`
+    when calling this from within the running `searchat-web` process (see
+    `_read_indexed_paths_by_connector`); omit it for standalone/CLI use.
     """
     db_path = config.storage.resolve_duckdb_path(search_dir)
-    indexed_by_connector = _read_indexed_paths_by_connector(db_path)
+    indexed_by_connector = _read_indexed_paths_by_connector(db_path, connection=connection)
 
     agents: list[AgentDiskUsage] = []
     for connector in get_connectors():

--- a/src/searchat/services/disk_accounting.py
+++ b/src/searchat/services/disk_accounting.py
@@ -14,10 +14,26 @@ M11 dedup detection build on this module but stay report-only too).
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import duckdb
+
 from searchat.config import Config
+from searchat.core.connectors.registry import detect_connector
+
+# Age histogram bucket boundaries, in days, applied to each connector's
+# discovered conversation files (mtime-based). The final bucket is open-ended.
+_AGE_BUCKET_DAYS: tuple[int, ...] = (7, 30, 90, 365)
+_AGE_BUCKET_LABELS: tuple[str, ...] = ("0-7d", "7-30d", "30-90d", "90-365d", "365d+")
+
+
+def _age_bucket(age_days: float) -> str:
+    for boundary, label in zip(_AGE_BUCKET_DAYS, _AGE_BUCKET_LABELS):
+        if age_days < boundary:
+            return label
+    return _AGE_BUCKET_LABELS[-1]
 
 
 @dataclass(frozen=True)
@@ -92,6 +108,38 @@ def _connector_watch_dirs(connector: Any, config: Config) -> list[Path]:
     return dirs
 
 
+def _read_indexed_paths_by_connector(db_path: Path) -> dict[str, set[str]]:
+    """Return `{connector_name: {file_path, ...}}` for `status = 'indexed'` rows.
+
+    Rows written before `connector_name` was threaded through (or by legacy
+    code paths) have a null/empty `connector_name`; those are routed to the
+    correct connector by re-running `detect_connector` on the stored path
+    rather than being fanned out into every connector's set.
+    """
+    if not db_path.exists():
+        return {}
+    con = duckdb.connect(str(db_path), read_only=True)
+    try:
+        rows = con.execute(
+            "SELECT connector_name, file_path FROM source_file_state WHERE status = 'indexed'"
+        ).fetchall()
+    except duckdb.Error:
+        return {}
+    finally:
+        con.close()
+
+    by_connector: dict[str, set[str]] = {}
+    for connector_name, file_path in rows:
+        name = connector_name
+        if not name:
+            try:
+                name = detect_connector(Path(file_path)).name
+            except ValueError:
+                name = "unknown"
+        by_connector.setdefault(name, set()).add(file_path)
+    return by_connector
+
+
 @dataclass(frozen=True)
 class AgentDiskUsage:
     """Read-only disk-usage summary for one registered connector."""
@@ -101,6 +149,13 @@ class AgentDiskUsage:
     total_size_bytes: int
     total_file_count: int
     conversation_file_count: int
+    indexed_file_count: int
+    indexed_size_bytes: int
+    unindexed_file_count: int
+    unindexed_size_bytes: int
+    oldest_conversation_age_days: float | None
+    newest_conversation_age_days: float | None
+    age_histogram: dict[str, int]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -109,19 +164,32 @@ class AgentDiskUsage:
             "total_size_bytes": self.total_size_bytes,
             "total_file_count": self.total_file_count,
             "conversation_file_count": self.conversation_file_count,
+            "indexed_file_count": self.indexed_file_count,
+            "indexed_size_bytes": self.indexed_size_bytes,
+            "unindexed_file_count": self.unindexed_file_count,
+            "unindexed_size_bytes": self.unindexed_size_bytes,
+            "oldest_conversation_age_days": self.oldest_conversation_age_days,
+            "newest_conversation_age_days": self.newest_conversation_age_days,
+            "age_histogram": dict(self.age_histogram),
         }
 
 
-def compute_agent_disk_usage(connector: Any, config: Config) -> AgentDiskUsage:
-    """Build the size/count summary for one connector.
+def compute_agent_disk_usage(
+    connector: Any,
+    config: Config,
+    indexed_paths: set[str],
+    *,
+    now: datetime | None = None,
+) -> AgentDiskUsage:
+    """Build the disk-usage summary for one connector.
 
     `total_size_bytes`/`total_file_count` walk every file under the
     connector's watch directories (the `du`-equivalent figure the M6
     acceptance criterion is measured against), independent of whether a
-    given file is a conversation the connector recognizes.
-    `conversation_file_count` is scoped to `discover_files` results only --
-    non-conversation files in the same directory (harness state, caches)
-    are counted toward the size total but not toward this count.
+    given file is a conversation the connector recognizes. Indexed/unindexed
+    and age are scoped to `discover_files` results only -- non-conversation
+    files in the same directory (harness state, caches) are counted toward
+    the size total but never toward conversation/indexed/unindexed counts.
     """
     watch_dirs = _connector_watch_dirs(connector, config)
     total_size = 0
@@ -136,10 +204,42 @@ def compute_agent_disk_usage(connector: Any, config: Config) -> AgentDiskUsage:
     except Exception:
         conversation_files = []
 
+    reference = now or datetime.now()
+    indexed_count = 0
+    indexed_size = 0
+    unindexed_count = 0
+    unindexed_size = 0
+    ages_days: list[float] = []
+    histogram = {label: 0 for label in _AGE_BUCKET_LABELS}
+
+    for file_path in conversation_files:
+        try:
+            stat = file_path.stat()
+        except OSError:
+            continue
+        size = stat.st_size
+        mtime = datetime.fromtimestamp(stat.st_mtime)
+        age_days = max((reference - mtime).total_seconds() / 86400.0, 0.0)
+        ages_days.append(age_days)
+        histogram[_age_bucket(age_days)] += 1
+        if str(file_path) in indexed_paths:
+            indexed_count += 1
+            indexed_size += size
+        else:
+            unindexed_count += 1
+            unindexed_size += size
+
     return AgentDiskUsage(
         connector=connector.name,
         watch_dirs=tuple(str(d) for d in watch_dirs),
         total_size_bytes=total_size,
         total_file_count=total_count,
         conversation_file_count=len(conversation_files),
+        indexed_file_count=indexed_count,
+        indexed_size_bytes=indexed_size,
+        unindexed_file_count=unindexed_count,
+        unindexed_size_bytes=unindexed_size,
+        oldest_conversation_age_days=max(ages_days) if ages_days else None,
+        newest_conversation_age_days=min(ages_days) if ages_days else None,
+        age_histogram=histogram,
     )

--- a/src/searchat/services/disk_accounting.py
+++ b/src/searchat/services/disk_accounting.py
@@ -21,12 +21,28 @@ from typing import Any
 import duckdb
 
 from searchat.config import Config
-from searchat.core.connectors.registry import detect_connector
+from searchat.core.connectors.registry import detect_connector, get_connectors
 
 # Age histogram bucket boundaries, in days, applied to each connector's
 # discovered conversation files (mtime-based). The final bucket is open-ended.
 _AGE_BUCKET_DAYS: tuple[int, ...] = (7, 30, 90, 365)
 _AGE_BUCKET_LABELS: tuple[str, ...] = ("0-7d", "7-30d", "30-90d", "90-365d", "365d+")
+
+# Searchat's own `~/.searchat` subdirectories included in self-accounting,
+# labeled per the M6 acceptance criterion ("index/backup/model/expertise
+# subdirectories are included"). `index` maps to `data/`, which holds the
+# DuckDB store (source-of-truth + derived tables) and its supporting Parquet
+# exports -- the single largest contributor to Searchat's own footprint.
+_SELF_ACCOUNTING_SUBDIRS: tuple[tuple[str, str], ...] = (
+    ("index", "data"),
+    ("backups", "backups"),
+    ("models", "models"),
+    ("expertise", "expertise"),
+    ("knowledge_graph", "knowledge_graph"),
+    ("analytics", "analytics"),
+    ("config", "config"),
+    ("logs", "logs"),
+)
 
 
 def _age_bucket(age_days: float) -> str:
@@ -242,4 +258,117 @@ def compute_agent_disk_usage(
         oldest_conversation_age_days=max(ages_days) if ages_days else None,
         newest_conversation_age_days=min(ages_days) if ages_days else None,
         age_histogram=histogram,
+    )
+
+
+@dataclass(frozen=True)
+class SubdirectoryUsage:
+    """Read-only disk-usage summary for one Searchat self-accounting subdirectory."""
+
+    label: str
+    path: str
+    exists: bool
+    total_size_bytes: int
+    file_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "path": self.path,
+            "exists": self.exists,
+            "total_size_bytes": self.total_size_bytes,
+            "file_count": self.file_count,
+        }
+
+
+@dataclass(frozen=True)
+class SearchatSelfUsage:
+    """Read-only disk-usage summary for Searchat's own `~/.searchat` footprint."""
+
+    search_dir: str
+    subdirectories: tuple[SubdirectoryUsage, ...]
+    total_size_bytes: int
+    total_file_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "search_dir": self.search_dir,
+            "subdirectories": [sub.to_dict() for sub in self.subdirectories],
+            "total_size_bytes": self.total_size_bytes,
+            "total_file_count": self.total_file_count,
+        }
+
+
+def compute_searchat_self_usage(search_dir: Path) -> SearchatSelfUsage:
+    """Sum Searchat's own footprint across its known subdirectories.
+
+    Always reports the `index`/`backups`/`models`/`expertise` subdirectories
+    by name (size 0 when absent, e.g. a fresh install with no models
+    downloaded yet) plus every other known subdirectory, so Searchat's own
+    storage is never the invisible entry the enhancement analysis called out.
+    """
+    subdirs: list[SubdirectoryUsage] = []
+    total_size = 0
+    total_count = 0
+    for label, dirname in _SELF_ACCOUNTING_SUBDIRS:
+        sub_path = search_dir / dirname
+        usage = _walk_directory(sub_path)
+        subdirs.append(
+            SubdirectoryUsage(
+                label=label,
+                path=str(sub_path),
+                exists=sub_path.exists(),
+                total_size_bytes=usage.total_size_bytes,
+                file_count=usage.file_count,
+            )
+        )
+        total_size += usage.total_size_bytes
+        total_count += usage.file_count
+    return SearchatSelfUsage(
+        search_dir=str(search_dir),
+        subdirectories=tuple(subdirs),
+        total_size_bytes=total_size,
+        total_file_count=total_count,
+    )
+
+
+@dataclass(frozen=True)
+class DiskAccountingReport:
+    """Unified, read-only disk-accounting report consumed by `searchat disk`
+    and the `/api/disk` endpoint."""
+
+    agents: tuple[AgentDiskUsage, ...]
+    searchat_self: SearchatSelfUsage
+    generated_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agents": [agent.to_dict() for agent in self.agents],
+            "searchat_self": self.searchat_self.to_dict(),
+            "generated_at": self.generated_at,
+        }
+
+
+def build_disk_accounting_report(search_dir: Path, config: Config) -> DiskAccountingReport:
+    """Assemble the full read-only disk-accounting report for `search_dir`.
+
+    A connector whose accounting raises is skipped so one bad harness never
+    fails the whole report -- the same resilience contract `storage_health`
+    already applies to `estimate_harness_source_sizes` (M1).
+    """
+    db_path = config.storage.resolve_duckdb_path(search_dir)
+    indexed_by_connector = _read_indexed_paths_by_connector(db_path)
+
+    agents: list[AgentDiskUsage] = []
+    for connector in get_connectors():
+        try:
+            indexed_paths = indexed_by_connector.get(connector.name, set())
+            agents.append(compute_agent_disk_usage(connector, config, indexed_paths))
+        except Exception:
+            continue
+
+    return DiskAccountingReport(
+        agents=tuple(agents),
+        searchat_self=compute_searchat_self_usage(search_dir),
+        generated_at=datetime.now().isoformat(),
     )

--- a/tests/unit/services/test_disk_accounting.py
+++ b/tests/unit/services/test_disk_accounting.py
@@ -419,3 +419,102 @@ def test_agent_disk_usage_to_dict_serializes_all_fields() -> None:
     assert payload["age_histogram"] == {"0-7d": 1, "7-30d": 1, "30-90d": 0, "90-365d": 0, "365d+": 0}
     assert payload["oldest_conversation_age_days"] == 10.0
     assert payload["connector"] == "claude"
+
+
+# ---------------------------------------------------------------------------
+# Bug fix: `connection=` kwarg lets a caller reuse an already-open DuckDB
+# connection (the live `searchat-web` server's `UnifiedStorage.connection`)
+# instead of opening a second file connection, which DuckDB refuses once
+# the first connection has non-default config (e.g. `memory_limit`) --
+# mirroring the pre-existing `/api/health` storage-section failure for the
+# identical reason.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_read_indexed_paths_by_connector_uses_passed_connection_instead_of_opening_new_one(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "state.duckdb"
+    conn = duckdb.connect(str(db_path))
+    ensure_tables(conn)
+    now = datetime.now()
+    conn.execute(
+        "INSERT INTO source_file_state "
+        "(file_path, conversation_id, project_id, connector_name, status, file_size, updated_at) "
+        "VALUES (?, ?, ?, ?, 'indexed', ?, ?)",
+        ["/watch/claude/conv1.jsonl", "c1", "p1", "claude", 10, now],
+    )
+
+    result = _read_indexed_paths_by_connector(db_path, connection=conn)
+    conn.close()
+
+    assert result == {"claude": {"/watch/claude/conv1.jsonl"}}
+
+
+@pytest.mark.unit
+def test_read_indexed_paths_by_connector_reuses_connection_with_mismatched_config_in_same_process(
+    tmp_path: Path,
+) -> None:
+    """Regression test for the reproduced `GET /api/disk` 500.
+
+    A second `duckdb.connect(db_path, read_only=True)` to a file that
+    already has an open, non-default-config connection in the same process
+    raises `duckdb.ConnectionException`. Passing that same connection
+    through `connection=` must route through `connection.cursor()` instead,
+    so no second file connection is ever attempted.
+    """
+    db_path = tmp_path / "state.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute("PRAGMA memory_limit='512MB'")  # mirrors UnifiedStorage.__init__
+    ensure_tables(con)
+    now = datetime.now()
+    con.execute(
+        "INSERT INTO source_file_state "
+        "(file_path, conversation_id, project_id, connector_name, status, file_size, updated_at) "
+        "VALUES (?, ?, ?, ?, 'indexed', ?, ?)",
+        ["/watch/vibe/session.json", "c1", "p1", "vibe", 10, now],
+    )
+
+    # The old code path (`duckdb.connect(db_path, read_only=True)` while `con`
+    # is still open with non-default config) is exactly what raised in
+    # production; asserting that here documents the failure this closes.
+    with pytest.raises(duckdb.Error):
+        duckdb.connect(str(db_path), read_only=True)
+
+    result = _read_indexed_paths_by_connector(db_path, connection=con)
+    con.close()
+
+    assert result == {"vibe": {"/watch/vibe/session.json"}}
+
+
+@pytest.mark.unit
+def test_build_disk_accounting_report_threads_connection_kwarg_to_indexed_paths_lookup(
+    temp_search_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    watch_dir = tmp_path / "claude_home"
+    conv = _write(watch_dir / "conv.jsonl", 10)
+    connector = _FakeConnector(name="claude", supported_extensions=(".jsonl",), files=[conv])
+    monkeypatch.setattr("searchat.services.disk_accounting.get_connectors", lambda: (connector,))
+
+    db_path = temp_search_dir / "data" / "searchat.duckdb"
+    config = Mock()
+    config.storage.resolve_duckdb_path.return_value = db_path
+
+    sentinel_connection = Mock(spec=duckdb.DuckDBPyConnection)
+    received: dict[str, object] = {}
+
+    def fake_read_indexed_paths_by_connector(path, *, connection=None):
+        received["db_path"] = path
+        received["connection"] = connection
+        return {}
+
+    monkeypatch.setattr(
+        "searchat.services.disk_accounting._read_indexed_paths_by_connector",
+        fake_read_indexed_paths_by_connector,
+    )
+
+    build_disk_accounting_report(temp_search_dir, config, connection=sentinel_connection)
+
+    assert received["connection"] is sentinel_connection
+    assert received["db_path"] == db_path

--- a/tests/unit/services/test_disk_accounting.py
+++ b/tests/unit/services/test_disk_accounting.py
@@ -1,0 +1,421 @@
+"""Unit tests for `searchat.services.disk_accounting`.
+
+Covers the M6 disk-manager-dashboard acceptance criteria: `du`-equivalent
+per-agent size accounting (not restricted to discovered conversation
+files), exact indexed/unindexed deltas sourced from `source_file_state`,
+Searchat's own labeled self-accounting subdirectories (present or absent),
+null-`connector_name` routing via `detect_connector`, per-connector
+resilience in `build_disk_accounting_report`, and age-histogram bucketing.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import duckdb
+import pytest
+
+from searchat.services.disk_accounting import (
+    AgentDiskUsage,
+    DiskAccountingReport,
+    _read_indexed_paths_by_connector,
+    build_disk_accounting_report,
+    compute_agent_disk_usage,
+    compute_searchat_self_usage,
+)
+from searchat.storage.schema import ensure_tables
+
+_AGE_BUCKET_LABELS = ("0-7d", "7-30d", "30-90d", "90-365d", "365d+")
+_SELF_ACCOUNTING_LABELS = {
+    "index",
+    "backups",
+    "models",
+    "expertise",
+    "knowledge_graph",
+    "analytics",
+    "config",
+    "logs",
+}
+
+
+@dataclass
+class _FakeConnector:
+    """Minimal connector satisfying AgentConnector, with no `watch_dirs`
+    method -- exercises `_connector_watch_dirs`'s fallback of deriving watch
+    dirs from `discover_files` results' parent directories, the same path
+    most connectors without an explicit `watch_dirs` override take.
+    """
+
+    name: str
+    supported_extensions: tuple[str, ...]
+    files: list[Path]
+
+    def discover_files(self, config):
+        return list(self.files)
+
+    def can_parse(self, path):
+        return path.suffix in self.supported_extensions
+
+    def parse(self, path, embedding_id):
+        raise NotImplementedError
+
+
+class _BrokenNameConnector:
+    """Connector whose `.name` access raises.
+
+    `compute_agent_disk_usage` already swallows a raising `discover_files`
+    internally (falls back to an empty conversation list), so that alone
+    never reaches `build_disk_accounting_report`'s per-connector
+    `except Exception: continue` guard. Reading `.name` is the one
+    unguarded attribute access that guard actually protects -- it happens
+    both in `indexed_by_connector.get(connector.name, ...)` and inside
+    `AgentDiskUsage(connector=connector.name, ...)`.
+    """
+
+    supported_extensions: tuple[str, ...] = (".broken",)
+
+    @property
+    def name(self):
+        raise RuntimeError("harness metadata unavailable")
+
+    def discover_files(self, config):
+        return []
+
+    def can_parse(self, path):
+        return False
+
+    def parse(self, path, embedding_id):
+        raise NotImplementedError
+
+
+def _write(path: Path, size: int) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * size)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 1: total_size_bytes is a full `du`-equivalent walk of the
+# connector's watch dir, not restricted to discover_files() results.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_compute_agent_disk_usage_total_size_matches_du_walk_including_non_conversation_files(
+    tmp_path: Path,
+) -> None:
+    watch_dir = tmp_path / "claude"
+    conv1 = _write(watch_dir / "conv1.jsonl", 120)
+    conv2 = _write(watch_dir / "conv2.jsonl", 340)
+    cruft = _write(watch_dir / "state.lock", 57)  # never discovered as a conversation
+
+    connector = _FakeConnector(name="claude", supported_extensions=(".jsonl",), files=[conv1, conv2])
+    result = compute_agent_disk_usage(connector, Mock(), indexed_paths=set())
+
+    expected_total = sum(p.stat().st_size for p in (conv1, conv2, cruft))
+    assert result.total_size_bytes == expected_total
+    assert result.total_file_count == 3
+    assert result.conversation_file_count == 2
+    # Directly proves the walk is NOT silently scoped to discover_files() results.
+    assert result.total_size_bytes > conv1.stat().st_size + conv2.stat().st_size
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 2: unindexed_file_count == N - K exactly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_compute_agent_disk_usage_unindexed_count_matches_known_delta_exactly(tmp_path: Path) -> None:
+    watch_dir = tmp_path / "vibe"
+    files = [_write(watch_dir / f"conv_{i}.json", 10 + i) for i in range(5)]  # N=5
+    indexed = {str(files[0]), str(files[1])}  # K=2
+
+    connector = _FakeConnector(name="vibe", supported_extensions=(".json",), files=files)
+    result = compute_agent_disk_usage(connector, Mock(), indexed_paths=indexed)
+
+    assert result.conversation_file_count == 5
+    assert result.indexed_file_count == 2
+    assert result.unindexed_file_count == 3  # N - K, exactly
+    assert result.indexed_size_bytes == files[0].stat().st_size + files[1].stat().st_size
+    assert result.unindexed_size_bytes == sum(f.stat().st_size for f in files[2:])
+
+
+@pytest.mark.unit
+def test_build_disk_accounting_report_unindexed_count_matches_db_seeded_delta_exactly(
+    temp_search_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    watch_dir = tmp_path / "claude_home"
+    files = [_write(watch_dir / f"conv_{i}.jsonl", 50 + i) for i in range(5)]  # N=5
+    indexed_subset = files[:2]  # K=2; files[2:] never appear in source_file_state at all
+
+    db_path = temp_search_dir / "data" / "searchat.duckdb"
+    conn = duckdb.connect(str(db_path))
+    ensure_tables(conn)
+    now = datetime.now()
+    for f in indexed_subset:
+        conn.execute(
+            "INSERT INTO source_file_state "
+            "(file_path, conversation_id, project_id, connector_name, status, file_size, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [str(f), f"conv-{f.name}", "p1", "claude", "indexed", f.stat().st_size, now],
+        )
+    conn.close()  # release the write lock before build_disk_accounting_report opens read-only
+
+    connector = _FakeConnector(name="claude", supported_extensions=(".jsonl",), files=files)
+    monkeypatch.setattr("searchat.services.disk_accounting.get_connectors", lambda: (connector,))
+
+    config = Mock()
+    config.storage.resolve_duckdb_path.return_value = db_path
+
+    report = build_disk_accounting_report(temp_search_dir, config)
+
+    assert len(report.agents) == 1
+    agent = report.agents[0]
+    assert agent.conversation_file_count == 5
+    assert agent.indexed_file_count == 2
+    assert agent.unindexed_file_count == 3  # N - K, exactly
+    assert agent.indexed_size_bytes == sum(f.stat().st_size for f in indexed_subset)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 3: compute_searchat_self_usage's fixed label set, present and
+# absent subdirectories.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_compute_searchat_self_usage_includes_all_labels_with_existing_subdirectories(
+    temp_search_dir: Path,
+) -> None:
+    _write(temp_search_dir / "data" / "searchat.duckdb", 1000)  # index -> data/
+    _write(temp_search_dir / "backups" / "backup1" / "manifest.json", 40)
+    _write(temp_search_dir / "models" / "all-MiniLM-L6-v2.bin", 2048)
+    _write(temp_search_dir / "expertise" / "graph.json", 512)
+    # knowledge_graph/, analytics/, logs/ intentionally left absent; config/
+    # exists (created by temp_search_dir) but stays empty.
+
+    result = compute_searchat_self_usage(temp_search_dir)
+    by_label = {sub.label: sub for sub in result.subdirectories}
+
+    assert {sub.label for sub in result.subdirectories} == _SELF_ACCOUNTING_LABELS
+
+    assert by_label["index"].exists is True
+    assert by_label["index"].file_count == 1
+    assert by_label["index"].total_size_bytes == 1000
+
+    assert by_label["backups"].exists is True
+    assert by_label["backups"].total_size_bytes == 40
+
+    assert by_label["models"].exists is True
+    assert by_label["models"].total_size_bytes == 2048
+
+    assert by_label["expertise"].exists is True
+    assert by_label["expertise"].total_size_bytes == 512
+
+    assert by_label["config"].exists is True
+    assert by_label["config"].file_count == 0
+
+    assert by_label["knowledge_graph"].exists is False
+    assert by_label["knowledge_graph"].total_size_bytes == 0
+    assert by_label["logs"].exists is False
+    assert by_label["logs"].file_count == 0
+
+    assert result.total_size_bytes == 1000 + 40 + 2048 + 512
+    assert result.total_file_count == 4
+
+
+@pytest.mark.unit
+def test_compute_searchat_self_usage_reports_zero_without_raising_when_search_dir_absent(
+    tmp_path: Path,
+) -> None:
+    missing_search_dir = tmp_path / "never_initialized" / ".searchat"
+
+    result = compute_searchat_self_usage(missing_search_dir)
+
+    assert {sub.label for sub in result.subdirectories} == _SELF_ACCOUNTING_LABELS
+    for sub in result.subdirectories:
+        assert sub.exists is False
+        assert sub.total_size_bytes == 0
+        assert sub.file_count == 0
+    assert result.total_size_bytes == 0
+    assert result.total_file_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 4: null/empty connector_name rows are routed via
+# detect_connector, including its ValueError -> "unknown" fallback.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_read_indexed_paths_by_connector_routes_null_connector_name_via_detect_connector(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "state.duckdb"
+    conn = duckdb.connect(str(db_path))
+    ensure_tables(conn)
+    now = datetime.now()
+    rows = [
+        ("/watch/claude/conv1.jsonl", "claude"),  # normal: connector_name already set
+        ("/watch/vibe/session.json", None),  # null connector_name -> detect_connector fallback
+        ("/watch/mystery/file.xyz", ""),  # empty connector_name -> detect_connector raises ValueError
+    ]
+    for i, (path, connector_name) in enumerate(rows):
+        conn.execute(
+            "INSERT INTO source_file_state "
+            "(file_path, conversation_id, project_id, connector_name, status, file_size, updated_at) "
+            "VALUES (?, ?, ?, ?, 'indexed', ?, ?)",
+            [path, f"c{i}", "p1", connector_name, 10, now],
+        )
+    conn.close()
+
+    def fake_detect_connector(path: Path):
+        if path.suffix == ".json":
+            return SimpleNamespace(name="vibe")
+        raise ValueError(f"No connector found for {path}")
+
+    monkeypatch.setattr("searchat.services.disk_accounting.detect_connector", fake_detect_connector)
+
+    result = _read_indexed_paths_by_connector(db_path)
+
+    assert result["claude"] == {"/watch/claude/conv1.jsonl"}
+    assert result["vibe"] == {"/watch/vibe/session.json"}
+    assert result["unknown"] == {"/watch/mystery/file.xyz"}
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 5: a connector whose accounting raises is skipped, not fatal.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_disk_accounting_report_skips_connector_whose_accounting_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    watch_dir = tmp_path / "claude_home"
+    conv = _write(watch_dir / "conv.jsonl", 42)
+
+    good_connector = _FakeConnector(name="claude", supported_extensions=(".jsonl",), files=[conv])
+    broken_connector = _BrokenNameConnector()
+
+    monkeypatch.setattr(
+        "searchat.services.disk_accounting.get_connectors",
+        lambda: (good_connector, broken_connector),
+    )
+
+    config = Mock()
+    config.storage.resolve_duckdb_path.return_value = tmp_path / "missing.duckdb"
+
+    report = build_disk_accounting_report(tmp_path, config)
+
+    assert [agent.connector for agent in report.agents] == ["claude"]
+    assert report.agents[0].total_size_bytes == 42
+
+
+# ---------------------------------------------------------------------------
+# Acceptance 6: age histogram bucketing, and None ages with zero discovered
+# conversation files (never 0 or a crash).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_compute_agent_disk_usage_buckets_known_file_ages_into_correct_labels(tmp_path: Path) -> None:
+    watch_dir = tmp_path / "codex"
+    reference = datetime(2026, 1, 1, 12, 0, 0)
+    age_days_by_index = {0: 3, 1: 15, 2: 60, 3: 200, 4: 400}
+    expected_label_by_index = {0: "0-7d", 1: "7-30d", 2: "30-90d", 3: "90-365d", 4: "365d+"}
+
+    files = []
+    for i, age_days in age_days_by_index.items():
+        f = _write(watch_dir / f"conv_{i}.jsonl", 1)
+        mtime = (reference - timedelta(days=age_days)).timestamp()
+        os.utime(f, (mtime, mtime))
+        files.append(f)
+
+    connector = _FakeConnector(name="codex", supported_extensions=(".jsonl",), files=files)
+    result = compute_agent_disk_usage(connector, Mock(), indexed_paths=set(), now=reference)
+
+    expected_histogram = {label: 0 for label in _AGE_BUCKET_LABELS}
+    for label in expected_label_by_index.values():
+        expected_histogram[label] += 1
+
+    assert result.age_histogram == expected_histogram
+    assert result.oldest_conversation_age_days == pytest.approx(400.0, abs=0.5)
+    assert result.newest_conversation_age_days == pytest.approx(3.0, abs=0.5)
+
+
+@pytest.mark.unit
+def test_compute_agent_disk_usage_ages_are_none_with_zero_discovered_files(tmp_path: Path) -> None:
+    watch_dir = tmp_path / "empty_agent"
+    _write(watch_dir / "not_a_conversation.log", 5)  # on disk, never discovered
+
+    connector = _FakeConnector(name="empty_agent", supported_extensions=(".jsonl",), files=[])
+    result = compute_agent_disk_usage(connector, Mock(), indexed_paths=set())
+
+    assert result.conversation_file_count == 0
+    assert result.oldest_conversation_age_days is None
+    assert result.newest_conversation_age_days is None
+    assert result.age_histogram == {label: 0 for label in _AGE_BUCKET_LABELS}
+    assert result.indexed_file_count == 0
+    assert result.unindexed_file_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Supporting coverage: report assembly wiring and to_dict() serialization.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_disk_accounting_report_assembles_agents_and_searchat_self(
+    temp_search_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    watch_dir = tmp_path / "claude_home"
+    conv = _write(watch_dir / "conv.jsonl", 10)
+    connector = _FakeConnector(name="claude", supported_extensions=(".jsonl",), files=[conv])
+    monkeypatch.setattr("searchat.services.disk_accounting.get_connectors", lambda: (connector,))
+
+    config = Mock()
+    config.storage.resolve_duckdb_path.return_value = temp_search_dir / "data" / "missing.duckdb"
+
+    report = build_disk_accounting_report(temp_search_dir, config)
+
+    assert isinstance(report, DiskAccountingReport)
+    assert len(report.agents) == 1
+    assert report.agents[0].connector == "claude"
+    assert report.searchat_self.search_dir == str(temp_search_dir)
+    datetime.fromisoformat(report.generated_at)  # ISO-parseable, never raises
+
+    payload = report.to_dict()
+    assert payload["agents"][0]["connector"] == "claude"
+    assert payload["searchat_self"]["search_dir"] == str(temp_search_dir)
+    assert payload["generated_at"] == report.generated_at
+
+
+@pytest.mark.unit
+def test_agent_disk_usage_to_dict_serializes_all_fields() -> None:
+    usage = AgentDiskUsage(
+        connector="claude",
+        watch_dirs=("/a", "/b"),
+        total_size_bytes=10,
+        total_file_count=2,
+        conversation_file_count=2,
+        indexed_file_count=1,
+        indexed_size_bytes=5,
+        unindexed_file_count=1,
+        unindexed_size_bytes=5,
+        oldest_conversation_age_days=10.0,
+        newest_conversation_age_days=1.0,
+        age_histogram={"0-7d": 1, "7-30d": 1, "30-90d": 0, "90-365d": 0, "365d+": 0},
+    )
+
+    payload = usage.to_dict()
+
+    assert payload["watch_dirs"] == ["/a", "/b"]
+    assert payload["age_histogram"] == {"0-7d": 1, "7-30d": 1, "30-90d": 0, "90-365d": 0, "365d+": 0}
+    assert payload["oldest_conversation_age_days"] == 10.0
+    assert payload["connector"] == "claude"


### PR DESCRIPTION
## Summary

Part 1/3 of M6 (Disk manager dashboard).

- New `services/disk_accounting.py`: per-connector disk-usage aggregation via each connector's watch directories (`watch_dirs()` when defined, else the deduplicated parent directories of `discover_files()`) -- a `du`-equivalent walk that sums *every* file under the watch dir, not just recognized conversation files.
- Indexed-vs-unindexed delta: discovered conversation files are matched against `source_file_state` (`status='indexed'`) scoped to that connector, with a `detect_connector` fallback for legacy rows missing `connector_name`.
- Age histogram (0-7d/7-30d/30-90d/90-365d/365d+) and oldest/newest conversation age, scoped to discovered conversation files.
- Searchat self-accounting: `index`/`backups`/`models`/`expertise` plus `knowledge_graph`/`analytics`/`config`/`logs`, each reported (size 0 when absent) rather than omitted.
- `build_disk_accounting_report` ties per-connector and self-accounting together; a connector whose accounting raises is skipped rather than failing the whole report (mirrors M1's `estimate_harness_source_sizes` resilience contract).
- Read-only throughout: no filesystem-mutating call anywhere in this module.

## Stack

Position: 1/3 (bottom of stack)

1. `feat/disk-accounting-service` -> this PR
2. `feat/disk-api-router` (#104)
3. `feat/disk-ui-cli` (pending)

Depends on: none (targets `main`)
Upstack: #104

## Acceptance evidence

`tests/unit/services/test_disk_accounting.py` exercises the M6 acceptance criteria directly:
- `test_compute_agent_disk_usage_total_size_matches_du_walk_including_non_conversation_files` proves `total_size_bytes` is a full directory walk (a cruft file never returned by `discover_files` still counts).
- `test_compute_agent_disk_usage_unindexed_count_matches_known_delta_exactly` and `test_build_disk_accounting_report_unindexed_count_matches_db_seeded_delta_exactly` prove `unindexed_file_count == N - K` exactly, at the unit level and against a real DuckDB-seeded `source_file_state` table.
- `test_compute_searchat_self_usage_includes_all_labels_with_existing_subdirectories` / `..._reports_zero_without_raising_when_search_dir_absent` cover the `index`/`backups`/`models`/`expertise` labels both present and entirely absent from disk.
- `test_build_disk_accounting_report_skips_connector_whose_accounting_raises` proves per-connector resilience.

## Validation

- `uv run pytest tests/unit/services/test_disk_accounting.py -v --tb=short --no-cov` — 11 passed
- `uv run pytest -v --tb=short` — 2222 passed, 1 skipped, 82.90% coverage (gate: 80%)
- `uv run ruff check` / `uv run mypy` on the new module — clean (supplementary, non-blocking per repo CI)