### PR TITLE
feat(services): add cruft detection rules

### DIFF
--- a/src/searchat/services/disk_accounting.py
+++ b/src/searchat/services/disk_accounting.py
@@ -8,9 +8,11 @@ and any other subdirectory found).
 
 Every function in this module only reads the filesystem and the DuckDB
 store opened read-only -- there is no mutation code path here, matching the
-"report first" ordering from the enhancement catalog (M7 cruft advisor and
-M11 dedup detection build on this module but stay report-only too).
+"report first" ordering from the enhancement catalog. M7's cruft advisor
+(`KNOWN_CRUFT_PATTERNS`, `detect_cruft`) extends this module with the same
+contract; M11 dedup detection builds on it too and stays report-only.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -404,3 +406,117 @@ def build_disk_accounting_report(
         searchat_self=compute_searchat_self_usage(search_dir),
         generated_at=datetime.now().isoformat(),
     )
+
+
+# ---------------------------------------------------------------------------
+# M7 -- Cruft advisor (report-only).
+#
+# Flags known non-conversation heavyweight artifacts per harness (tool
+# logs, plugin dirs, caches) so the M6 dashboard/CLI can surface them
+# alongside conversation accounting. Deleting another tool's internals is
+# out of contract (concern 5 in the enhancement analysis) -- every function
+# below only calls `Path.glob`, `Path.is_dir`/`is_symlink`, and `stat()`,
+# the same read-only primitives `_walk_directory` already uses. There is no
+# `os.remove`/`shutil.rmtree`/`Path.unlink`/`Path.rmdir` call anywhere in
+# this module.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CruftPattern:
+    """One known non-conversation heavyweight-artifact pattern.
+
+    `path_glob` is resolved relative to a harness home directory
+    (`Path.home()` by default, injectable via `detect_cruft`'s `home`
+    argument for tests) through `Path.glob()` -- supports a literal
+    relative path (the common case, e.g. `.codex/logs_2.sqlite`) or a
+    pattern with wildcard components. `cleanup_hint` names the owning
+    tool's own documented cleanup command when one is confirmed; `None`
+    when no such command is known -- this module never fabricates one and
+    never runs one.
+    """
+
+    path_glob: str
+    label: str
+    explanation: str
+    cleanup_hint: str | None = None
+
+
+# Grounded in each harness's own well-documented, non-conversation state:
+# plugin/extension installs, log and telemetry stores, and rebuildable
+# local caches that sit alongside (never inside) the connector's own
+# conversation watch directory. `.codex/logs_2.sqlite` is the exact example
+# cited by the enhancement analysis (a 424 MB internal log database, sized
+# independently of the 346 MB `sessions/` conversation directory it sits
+# next to).
+KNOWN_CRUFT_PATTERNS: tuple[CruftPattern, ...] = (
+    CruftPattern(
+        path_glob=".codex/logs_2.sqlite",
+        label="Codex CLI log database",
+        explanation=(
+            "OpenAI Codex CLI's internal SQLite log store, a sibling of the "
+            "conversation sessions/ directory; holds no conversation content."
+        ),
+    ),
+    CruftPattern(
+        path_glob=".codex/plugins",
+        label="Codex CLI plugins",
+        explanation="Installed Codex CLI plugin/extension data.",
+    ),
+    CruftPattern(
+        path_glob=".claude/plugins",
+        label="Claude Code plugins",
+        explanation="Installed Claude Code plugin and MCP-server data (marketplace installs).",
+    ),
+    CruftPattern(
+        path_glob=".claude/shell-snapshots",
+        label="Claude Code shell snapshots",
+        explanation=(
+            "Per-session shell environment snapshots captured for bash-tool "
+            "commands; grows unbounded, holds no conversation content."
+        ),
+    ),
+    CruftPattern(
+        path_glob=".claude/file-history",
+        label="Claude Code file history cache",
+        explanation=(
+            "Claude Code's file-edit checkpoint/undo cache, not a "
+            "conversation transcript."
+        ),
+    ),
+    CruftPattern(
+        path_glob=".omp/cache",
+        label="omp cache",
+        explanation="oh-my-pi's own tool/session cache directory.",
+    ),
+    CruftPattern(
+        path_glob=".omp/logs",
+        label="omp logs",
+        explanation="oh-my-pi's own log output directory.",
+    ),
+    CruftPattern(
+        path_glob=".omp/stats.db",
+        label="omp stats database",
+        explanation=(
+            "oh-my-pi's local usage-metrics database; not a conversation store."
+        ),
+    ),
+    CruftPattern(
+        path_glob=".continue/index",
+        label="Continue local index cache",
+        explanation=(
+            "Continue's local embedding/search index over the workspace, "
+            "rebuildable from source."
+        ),
+    ),
+    CruftPattern(
+        path_glob=".cursor/extensions",
+        label="Cursor extensions",
+        explanation="Installed Cursor/VS-Code-derived extension binaries.",
+    ),
+    CruftPattern(
+        path_glob=".config/opencode/node_modules",
+        label="opencode config dependencies",
+        explanation="npm dependencies installed for opencode's local config/plugins.",
+    ),
+)

