### PR TITLE
feat(api): add read-only disk-accounting API endpoint

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -822,3 +822,45 @@ Parameters:
 ```
 force  bool  Force shutdown even if indexing is in progress (default: false)
 ```
+
+---
+
+## Disk Accounting
+
+### GET /api/disk
+
+Read-only per-agent and Searchat self disk-usage report. No mutation capability -- this endpoint only reports.
+
+Response:
+```json
+{
+  "agents": [
+    {
+      "connector": "omp",
+      "watch_dirs": ["/Users/you/.omp/agent/sessions"],
+      "total_size_bytes": 9773412352,
+      "total_file_count": 4210,
+      "conversation_file_count": 4102,
+      "indexed_file_count": 4102,
+      "indexed_size_bytes": 9700000000,
+      "unindexed_file_count": 0,
+      "unindexed_size_bytes": 0,
+      "oldest_conversation_age_days": 214.5,
+      "newest_conversation_age_days": 0.3,
+      "age_histogram": {"0-7d": 12, "7-30d": 40, "30-90d": 118, "90-365d": 3932, "365d+": 0}
+    }
+  ],
+  "searchat_self": {
+    "search_dir": "/Users/you/.searchat",
+    "subdirectories": [
+      {"label": "index", "path": "/Users/you/.searchat/data", "exists": true, "total_size_bytes": 7464300544, "file_count": 812},
+      {"label": "backups", "path": "/Users/you/.searchat/backups", "exists": true, "total_size_bytes": 512000000, "file_count": 4}
+    ],
+    "total_size_bytes": 7976300544,
+    "total_file_count": 816
+  },
+  "generated_at": "2026-07-03T09:29:54.090146"
+}
+```
+
+`total_size_bytes`/`total_file_count` per agent are a `du`-equivalent walk of the connector's watch directories (every file, not just recognized conversation files). `indexed_file_count`/`unindexed_file_count` are scoped to discovered conversation files only, matched against `source_file_state`. `searchat_self.subdirectories` always includes `index`, `backups`, `models`, and `expertise` (size 0 when absent) alongside any other known Searchat subdirectory.

