### PR TITLE
feat(services): add verify_ingested checksum + message-count gate

### DIFF
--- a/src/searchat/services/source_lifecycle.py
+++ b/src/searchat/services/source_lifecycle.py
@@ -1,0 +1,222 @@
+"""Source conversation-file lifecycle: verified archive-then-prune (M8).
+
+CRITICAL: this module is the only place in Searchat allowed to delete a
+harness's source conversation file. The project has already lost source
+JSONLs to an over-eager reindex once; every capability added here is
+gated so that a bug can only make the tool do LESS, never MORE, than a
+human explicitly asked for:
+
+- ``prune_source``/``archive_source`` never run implicitly -- callers
+  (the ``sources`` CLI, see ``cli/sources_cmd.py``) must explicitly opt
+  out of ``dry_run`` per invocation.
+- Both ``verify_ingested`` and ``verify_roundtrip`` must pass before any
+  mutation is even considered -- enforced by ``evaluate_candidate``
+  returning ``eligible=False`` otherwise, not by caller discipline.
+- Every successful archive/prune writes exactly one append-only
+  tombstone entry recording enough provenance (checksum, connector,
+  conversation id, Parquet message count) to know what was removed and
+  why the pipeline believed it was safe to do so.
+
+Two-stage verification pipeline, per source file:
+
+1. ``verify_ingested`` -- structural proof the file is fully, currently
+   indexed: its on-disk checksum matches what Searchat indexed, and a
+   fresh re-parse's message count matches the ``conversations`` row
+   already in Parquet. Read-only.
+2. ``verify_roundtrip`` -- structural proof the file's content can be
+   regenerated from Parquet alone: the connector's ``export_original``
+   is re-parsed and diffed field-by-field against the stored record.
+   Read-only (writes only to a throwaway temp directory, never to the
+   source file or its siblings).
+
+Only once both pass -- and the connector is age-gated and explicitly
+opted into ``lifecycle.enabled_agents`` -- may ``archive_source`` (zstd
+in place) or ``prune_source`` (delete) run.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+import duckdb
+
+from searchat.core.connectors.base import AgentProviderBase
+from searchat.core.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Verdict from one verification stage (`verify_ingested` or
+    `verify_roundtrip`). `ok=False` always carries a human-readable `reason`
+    so a refused archive/prune is explainable, not a silent no-op."""
+
+    ok: bool
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {"ok": self.ok, "reason": self.reason}
+
+
+_SOURCE_FILE_STATE_COLUMNS = (
+    "file_path",
+    "conversation_id",
+    "project_id",
+    "connector_name",
+    "status",
+    "file_size",
+    "file_hash",
+    "updated_at",
+)
+
+
+def _read_source_file_state(
+    db_path: Path,
+    file_path: Path,
+    *,
+    connection: duckdb.DuckDBPyConnection | None = None,
+) -> dict[str, object] | None:
+    """Fetch the `source_file_state` row for `file_path`, or `None`.
+
+    Mirrors `services/disk_accounting.py`'s connection-reuse pattern: a
+    live server connection is reused via a fresh cursor (DuckDB refuses a
+    second same-process connection once the first has non-default config);
+    the CLI path opens its own short-lived read-only connection.
+    """
+    query = (
+        "SELECT " + ", ".join(_SOURCE_FILE_STATE_COLUMNS) + " "
+        "FROM source_file_state WHERE file_path = ? LIMIT 1"
+    )
+    params = [str(file_path)]
+
+    if connection is not None:
+        cur = connection.cursor()
+        try:
+            row = cur.execute(query, params).fetchone()
+        except duckdb.Error:
+            return None
+        finally:
+            cur.close()
+    else:
+        if not db_path.exists():
+            return None
+        con = duckdb.connect(str(db_path), read_only=True)
+        try:
+            row = con.execute(query, params).fetchone()
+        except duckdb.Error:
+            return None
+        finally:
+            con.close()
+
+    if row is None:
+        return None
+    return dict(zip(_SOURCE_FILE_STATE_COLUMNS, row))
+
+
+def _read_conversation_meta(
+    db_path: Path,
+    conversation_id: str,
+    *,
+    connection: duckdb.DuckDBPyConnection | None = None,
+) -> dict[str, object] | None:
+    """Fetch `{conversation_id, message_count}` from `conversations`, or `None`."""
+    query = "SELECT conversation_id, message_count FROM conversations WHERE conversation_id = ? LIMIT 1"
+    params = [conversation_id]
+
+    if connection is not None:
+        cur = connection.cursor()
+        try:
+            row = cur.execute(query, params).fetchone()
+        except duckdb.Error:
+            return None
+        finally:
+            cur.close()
+    else:
+        if not db_path.exists():
+            return None
+        con = duckdb.connect(str(db_path), read_only=True)
+        try:
+            row = con.execute(query, params).fetchone()
+        except duckdb.Error:
+            return None
+        finally:
+            con.close()
+
+    if row is None:
+        return None
+    return {"conversation_id": row[0], "message_count": row[1]}
+
+
+def verify_ingested(
+    db_path: Path,
+    connector: AgentProviderBase,
+    file_path: Path,
+    *,
+    connection: duckdb.DuckDBPyConnection | None = None,
+) -> VerificationResult:
+    """Structural proof that `file_path` is fully, currently ingested.
+
+    Two independent checks, both required to pass:
+
+    1. Checksum parity -- the file's current on-disk SHA-256 must equal
+       the hash `source_file_state` recorded at ingestion time. A
+       mismatch means the file changed (or was never indexed), so
+       whatever Searchat has in Parquet may not reflect its full content.
+    2. Message-count parity -- re-parsing the file with its owning
+       connector must yield the same `message_count` already stored on
+       the `conversations` row. A mismatch means the index only captured
+       a partial ingest (e.g. an interrupted indexing run), which a
+       checksum match alone would not catch if the file was rewritten
+       identically after a partial index.
+
+    Read-only: only ever opens `file_path` and `db_path` for reading.
+    """
+    if not file_path.is_file():
+        return VerificationResult(False, "source file does not exist on disk")
+
+    row = _read_source_file_state(db_path, file_path, connection=connection)
+    if row is None:
+        return VerificationResult(False, "no source_file_state row for this path")
+    if row["status"] != "indexed":
+        return VerificationResult(False, f"source_file_state status is {row['status']!r}, not 'indexed'")
+
+    conversation_id = row["conversation_id"]
+    if not conversation_id or not isinstance(conversation_id, str):
+        return VerificationResult(False, "source_file_state row has no conversation_id")
+
+    indexed_hash = row["file_hash"]
+    if not indexed_hash:
+        return VerificationResult(False, "source_file_state row has no recorded file_hash")
+
+    current_hash = _sha256_file(file_path)
+    if current_hash != indexed_hash:
+        return VerificationResult(False, "on-disk file hash differs from the indexed hash")
+
+    meta = _read_conversation_meta(db_path, conversation_id, connection=connection)
+    if meta is None:
+        return VerificationResult(False, f"conversation_id {conversation_id!r} not found in conversations table")
+
+    try:
+        reparsed = connector.parse(file_path, embedding_id=0)
+    except Exception as exc:
+        return VerificationResult(False, f"re-parse for message-count check failed: {exc}")
+
+    indexed_count = meta["message_count"]
+    if reparsed.message_count != indexed_count:
+        return VerificationResult(
+            False,
+            "message count mismatch: on-disk re-parse="
+            f"{reparsed.message_count}, indexed Parquet={indexed_count}",
+        )
+
+    return VerificationResult(True)