--- a/src/searchat/services/disk_accounting.py
+++ b/src/searchat/services/disk_accounting.py
@@ -520,3 +520,79 @@ KNOWN_CRUFT_PATTERNS: tuple[CruftPattern, ...] = (
         explanation="npm dependencies installed for opencode's local config/plugins.",
     ),
 )
+
+
+@dataclass(frozen=True)
+class CruftFinding:
+    """One matched cruft artifact on disk -- reported, never a delete target."""
+
+    label: str
+    path: str
+    path_glob: str
+    explanation: str
+    cleanup_hint: str | None
+    total_size_bytes: int
+    file_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "path": self.path,
+            "path_glob": self.path_glob,
+            "explanation": self.explanation,
+            "cleanup_hint": self.cleanup_hint,
+            "total_size_bytes": self.total_size_bytes,
+            "file_count": self.file_count,
+        }
+
+
+def detect_cruft(
+    home: Path | None = None,
+    patterns: tuple[CruftPattern, ...] = KNOWN_CRUFT_PATTERNS,
+) -> tuple[CruftFinding, ...]:
+    """Pure read-only scan for known non-conversation heavyweight artifacts.
+
+    Matches each pattern in `patterns` against `home` (`Path.home()` by
+    default; pass a fixture directory in tests) via `Path.glob()`, sizing
+    every match with the same `du`-equivalent walk `compute_agent_disk_usage`
+    uses for a directory match, or a single `stat()` for a file match. A
+    pattern that matches nothing (the artifact is absent on this machine)
+    contributes no finding -- this is a report of what exists, not a
+    checklist of what should. Results are sorted largest-first so the
+    heaviest artifacts surface at the top of the dashboard/CLI output.
+
+    Symlinked matches are skipped (mirrors `_walk_directory`'s handling and
+    keeps this scan from following a link outside the intended harness
+    directory) and unreadable matches are skipped rather than raised, so one
+    permission error never fails the whole scan.
+    """
+    base = home if home is not None else Path.home()
+    findings: list[CruftFinding] = []
+    for pattern in patterns:
+        try:
+            matches = sorted(base.glob(pattern.path_glob))
+        except OSError:
+            continue
+        for match in matches:
+            try:
+                if match.is_symlink():
+                    continue
+                if match.is_dir():
+                    usage = _walk_directory(match)
+                    size, count = usage.total_size_bytes, usage.file_count
+                else:
+                    size, count = match.stat().st_size, 1
+            except OSError:
+                continue
+            findings.append(
+                CruftFinding(
+                    label=pattern.label,
+                    path=str(match),
+                    path_glob=pattern.path_glob,
+                    explanation=pattern.explanation,
+                    cleanup_hint=pattern.cleanup_hint,
+                    total_size_bytes=size,
+                    file_count=count,
+                )
+            )
+    return tuple(sorted(findings, key=lambda f: f.total_size_bytes, reverse=True))

--- a/tests/unit/services/test_disk_accounting.py
+++ b/tests/unit/services/test_disk_accounting.py
@@ -20,12 +20,16 @@ import duckdb
 import pytest
 
 from searchat.services.disk_accounting import (
+    KNOWN_CRUFT_PATTERNS,
     AgentDiskUsage,
+    CruftFinding,
+    CruftPattern,
     DiskAccountingReport,
     _read_indexed_paths_by_connector,
     build_disk_accounting_report,
     compute_agent_disk_usage,
     compute_searchat_self_usage,
+    detect_cruft,
 )
 from searchat.storage.schema import ensure_tables
 
@@ -518,3 +522,145 @@ def test_build_disk_accounting_report_threads_connection_kwarg_to_indexed_paths_
 
     assert received["connection"] is sentinel_connection
     assert received["db_path"] == db_path