--- a/src/searchat/api/app.py
+++ b/src/searchat/api/app.py
@@ -56,6 +56,7 @@ from searchat.api.routers import (
     fragments_router,
     health_router,
     palace_router,
+    disk_router,
 )
 from searchat.config.constants import (
     APP_VERSION,
@@ -188,6 +189,7 @@ app.include_router(knowledge_graph_router)
 app.include_router(fragments_router)
 app.include_router(health_router, prefix="/api", tags=["health"])
 app.include_router(palace_router)
+app.include_router(disk_router, prefix="/api", tags=["disk"])
 
 
 def on_new_conversations(file_paths: list[str]) -> None:

--- a/src/searchat/api/routers/__init__.py
+++ b/src/searchat/api/routers/__init__.py
@@ -18,6 +18,7 @@ from searchat.api.routers.knowledge_graph import router as knowledge_graph_route
 from searchat.api.routers.fragments import router as fragments_router
 from searchat.api.routers.health import router as health_router
 from searchat.api.routers.palace import router as palace_router
+from searchat.api.routers.disk import router as disk_router
 
 __all__ = [
     "search_router",
@@ -39,4 +40,5 @@ __all__ = [
     "fragments_router",
     "health_router",
     "palace_router",
+    "disk_router",
 ]

--- a/src/searchat/api/routers/disk.py
+++ b/src/searchat/api/routers/disk.py
@@ -11,7 +11,7 @@ import logging
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from searchat.api.dependencies import get_config, get_search_dir
+from searchat.api.dependencies import get_config, get_duckdb_store, get_search_dir
 from searchat.contracts.errors import internal_server_error_message
 from searchat.services.disk_accounting import build_disk_accounting_report
 
@@ -65,9 +65,21 @@ class DiskAccountingResponse(BaseModel):
 
 @router.get("/disk", response_model=DiskAccountingResponse)
 async def get_disk_accounting() -> DiskAccountingResponse:
-    """Read-only per-agent and Searchat self disk-usage report."""
+    """Read-only per-agent and Searchat self disk-usage report.
+
+    Reuses the server's own live DuckDB connection when available (see
+    `services.disk_accounting.build_disk_accounting_report`'s `connection`
+    parameter) -- a fresh `duckdb.connect(db_path, read_only=True)` from
+    this same process conflicts with `UnifiedStorage`'s already-open
+    connection and would otherwise 500 on every request.
+    """
+    connection = None
     try:
-        report = build_disk_accounting_report(get_search_dir(), get_config())
+        connection = get_duckdb_store().connection
+    except Exception:
+        connection = None
+    try:
+        report = build_disk_accounting_report(get_search_dir(), get_config(), connection=connection)
     except Exception:
         logger.exception("Failed to build disk accounting report")
         raise HTTPException(status_code=500, detail=internal_server_error_message())

--- a/src/searchat/api/routers/disk.py
+++ b/src/searchat/api/routers/disk.py
@@ -6,6 +6,7 @@ the milestone's "report first" scope.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from fastapi import APIRouter, HTTPException
@@ -72,6 +73,14 @@ async def get_disk_accounting() -> DiskAccountingResponse:
     parameter) -- a fresh `duckdb.connect(db_path, read_only=True)` from
     this same process conflicts with `UnifiedStorage`'s already-open
     connection and would otherwise 500 on every request.
+
+    Runs off-thread (`asyncio.to_thread`): this walks every registered
+    connector's watch directory tree byte-by-byte plus Searchat's own
+    subdirectories, which can be several GB / thousands of files (e.g. a
+    9 GB omp store) -- running that synchronously on the event loop would
+    stall every other in-flight request for the duration of the scan, the
+    same constraint documented on `dependencies.maybe_auto_compact_on_shutdown`
+    and followed by every other heavy-IO route in this codebase.
     """
     connection = None
     try:
@@ -79,7 +88,9 @@ async def get_disk_accounting() -> DiskAccountingResponse:
     except Exception:
         connection = None
     try:
-        report = build_disk_accounting_report(get_search_dir(), get_config(), connection=connection)
+        report = await asyncio.to_thread(
+            build_disk_accounting_report, get_search_dir(), get_config(), connection=connection
+        )
     except Exception:
         logger.exception("Failed to build disk accounting report")
         raise HTTPException(status_code=500, detail=internal_server_error_message())

--- a/src/searchat/api/routers/disk.py
+++ b/src/searchat/api/routers/disk.py
@@ -1,0 +1,74 @@
+"""Disk accounting endpoint -- read-only per-agent and Searchat self footprint.
+
+M6 -- Disk manager dashboard. Serves `services/disk_accounting.py`'s report
+over HTTP; there is no mutation endpoint anywhere in this router, matching
+the milestone's "report first" scope.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from searchat.api.dependencies import get_config, get_search_dir
+from searchat.contracts.errors import internal_server_error_message
+from searchat.services.disk_accounting import build_disk_accounting_report
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+
+class AgentDiskUsageResponse(BaseModel):
+    """Per-connector disk-usage summary."""
+
+    connector: str
+    watch_dirs: list[str]
+    total_size_bytes: int
+    total_file_count: int
+    conversation_file_count: int
+    indexed_file_count: int
+    indexed_size_bytes: int
+    unindexed_file_count: int
+    unindexed_size_bytes: int
+    oldest_conversation_age_days: float | None
+    newest_conversation_age_days: float | None
+    age_histogram: dict[str, int]
+
+
+class SubdirectoryUsageResponse(BaseModel):
+    """Disk-usage summary for one Searchat self-accounting subdirectory."""
+
+    label: str
+    path: str
+    exists: bool
+    total_size_bytes: int
+    file_count: int
+
+
+class SearchatSelfUsageResponse(BaseModel):
+    """Searchat's own `~/.searchat` footprint."""
+
+    search_dir: str
+    subdirectories: list[SubdirectoryUsageResponse]
+    total_size_bytes: int
+    total_file_count: int
+
+
+class DiskAccountingResponse(BaseModel):
+    """Full read-only disk-accounting report."""
+
+    agents: list[AgentDiskUsageResponse]
+    searchat_self: SearchatSelfUsageResponse
+    generated_at: str
+
+
+@router.get("/disk", response_model=DiskAccountingResponse)
+async def get_disk_accounting() -> DiskAccountingResponse:
+    """Read-only per-agent and Searchat self disk-usage report."""
+    try:
+        report = build_disk_accounting_report(get_search_dir(), get_config())
+    except Exception:
+        logger.exception("Failed to build disk accounting report")
+        raise HTTPException(status_code=500, detail=internal_server_error_message())
+    return DiskAccountingResponse(**report.to_dict())

--- a/tests/api/test_disk_routes.py
+++ b/tests/api/test_disk_routes.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -313,3 +313,33 @@ class TestDiskAccountingEndpoint:
 
         assert response.status_code == 200
         mock_build.assert_called_once_with(fake_search_dir, fake_config, connection=None)
+
+    def test_get_disk_accounting_offloads_via_asyncio_to_thread(self, client, mock_report):
+        """The heavy filesystem walk runs via `asyncio.to_thread`, not a direct synchronous call.
+
+        Mocking `asyncio.to_thread` itself -- rather than `build_disk_accounting_report` -- is
+        the only way to distinguish `await asyncio.to_thread(fn, ...)` from `fn(...)`: only the
+        former ever reaches this mock. Asserting the mock's call signature plus that the real
+        service function was never invoked directly proves the route genuinely offloads the scan
+        instead of running it inline on the event loop.
+        """
+        fake_search_dir = Path("/home/user/.searchat")
+        fake_config = Mock(name="fake_config")
+
+        with patch('searchat.api.routers.disk.get_search_dir', return_value=fake_search_dir):
+            with patch('searchat.api.routers.disk.get_config', return_value=fake_config):
+                with patch(
+                    'searchat.api.routers.disk.build_disk_accounting_report'
+                ) as mock_build:
+                    with patch(
+                        'searchat.api.routers.disk.asyncio.to_thread',
+                        new_callable=AsyncMock,
+                        return_value=mock_report,
+                    ) as mock_to_thread:
+                        response = client.get("/api/disk")
+
+        assert response.status_code == 200
+        mock_to_thread.assert_called_once_with(
+            mock_build, fake_search_dir, fake_config, connection=None
+        )
+        mock_build.assert_not_called()

--- a/tests/api/test_disk_routes.py
+++ b/tests/api/test_disk_routes.py
@@ -264,9 +264,12 @@ class TestDiskAccountingEndpoint:
         assert data["agents"][0]["newest_conversation_age_days"] is None
 
     def test_get_disk_accounting_calls_service_with_search_dir_and_config(self, client, mock_report):
-        """The route wires `get_search_dir()`/`get_config()` singletons into the service call."""
+        """The route wires `get_search_dir()`/`get_config()`/the live DuckDB connection into the service call."""
         fake_search_dir = Path("/home/user/.searchat")
         fake_config = Mock(name="fake_config")
+        fake_connection = Mock(name="fake_duckdb_connection")
+        fake_store = Mock(name="fake_duckdb_store")
+        fake_store.connection = fake_connection
 
         with patch(
             'searchat.api.routers.disk.get_search_dir', return_value=fake_search_dir
@@ -275,12 +278,38 @@ class TestDiskAccountingEndpoint:
                 'searchat.api.routers.disk.get_config', return_value=fake_config
             ) as mock_get_config:
                 with patch(
-                    'searchat.api.routers.disk.build_disk_accounting_report',
-                    return_value=mock_report,
-                ) as mock_build:
-                    response = client.get("/api/disk")
+                    'searchat.api.routers.disk.get_duckdb_store', return_value=fake_store
+                ) as mock_get_store:
+                    with patch(
+                        'searchat.api.routers.disk.build_disk_accounting_report',
+                        return_value=mock_report,
+                    ) as mock_build:
+                        response = client.get("/api/disk")
 
         assert response.status_code == 200
         mock_get_dir.assert_called_once()
         mock_get_config.assert_called_once()