--- a/tests/unit/services/test_source_lifecycle.py
+++ b/tests/unit/services/test_source_lifecycle.py
@@ -1,0 +1,364 @@
+"""Unit tests for `searchat.services.source_lifecycle.verify_ingested`.
+
+`verify_ingested` is the first, read-only stage of the M8 archive-then-prune
+pipeline: it proves a source conversation file is fully and currently
+indexed before any later stage is allowed to even consider deleting it.
+These tests build real fixture DuckDB databases (via
+`searchat.storage.schema.ensure_tables`) and real Claude-format `.jsonl`
+fixture files, and exercise every branch of `verify_ingested` without any
+filesystem mocking -- the function performs no mutation, so none is needed.
+
+Only `verify_ingested` is covered here. `verify_roundtrip`, `archive_source`,
+and `prune_source` are added to `source_lifecycle.py` by later milestones
+and get their own test coverage in this same file at that point.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from searchat.core.connectors.claude import ClaudeConnector
+from searchat.services.source_lifecycle import VerificationResult, verify_ingested
+from searchat.storage.schema import ensure_tables
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_claude_jsonl(path: Path, num_exchanges: int = 1) -> Path:
+    """Write a real, minimal Claude-format JSONL fixture -- the exact shape
+    `ClaudeConnector.parse()` expects: `type` in {"user", "assistant"},
+    `message.content` as a plain string, and an ISO `timestamp`.
+
+    Each exchange is one user line + one assistant line, so `num_exchanges`
+    real messages a fresh parse will count is `2 * num_exchanges`.
+    """
+    base = datetime(2025, 1, 15, 10, 0, 0)
+    entries: list[dict[str, object]] = []
+    for i in range(num_exchanges):
+        entries.append(
+            {
+                "type": "user",
+                "message": {"content": f"Question {i}"},
+                "timestamp": (base + timedelta(minutes=2 * i)).isoformat(),
+            }
+        )
+        entries.append(
+            {
+                "type": "assistant",
+                "message": {"content": f"Answer {i}"},
+                "timestamp": (base + timedelta(minutes=2 * i, seconds=30)).isoformat(),
+            }
+        )
+    path.write_text("\n".join(json.dumps(entry) for entry in entries) + "\n", encoding="utf-8")
+    return path
+
+
+def _new_db(tmp_path: Path, name: str = "state.duckdb") -> Path:
+    """Create an empty but fully-migrated fixture DuckDB file."""
+    db_path = tmp_path / name
+    conn = duckdb.connect(str(db_path))
+    try:
+        ensure_tables(conn)
+    finally:
+        conn.close()
+    return db_path
+
+
+def _insert_source_file_state(
+    db_path: Path,
+    *,
+    file_path: str,
+    conversation_id: str | None,
+    project_id: str = "proj",
+    connector_name: str = "claude",
+    status: str = "indexed",
+    file_size: int = 0,
+    file_hash: str | None,
+    updated_at: datetime | None = None,
+) -> None:
+    conn = duckdb.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO source_file_state "
+            "(file_path, conversation_id, project_id, connector_name, status, "
+            "file_size, file_hash, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                file_path,
+                conversation_id,
+                project_id,
+                connector_name,
+                status,
+                file_size,
+                file_hash,
+                updated_at or datetime.now(),
+            ],
+        )
+    finally:
+        conn.close()
+
+
+def _insert_conversation(
+    db_path: Path,
+    *,
+    conversation_id: str,
+    file_path: str,
+    message_count: int,
+    project_id: str = "proj",
+    title: str = "Test conversation",
+    full_text: str = "some indexed text",
+    file_hash: str = "unused-in-conversations-lookup",
+) -> None:
+    now = datetime.now()
+    conn = duckdb.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO conversations "
+            "(conversation_id, project_id, file_path, title, created_at, updated_at, "
+            "message_count, full_text, file_hash, indexed_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                conversation_id,
+                project_id,
+                file_path,
+                title,
+                now,
+                now,
+                message_count,
+                full_text,
+                file_hash,
+                now,
+            ],
+        )
+    finally:
+        conn.close()
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# 1. Fully verified: hash and message count both match.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_verify_ingested_returns_ok_when_hash_and_message_count_both_match(tmp_path: Path) -> None:
+    source_file = _write_claude_jsonl(tmp_path / "conv-verified.jsonl", num_exchanges=1)
+    connector = ClaudeConnector()
+    real_hash = _sha256(source_file)
+    real_message_count = connector.parse(source_file, embedding_id=0).message_count
+    conversation_id = source_file.stem
+
+    db_path = _new_db(tmp_path)
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=conversation_id,
+        file_hash=real_hash,
+    )
+    _insert_conversation(
+        db_path,
+        conversation_id=conversation_id,
+        file_path=str(source_file),
+        message_count=real_message_count,
+    )
+
+    result = verify_ingested(db_path, connector, source_file)
+
+    assert isinstance(result, VerificationResult)
+    assert result.ok is True
+    assert result.reason is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Missing source file on disk.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_verify_ingested_fails_when_source_file_missing_from_disk(tmp_path: Path) -> None:
+    missing_file = tmp_path / "never-written.jsonl"
+    db_path = _new_db(tmp_path)
+
+    result = verify_ingested(db_path, ClaudeConnector(), missing_file)
+
+    assert result.ok is False
+    assert result.reason
+    assert "exist" in result.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# 3. No source_file_state row at all for that path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_verify_ingested_fails_when_no_source_file_state_row_exists(tmp_path: Path) -> None:
+    source_file = _write_claude_jsonl(tmp_path / "conv-unknown.jsonl")
+    db_path = _new_db(tmp_path)  # no source_file_state row inserted at all
+
+    result = verify_ingested(db_path, ClaudeConnector(), source_file)
+
+    assert result.ok is False
+    assert result.reason
+    assert "source_file_state" in result.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# 4. source_file_state.status is not 'indexed'.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad_status", ["orphaned", "error"])
+def test_verify_ingested_fails_when_status_is_not_indexed(tmp_path: Path, bad_status: str) -> None:
+    source_file = _write_claude_jsonl(tmp_path / f"conv-{bad_status}.jsonl")
+    real_hash = _sha256(source_file)
+    conversation_id = source_file.stem
+
+    db_path = _new_db(tmp_path)
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=conversation_id,
+        status=bad_status,
+        file_hash=real_hash,
+    )
+
+    result = verify_ingested(db_path, ClaudeConnector(), source_file)
+
+    assert result.ok is False
+    assert result.reason
+    assert "status" in result.reason.lower()
+    assert bad_status in result.reason
+
+
+# ---------------------------------------------------------------------------
+# 5. Checksum mismatch: file changed on disk since it was indexed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_verify_ingested_fails_on_checksum_mismatch(tmp_path: Path) -> None:
+    source_file = _write_claude_jsonl(tmp_path / "conv-modified.jsonl")
+    conversation_id = source_file.stem
+    wrong_hash = hashlib.sha256(b"this is not the real file content").hexdigest()
+    assert wrong_hash != _sha256(source_file)
+
+    db_path = _new_db(tmp_path)
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=conversation_id,
+        file_hash=wrong_hash,
+    )
+
+    result = verify_ingested(db_path, ClaudeConnector(), source_file)
+
+    assert result.ok is False
+    assert result.reason
+    assert "hash" in result.reason.lower() or "checksum" in result.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# 6. Message-count mismatch: checksum is correct but the indexed
+#    conversations row disagrees with a fresh re-parse.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_verify_ingested_fails_on_message_count_mismatch(tmp_path: Path) -> None:
+    source_file = _write_claude_jsonl(tmp_path / "conv-partial-index.jsonl", num_exchanges=1)
+    connector = ClaudeConnector()
+    real_hash = _sha256(source_file)
+    real_message_count = connector.parse(source_file, embedding_id=0).message_count
+    conversation_id = source_file.stem
+    wrong_message_count = real_message_count + 3
+    assert wrong_message_count != real_message_count
+
+    db_path = _new_db(tmp_path)
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=conversation_id,
+        file_hash=real_hash,
+    )
+    _insert_conversation(
+        db_path,
+        conversation_id=conversation_id,
+        file_path=str(source_file),
+        message_count=wrong_message_count,
+    )
+
+    result = verify_ingested(db_path, connector, source_file)
+
+    assert result.ok is False
+    assert result.reason
+    assert "message count" in result.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# 7. source_file_state row has a null/empty conversation_id.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("empty_conversation_id", [None, ""])
+def test_verify_ingested_fails_when_conversation_id_is_null_or_empty(
+    tmp_path: Path, empty_conversation_id: str | None
+) -> None:
+    source_file = _write_claude_jsonl(tmp_path / "conv-no-id.jsonl")
+    real_hash = _sha256(source_file)
+
+    db_path = _new_db(tmp_path)
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=empty_conversation_id,
+        file_hash=real_hash,
+    )
+
+    result = verify_ingested(db_path, ClaudeConnector(), source_file)
+
+    assert result.ok is False
+    assert result.reason
+    assert "conversation_id" in result.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# 8. conversation_id present in source_file_state but absent from
+#    conversations.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_verify_ingested_fails_when_conversation_id_has_no_matching_conversations_row(
+    tmp_path: Path,
+) -> None:
+    source_file = _write_claude_jsonl(tmp_path / "conv-orphaned-id.jsonl")
+    real_hash = _sha256(source_file)
+    conversation_id = source_file.stem
+
+    db_path = _new_db(tmp_path)
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=conversation_id,
+        file_hash=real_hash,
+    )
+    # deliberately no matching row inserted into `conversations`
+
+    result = verify_ingested(db_path, ClaudeConnector(), source_file)
+
+    assert result.ok is False
+    assert result.reason
+    assert conversation_id in result.reason
+    assert "conversations" in result.reason.lower()


### PR DESCRIPTION
## Stack

Stack-Id: `m8-archive-then-prune`
Base: `main`
Position: 1/6

1. `feat/source-lifecycle-verify-ingested` -> this PR
2. `feat/source-lifecycle-export-roundtrip` -> PR-2
3. `feat/source-lifecycle-archive` -> PR-3
4. `feat/source-lifecycle-prune-tombstone` -> PR-4
5. `feat/source-lifecycle-policy-gates` -> PR-5
6. `feat/source-lifecycle-cli` -> PR-6

Depends on: none (root)
Upstack: PR-2

## Summary

M8 (Archive-then-prune with round-trip verification), PR 1 of 6 — the
first of two independent verification stages that must both pass
before any source conversation file becomes archive/prune-eligible.

Adds `services/source_lifecycle.py::verify_ingested`: a **read-only**
structural check that a source file is fully, currently indexed:

1. **Checksum parity** — the file's current on-disk SHA-256 must equal
   `source_file_state.file_hash` recorded at ingestion time. A
   mismatch means the file changed (or was never indexed).
2. **Message-count parity** — re-parsing the file with its owning
   connector must yield the same `message_count` already stored on
   the `conversations` row. A mismatch means the index only captured
   a partial ingest.

No mutation capability exists anywhere in this PR — `verify_ingested`
only ever opens files for reading.

## Verification

```
uv run pytest tests/unit/services/test_source_lifecycle.py -v --tb=short --no-cov
```
10/10 passed.

Depends on M2 (rebuild-derived split) and M4 (backup v2), both already
merged to `main`.