+
+
+# ---------------------------------------------------------------------------
+# M7 acceptance: cruft advisor detection primitives (CruftPattern,
+# CruftFinding, KNOWN_CRUFT_PATTERNS, detect_cruft). Report-only -- nothing
+# below ever deletes anything, and a real conversation-bearing path must
+# never be flagged.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_detect_cruft_matches_known_patterns_with_exact_sizes_and_never_flags_conversations(
+    tmp_path: Path,
+) -> None:
+    fake_home = tmp_path / "home"
+    log_db = _write(fake_home / ".codex" / "logs_2.sqlite", 4096)
+    plugin1 = _write(fake_home / ".claude" / "plugins" / "one.json", 100)
+    plugin2 = _write(fake_home / ".claude" / "plugins" / "two.json", 250)
+    plugin3 = _write(fake_home / ".claude" / "plugins" / "nested" / "three.bin", 75)
+    conversation = _write(
+        fake_home / ".codex" / "sessions" / "some-conversation.jsonl", 999
+    )
+
+    results = detect_cruft(home=fake_home)
+
+    by_glob = {finding.path_glob: finding for finding in results}
+    assert by_glob[".codex/logs_2.sqlite"].total_size_bytes == log_db.stat().st_size
+    assert by_glob[".codex/logs_2.sqlite"].file_count == 1
+    assert by_glob[".claude/plugins"].total_size_bytes == sum(
+        p.stat().st_size for p in (plugin1, plugin2, plugin3)
+    )
+    assert by_glob[".claude/plugins"].file_count == 3
+    assert sum(1 for f in results if f.path_glob == ".codex/logs_2.sqlite") == 1
+    assert sum(1 for f in results if f.path_glob == ".claude/plugins") == 1
+    assert all(finding.path != str(conversation) for finding in results)
+    # Registry patterns whose target was never created contribute no finding
+    # at all -- not a zero-sized one.
+    assert not any(f.path_glob == ".omp/cache" for f in results)
+    assert not any(f.path_glob == ".cursor/extensions" for f in results)
+
+
+@pytest.mark.unit
+def test_detect_cruft_results_sorted_largest_first(tmp_path: Path) -> None:
+    fake_home = tmp_path / "home"
+    _write(fake_home / ".codex" / "logs_2.sqlite", 500)
+    _write(fake_home / ".omp" / "stats.db", 9000)
+    _write(fake_home / ".claude" / "shell-snapshots" / "a.txt", 2000)
+    _write(fake_home / ".claude" / "shell-snapshots" / "b.txt", 1000)  # dir totals 3000
+    _write(fake_home / ".omp" / "logs" / "one.log", 100)  # dir totals 100
+
+    results = detect_cruft(home=fake_home)
+
+    assert len(results) == 4
+    sizes = [finding.total_size_bytes for finding in results]
+    assert len(set(sizes)) == 4  # distinct known sizes, not a coincidental tie
+    assert all(sizes[i] >= sizes[i + 1] for i in range(len(sizes) - 1))
+
+
+@pytest.mark.unit
+def test_detect_cruft_home_none_defaults_to_path_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_home = tmp_path / "home"
+    _write(fake_home / ".codex" / "logs_2.sqlite", 321)
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    explicit = detect_cruft(home=fake_home)
+    defaulted = detect_cruft()
+
+    assert defaulted == explicit
+    assert len(defaulted) == 1
+
+
+@pytest.mark.unit
+def test_detect_cruft_skips_symlinked_match(tmp_path: Path) -> None:
+    fake_home = tmp_path / "home"
+    real_target_dir = (tmp_path / "real_target").resolve()
+    _write(real_target_dir / "big.bin", 5000)
+    symlink_path = fake_home / ".omp" / "cache"
+    symlink_path.parent.mkdir(parents=True, exist_ok=True)
+    symlink_path.symlink_to(real_target_dir)
+
+    results = detect_cruft(home=fake_home)
+
+    assert not any(finding.path_glob == ".omp/cache" for finding in results)
+
+
+@pytest.mark.unit
+def test_detect_cruft_custom_patterns_override_registry(tmp_path: Path) -> None:
+    fake_home = tmp_path / "home"
+    custom_file = _write(fake_home / "custom" / "thing", 42)
+    custom_pattern = CruftPattern(
+        path_glob="custom/thing", label="Custom", explanation="A custom test pattern."
+    )
+
+    results = detect_cruft(home=fake_home, patterns=(custom_pattern,))
+
+    assert len(results) == 1
+    finding = results[0]
+    assert finding.label == "Custom"
+    assert finding.path_glob == "custom/thing"
+    assert finding.explanation == "A custom test pattern."
+    assert finding.cleanup_hint is None
+    assert finding.total_size_bytes == custom_file.stat().st_size
+    assert finding.file_count == 1
+
+
+@pytest.mark.unit
+def test_cruft_finding_to_dict_serializes_all_seven_fields() -> None:
+    finding = CruftFinding(
+        label="Test Label",
+        path="/fake/home/.tool/cruft",
+        path_glob=".tool/cruft",
+        explanation="A fabricated finding for serialization testing.",
+        cleanup_hint="tool cache clear",
+        total_size_bytes=123456,
+        file_count=7,
+    )
+
+    payload = finding.to_dict()
+
+    assert payload == {
+        "label": "Test Label",
+        "path": "/fake/home/.tool/cruft",
+        "path_glob": ".tool/cruft",
+        "explanation": "A fabricated finding for serialization testing.",
+        "cleanup_hint": "tool cache clear",
+        "total_size_bytes": 123456,
+        "file_count": 7,
+    }
+
+
+@pytest.mark.unit
+def test_known_cruft_patterns_registry_entries_are_well_formed_and_unique() -> None:
+    assert len(KNOWN_CRUFT_PATTERNS) > 0
+    for pattern in KNOWN_CRUFT_PATTERNS:
+        assert pattern.path_glob
+        assert pattern.label
+        assert pattern.explanation
+
+    globs = [pattern.path_glob for pattern in KNOWN_CRUFT_PATTERNS]
+    assert len(globs) == len(set(globs))