-        mock_build.assert_called_once_with(fake_search_dir, fake_config)
+        mock_get_store.assert_called_once()
+        mock_build.assert_called_once_with(fake_search_dir, fake_config, connection=fake_connection)
+
+    def test_get_disk_accounting_falls_back_when_duckdb_store_unavailable(self, client, mock_report):
+        """If `get_duckdb_store()` raises (services not initialized), the route degrades to a
+        fresh-connection call instead of failing the whole request with a 500.
+        """
+        fake_search_dir = Path("/home/user/.searchat")
+        fake_config = Mock(name="fake_config")
+
+        with patch('searchat.api.routers.disk.get_search_dir', return_value=fake_search_dir):
+            with patch('searchat.api.routers.disk.get_config', return_value=fake_config):
+                with patch(
+                    'searchat.api.routers.disk.get_duckdb_store',
+                    side_effect=RuntimeError("Services not initialized"),
+                ):
+                    with patch(
+                        'searchat.api.routers.disk.build_disk_accounting_report',
+                        return_value=mock_report,
+                    ) as mock_build:
+                        response = client.get("/api/disk")
+
+        assert response.status_code == 200
+        mock_build.assert_called_once_with(fake_search_dir, fake_config, connection=None)

--- a/tests/api/test_disk_routes.py
+++ b/tests/api/test_disk_routes.py
@@ -1,0 +1,286 @@
+"""Unit tests for the disk accounting API route."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from searchat.api.app import app
+from searchat.services.disk_accounting import (
+    AgentDiskUsage,
+    DiskAccountingReport,
+    SearchatSelfUsage,
+    SubdirectoryUsage,
+)
+
+
+@pytest.fixture
+def client():
+    """FastAPI test client."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_agent_usage():
+    """`AgentDiskUsage` for one registered connector."""
+    return AgentDiskUsage(
+        connector="claude-code",
+        watch_dirs=("/home/user/.claude/projects",),
+        total_size_bytes=104857600,
+        total_file_count=42,
+        conversation_file_count=40,
+        indexed_file_count=35,
+        indexed_size_bytes=90000000,
+        unindexed_file_count=5,
+        unindexed_size_bytes=14857600,
+        oldest_conversation_age_days=120.5,
+        newest_conversation_age_days=0.5,
+        age_histogram={"0-7d": 3, "7-30d": 10, "30-90d": 15, "90-365d": 12, "365d+": 0},
+    )
+
+
+@pytest.fixture
+def mock_subdirectories():
+    """`SubdirectoryUsage` entries for Searchat's own self-accounting."""
+    return (
+        SubdirectoryUsage(
+            label="index",
+            path="/home/user/.searchat/data",
+            exists=True,
+            total_size_bytes=52428800,
+            file_count=8,
+        ),
+        SubdirectoryUsage(
+            label="backups",
+            path="/home/user/.searchat/backups",
+            exists=False,
+            total_size_bytes=0,
+            file_count=0,
+        ),
+    )
+
+
+@pytest.fixture
+def mock_report(mock_agent_usage, mock_subdirectories):
+    """Full `DiskAccountingReport` with one agent and Searchat self usage."""
+    return DiskAccountingReport(
+        agents=(mock_agent_usage,),
+        searchat_self=SearchatSelfUsage(
+            search_dir="/home/user/.searchat",
+            subdirectories=mock_subdirectories,
+            total_size_bytes=52428800,
+            total_file_count=8,
+        ),
+        generated_at="2026-07-03T12:00:00",
+    )
+
+
+@pytest.fixture
+def mock_empty_report(mock_subdirectories):
+    """`DiskAccountingReport` with no registered connectors."""
+    return DiskAccountingReport(
+        agents=(),
+        searchat_self=SearchatSelfUsage(
+            search_dir="/home/user/.searchat",
+            subdirectories=mock_subdirectories,
+            total_size_bytes=52428800,
+            total_file_count=8,
+        ),
+        generated_at="2026-07-03T12:00:00",
+    )
+
+
+@pytest.mark.unit
+class TestDiskAccountingEndpoint:
+    """Tests for GET /api/disk endpoint."""
+
+    def test_get_disk_accounting_success(self, client, mock_report):
+        """Full report round-trips through the response schema with correct values."""
+        with patch('searchat.api.routers.disk.get_search_dir', return_value=Path("/home/user/.searchat")):
+            with patch('searchat.api.routers.disk.get_config', return_value=Mock()):
+                with patch(
+                    'searchat.api.routers.disk.build_disk_accounting_report',
+                    return_value=mock_report,
+                ) as mock_build:
+                    response = client.get("/api/disk")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert list(data) == ["agents", "searchat_self", "generated_at"]
+        assert data["generated_at"] == "2026-07-03T12:00:00"
+
+        assert len(data["agents"]) == 1
+        agent = data["agents"][0]
+        assert agent["connector"] == "claude-code"
+        assert agent["watch_dirs"] == ["/home/user/.claude/projects"]
+        assert agent["total_size_bytes"] == 104857600
+        assert agent["total_file_count"] == 42
+        assert agent["conversation_file_count"] == 40
+        assert agent["indexed_file_count"] == 35
+        assert agent["indexed_size_bytes"] == 90000000
+        assert agent["unindexed_file_count"] == 5
+        assert agent["unindexed_size_bytes"] == 14857600
+        assert agent["oldest_conversation_age_days"] == 120.5
+        assert agent["newest_conversation_age_days"] == 0.5
+        assert agent["age_histogram"] == {
+            "0-7d": 3,
+            "7-30d": 10,
+            "30-90d": 15,
+            "90-365d": 12,
+            "365d+": 0,
+        }
+
+        self_usage = data["searchat_self"]
+        assert self_usage["search_dir"] == "/home/user/.searchat"
+        assert self_usage["total_size_bytes"] == 52428800
+        assert self_usage["total_file_count"] == 8
+        assert len(self_usage["subdirectories"]) == 2
+        assert self_usage["subdirectories"][0] == {
+            "label": "index",
+            "path": "/home/user/.searchat/data",
+            "exists": True,
+            "total_size_bytes": 52428800,
+            "file_count": 8,
+        }
+        assert self_usage["subdirectories"][1]["exists"] is False
+
+        mock_build.assert_called_once()
+
+    def test_get_disk_accounting_empty_agents(self, client, mock_empty_report):
+        """No registered connectors still returns 200 with an empty agents list."""
+        with patch('searchat.api.routers.disk.get_search_dir', return_value=Path("/home/user/.searchat")):
+            with patch('searchat.api.routers.disk.get_config', return_value=Mock()):
+                with patch(
+                    'searchat.api.routers.disk.build_disk_accounting_report',
+                    return_value=mock_empty_report,
+                ):
+                    response = client.get("/api/disk")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["agents"] == []
+        assert len(data["searchat_self"]["subdirectories"]) == 2
+
+    def test_get_disk_accounting_error(self, client):
+        """Any exception from the service layer surfaces as a generic 500."""
+        with patch('searchat.api.routers.disk.get_search_dir', return_value=Path("/home/user/.searchat")):
+            with patch('searchat.api.routers.disk.get_config', return_value=Mock()):
+                with patch(
+                    'searchat.api.routers.disk.build_disk_accounting_report',
+                    side_effect=Exception("DuckDB connection failed"),
+                ):
+                    response = client.get("/api/disk")
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Internal server error"
+
+    def test_get_disk_accounting_response_schema(self, client, mock_report):
+        """Every declared field is present with the expected JSON type."""
+        with patch('searchat.api.routers.disk.get_search_dir', return_value=Path("/home/user/.searchat")):
+            with patch('searchat.api.routers.disk.get_config', return_value=Mock()):
+                with patch(
+                    'searchat.api.routers.disk.build_disk_accounting_report',
+                    return_value=mock_report,
+                ):
+                    response = client.get("/api/disk")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert isinstance(data["agents"], list)
+        assert isinstance(data["searchat_self"], dict)
+        assert isinstance(data["generated_at"], str)
+
+        agent = data["agents"][0]
+        assert isinstance(agent["connector"], str)
+        assert isinstance(agent["watch_dirs"], list)
+        assert all(isinstance(d, str) for d in agent["watch_dirs"])
+        assert isinstance(agent["total_size_bytes"], int)
+        assert isinstance(agent["total_file_count"], int)
+        assert isinstance(agent["conversation_file_count"], int)
+        assert isinstance(agent["indexed_file_count"], int)
+        assert isinstance(agent["indexed_size_bytes"], int)
+        assert isinstance(agent["unindexed_file_count"], int)
+        assert isinstance(agent["unindexed_size_bytes"], int)
+        assert isinstance(agent["oldest_conversation_age_days"], float)
+        assert isinstance(agent["newest_conversation_age_days"], float)
+        assert isinstance(agent["age_histogram"], dict)
+        assert all(isinstance(v, int) for v in agent["age_histogram"].values())
+
+        self_usage = data["searchat_self"]
+        assert isinstance(self_usage["search_dir"], str)
+        assert isinstance(self_usage["subdirectories"], list)
+        assert isinstance(self_usage["total_size_bytes"], int)
+        assert isinstance(self_usage["total_file_count"], int)
+
+        subdir = self_usage["subdirectories"][0]
+        assert isinstance(subdir["label"], str)
+        assert isinstance(subdir["path"], str)
+        assert isinstance(subdir["exists"], bool)
+        assert isinstance(subdir["total_size_bytes"], int)
+        assert isinstance(subdir["file_count"], int)
+
+    def test_get_disk_accounting_null_ages_when_no_conversations(self, client, mock_subdirectories):
+        """Optional age fields serialize as JSON null when no conversation files exist."""
+        agent = AgentDiskUsage(
+            connector="empty-connector",
+            watch_dirs=(),
+            total_size_bytes=0,
+            total_file_count=0,
+            conversation_file_count=0,
+            indexed_file_count=0,
+            indexed_size_bytes=0,
+            unindexed_file_count=0,
+            unindexed_size_bytes=0,
+            oldest_conversation_age_days=None,
+            newest_conversation_age_days=None,
+            age_histogram={"0-7d": 0, "7-30d": 0, "30-90d": 0, "90-365d": 0, "365d+": 0},
+        )
+        report = DiskAccountingReport(
+            agents=(agent,),
+            searchat_self=SearchatSelfUsage(
+                search_dir="/home/user/.searchat",
+                subdirectories=mock_subdirectories,
+                total_size_bytes=52428800,
+                total_file_count=8,
+            ),
+            generated_at="2026-07-03T12:00:00",
+        )
+
+        with patch('searchat.api.routers.disk.get_search_dir', return_value=Path("/home/user/.searchat")):
+            with patch('searchat.api.routers.disk.get_config', return_value=Mock()):
+                with patch(
+                    'searchat.api.routers.disk.build_disk_accounting_report',
+                    return_value=report,
+                ):
+                    response = client.get("/api/disk")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["agents"][0]["oldest_conversation_age_days"] is None
+        assert data["agents"][0]["newest_conversation_age_days"] is None
+
+    def test_get_disk_accounting_calls_service_with_search_dir_and_config(self, client, mock_report):
+        """The route wires `get_search_dir()`/`get_config()` singletons into the service call."""
+        fake_search_dir = Path("/home/user/.searchat")
+        fake_config = Mock(name="fake_config")
+
+        with patch(
+            'searchat.api.routers.disk.get_search_dir', return_value=fake_search_dir
+        ) as mock_get_dir:
+            with patch(
+                'searchat.api.routers.disk.get_config', return_value=fake_config
+            ) as mock_get_config:
+                with patch(
+                    'searchat.api.routers.disk.build_disk_accounting_report',
+                    return_value=mock_report,
+                ) as mock_build:
+                    response = client.get("/api/disk")
+
+        assert response.status_code == 200
+        mock_get_dir.assert_called_once()
+        mock_get_config.assert_called_once()
+        mock_build.assert_called_once_with(fake_search_dir, fake_config)


### PR DESCRIPTION
## Summary

Part 2/3 of M6 (Disk manager dashboard).

- New `api/routers/disk.py`: `GET /api/disk` serves `services/disk_accounting.py`'s report (PR-1) over HTTP via Pydantic response models (`DiskAccountingResponse` / `AgentDiskUsageResponse` / `SubdirectoryUsageResponse` / `SearchatSelfUsageResponse`).
- Registered at prefix `/api` alongside the other routers in `api/app.py`.
- Any exception from the service layer degrades to a generic 500 (`internal_server_error_message()`), matching the pattern in every other router.
- Documented in `docs/api-reference.md` following the existing per-endpoint convention (Statistics, Backup, Admin).
- Still read-only end to end: no mutation endpoint anywhere in this router.

**Follow-up fix (found via live E2E while building PR-3's UI):** `GET /api/disk` 500'd on every request made through a running `searchat-web` process (`duckdb.ConnectionException`: a fresh read-only connection conflicts with `UnifiedStorage`'s already-open connection, which always sets a non-default `memory_limit` PRAGMA). The route now fetches `get_duckdb_store().connection` and threads it into `build_disk_accounting_report(..., connection=...)` (PR-1's fix), falling back to `connection=None` when the store isn't initialized yet. Confirmed live: before the fix, `/api/disk` 500'd against a real running server with a real multi-connector environment (`~/.codex`, `~/.omp/agent/sessions`, `~/.claude/projects`, etc.); after, it returns correct per-agent data.

## Stack

Position: 2/3

1. `feat/disk-accounting-service` (#103)
2. `feat/disk-api-router` -> this PR
3. `feat/disk-ui-cli` (#105)

Depends on: #103 (base branch)
Upstack: #105

## Acceptance evidence

`tests/api/test_disk_routes.py` covers the HTTP layer against a mocked `build_disk_accounting_report`: a full 200 round-trip with correct nested agent/self-accounting field values, an empty-`agents`-list case, a 500 + `"Internal server error"` detail when the service raises, full Pydantic schema field/type coverage, `None`-age JSON-null serialization, that the route wires `get_search_dir()`/`get_config()`/the live DuckDB connection into the service call, and that a raising `get_duckdb_store()` degrades to `connection=None` instead of a 500. `services/disk_accounting.py`'s own size/count/age/indexed-vs-unindexed logic stays covered by PR-1's tests, not re-derived here.

## Validation

- `uv run pytest tests/unit/services/test_disk_accounting.py tests/api/test_disk_routes.py -v --tb=short --no-cov` — 21 passed
- `uv run pytest -v --tb=short` — 2232 passed, 1 skipped, 82.96% coverage (gate: 80%)
- `uv run ruff check` / `uv run mypy` on new/changed files — clean (supplementary, non-blocking per repo CI)
- Live E2E: isolated `searchat-web` instance against a real multi-connector home directory, `curl /api/disk` returns correct per-agent (codex/omp/claude/vibe/opencode/gemini/continue/cursor/aider) and self-accounting data