### PR DESCRIPTION
## Summary

Part 1/2 of M7 (Cruft advisor, report-only).

- `services/disk_accounting.py`: new `CruftPattern` + `KNOWN_CRUFT_PATTERNS` -- an 11-entry registry of known non-conversation heavyweight artifacts per harness (Codex CLI log database/plugins, Claude Code plugins/shell-snapshots/file-history, omp cache/logs/stats database, Continue's local index cache, Cursor extensions, opencode config dependencies). Every entry is a path glob resolved relative to a harness home directory, with a label and an explanation; `cleanup_hint` is left unset everywhere since no owning-tool cleanup command is confirmed for any of these -- never fabricated.
- New `CruftFinding` + `detect_cruft(home=None, patterns=KNOWN_CRUFT_PATTERNS)`: a pure read-only scan matching each pattern via `Path.glob()`, sizing a directory match with the module's existing `_walk_directory` (`du`-equivalent) and a file match with a single `stat()`. Only `Path.glob`/`is_dir`/`is_symlink`/`stat()` are called -- no `os.remove`, `shutil.rmtree`, `Path.unlink`, or `Path.rmdir` anywhere in this function or anything it calls.
- Patterns never overlap a connector's own conversation watch directory (e.g. `.codex/logs_2.sqlite` is a sibling of `.codex/sessions/`, not inside a scanned conversation path) -- verified per-harness against `config/path_resolver.py`'s actual `resolve_*_dirs` implementations before picking each entry.
- No wiring into `DiskAccountingReport`, the API router, the CLI, or the web UI yet -- that's PR-2.

## Stack

Position: 1/2

1. `feat/cruft-detection-rules` -> this PR
2. `feat/disk-cruft-surfacing` (dashboard/CLI surfacing + mutation guard, on top of this PR)

Depends on: none (root; M6 already merged to `main`)

## Acceptance evidence

- `.codex/logs_2.sqlite` is the exact artifact cited by the enhancement analysis (a 424 MB internal Codex CLI log database sized independently of the 346 MB `sessions/` conversation directory it sits beside) -- confirmed live against a real `~/.codex` before writing the registry entry.
- Every registry entry was checked against `config/path_resolver.py`'s `resolve_{codex,claude,omp,continue,cursor,opencode}_dirs` to confirm it never equals or nests a connector's actual watch directory (e.g. Cursor's watch dir is `~/Library/Application Support/Cursor/User` on macOS, never `~/.cursor` -- the whole `.cursor/*` pattern space is disjoint from conversation data).
- New tests (`tests/unit/services/test_disk_accounting.py`) prove: fixture-tree matches report exact `du`-equivalent sizes for both a file target and a directory target; a real conversation-bearing path is never flagged; an absent registry target contributes no finding (not a zero-sized one); results are sorted largest-first across a file+directory mix; the `home=None` default resolves via `Path.home()`; a symlinked match is skipped; a custom `patterns=` override round-trips all fields; `CruftFinding.to_dict()` serializes exactly its 7 fields; the registry itself has no empty fields and no duplicate `path_glob` values.

## Validation

- `uv run pytest tests/unit/services/test_disk_accounting.py -v --tb=short --no-cov -k cruft` -- 7 passed, 14 deselected
- `uv run pytest -v --tb=short` -- 2245 passed, 1 skipped, 82.99% coverage (gate: 80%)
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` on changed files -- clean (one pre-existing, out-of-scope `ruff format` complaint on `build_disk_accounting_report`'s signature predates this change and was left untouched)