### PR TITLE
feat(connectors): add export_original and verify_roundtrip reversibility proof

### DIFF
--- a/src/searchat/core/connectors/aider.py
+++ b/src/searchat/core/connectors/aider.py
@@ -178,3 +178,36 @@ class AiderConnector(AgentProviderBase):
 
         return messages
 
+
+    # -- V3: source lifecycle (M8) --
+
+    def export_original(self, record: ConversationRecord) -> bytes:
+        """Re-serialize as an `.aider.chat.history.md` transcript using the
+        `#### role` header delimiter `_parse_messages` recognizes.
+
+        NOTE: two fields are not reconstructible from `record` alone, both
+        because Aider's format carries no session identity or timestamp of
+        its own -- everything is inferred from the file's OWN filesystem
+        state at parse time, not from file content:
+
+        - `conversation_id` is `sha256(str(path.resolve()))[:16]`, a hash
+          of the file's absolute path.
+        - `created_at`/`updated_at`/every message `timestamp` are all
+          `path.stat().st_mtime` of that same file.
+
+        Once the export is written to a different path (as
+        `verify_roundtrip` always does, to avoid ever writing to the real
+        source location during verification), re-parsing it necessarily
+        yields a different `conversation_id` and different timestamps.
+        `verify_roundtrip` correctly reports this mismatch; Aider
+        conversations are not round-trip provable under this connector's
+        current path/mtime-only identity scheme, so they are not real
+        candidates for `archive_source`/`prune_source` until that scheme
+        changes -- a known, disclosed limitation, not a bug in this export.
+        """
+        parts: list[str] = []
+        for message in record.messages:
+            parts.append(f"#### {message.role}")
+            parts.append(message.content)
+            parts.append("")
+        return "\n".join(parts).encode("utf-8")

--- a/src/searchat/core/connectors/base.py
+++ b/src/searchat/core/connectors/base.py
@@ -67,3 +67,28 @@ class AgentProviderBase(ABC):
         Default: None (connector does not support resumption).
         """
         return None
+
+    # -- V3: source lifecycle (M8) --
+
+    @abstractmethod
+    def export_original(self, record: ConversationRecord) -> bytes:
+        """Re-serialize a stored `ConversationRecord` into this connector's
+        native on-disk format.
+
+        This is the reversibility proof gating
+        `services.source_lifecycle.archive_source`/`prune_source`: the
+        returned bytes, written to a path that preserves `record.file_path`'s
+        directory structure (some connectors derive identity -- e.g.
+        Claude's `project_id`/`conversation_id` from the parent directory
+        name and file stem, Gemini's project hash from a grandparent
+        directory name -- from that structure, not file content) and
+        re-parsed via `parse()`, must reproduce a `ConversationRecord` equal
+        to `record` in every field `services.source_lifecycle.verify_roundtrip`
+        compares. A connector whose identity scheme cannot be reconstructed
+        from `record` alone (e.g. a value derived from hashing information
+        that is not itself part of the stored record) should still implement
+        this as faithfully as possible; `verify_roundtrip` failing for such
+        conversations is the correct, safe outcome -- it withholds
+        archive/prune rather than silently mis-reporting reversibility.
+        """
+        ...

--- a/src/searchat/core/connectors/claude.py
+++ b/src/searchat/core/connectors/claude.py
@@ -199,3 +199,30 @@ class ClaudeConnector(AgentProviderBase):
     def build_resume_command(self, path: Path) -> str | None:
         conversation_id = path.stem
         return f"claude --conversation {conversation_id}"
+
+    # -- V3: source lifecycle (M8) --
+
+    def export_original(self, record: ConversationRecord) -> bytes:
+        """Re-serialize as Claude Code JSONL: one `{"type", "timestamp",
+        "message"}` line per stored message. `record.files_mentioned` is
+        re-attached as synthetic `tool_use` blocks on the first line so
+        `_extract_file_paths` recovers it on re-parse -- `MessageRecord`
+        only retains extracted text, not the original tool_use blocks, so
+        without this the round trip would silently lose `files_mentioned`.
+        """
+        lines: list[str] = []
+        file_mentions = record.files_mentioned or []
+        for index, message in enumerate(record.messages):
+            content_blocks: list[dict[str, Any]] = [{"type": "text", "text": message.content}]
+            if index == 0:
+                for file_path in file_mentions:
+                    content_blocks.append(
+                        {"type": "tool_use", "name": "Read", "input": {"file_path": file_path}}
+                    )
+            entry = {
+                "type": message.role,
+                "timestamp": message.timestamp.isoformat(),
+                "message": {"content": content_blocks},
+            }
+            lines.append(json.dumps(entry))
+        return ("\n".join(lines) + ("\n" if lines else "")).encode("utf-8")

--- a/src/searchat/core/connectors/codex.py
+++ b/src/searchat/core/connectors/codex.py
@@ -289,3 +289,27 @@ class CodexConnector(AgentProviderBase):
                 if session_id:
                     return f"codex --session {session_id}"
         return None
+
+    # -- V3: source lifecycle (M8) --
+
+    def export_original(self, record: ConversationRecord) -> bytes:
+        """Re-serialize as a Codex rollout JSONL: a `session_meta` line
+        carrying `record.conversation_id` (so re-parse's
+        `_extract_session_id` recovers it exactly, regardless of which of
+        Codex's several on-disk shapes the original file used) followed by
+        one bare `{role, content, timestamp}` line per stored message.
+        """
+        lines: list[str] = [
+            json.dumps({"type": "session_meta", "payload": {"id": record.conversation_id}})
+        ]
+        for message in record.messages:
+            lines.append(
+                json.dumps(
+                    {
+                        "role": message.role,
+                        "content": message.content,
+                        "timestamp": message.timestamp.isoformat(),
+                    }
+                )
+            )
+        return ("\n".join(lines) + "\n").encode("utf-8")

--- a/src/searchat/core/connectors/continue_cli.py
+++ b/src/searchat/core/connectors/continue_cli.py
@@ -208,3 +208,32 @@ class ContinueConnector(AgentProviderBase):
         digest = hashlib.sha1(value.strip().encode("utf-8")).hexdigest()
         return digest[:10]
 
+
+    # -- V3: source lifecycle (M8) --
+
+    def export_original(self, record: ConversationRecord) -> bytes:
+        """Re-serialize as a Continue session JSON. `project_id` is a
+        one-way `sha1(workspaceDirectory)[:10]` hash Continue computes at
+        parse time; when `record.project_id` already carries no workspace
+        hash (`"continue"`), `workspaceDirectory` is correctly omitted so
+        re-parse reproduces `"continue"` again. When a hash IS present, the
+        original `workspaceDirectory` value is not recoverable from
+        `record` alone (the hash cannot be inverted), so
+        `workspaceDirectory` is omitted here too -- re-parse will then
+        compute `project_id="continue"`, a mismatch against the stored
+        `"continue-<hash>"` that `verify_roundtrip` correctly reports as a
+        failed round trip rather than silently guessing a workspace path.
+        """
+        payload = {
+            "sessionId": record.conversation_id,
+            "title": record.title,
+            "history": [
+                {
+                    "role": message.role,
+                    "content": message.content,
+                    "timestamp": message.timestamp.isoformat(),
+                }
+                for message in record.messages
+            ],
+        }
+        return json.dumps(payload).encode("utf-8")

--- a/src/searchat/core/connectors/cursor.py
+++ b/src/searchat/core/connectors/cursor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -321,3 +322,65 @@ class CursorConnector(AgentProviderBase):
                 return f"cursor-{db_path.parts[idx + 1]}"
         suffix = hashlib.sha1(db_path.as_posix().encode("utf-8")).hexdigest()[:10]
         return f"cursor-{suffix}"
+
+    # -- V3: source lifecycle (M8) --
+
+    def export_original(self, record: ConversationRecord) -> bytes:
+        """Re-serialize as a minimal Cursor `state.vscdb`-shaped SQLite
+        database (an `ItemTable(key, value)` holding one
+        `composerData:<id>` row and one row per bubble) -- Cursor's native
+        format is rows inside a *shared* per-workspace SQLite state file,
+        not a standalone file, so this is the closest analog `parse()` can
+        read back.
+
+        NOTE: `project_id` is derived by `parse()` from the real
+        `state.vscdb` file's OWN filesystem path (`_project_id_from_db_path`),
+        which cannot be reconstructed from `record` alone once relocated to
+        a different path -- `verify_roundtrip` correctly reports a mismatch
+        on that one field for Cursor conversations. This is expected and is
+        exactly why Cursor's discovered pseudo-paths (see `discover_files`)
+        never reach a real `archive_source`/`prune_source` call in
+        production: they point at a path that does not exist on disk at
+        that literal location (the shared `.vscdb` lives one level up), so
+        `verify_ingested`'s existence check already refuses them before
+        `verify_roundtrip` would ever run.
+        """
+        bubble_ids: list[str] = [f"bubble-{index}" for index in range(len(record.messages))]
+        rows: list[tuple[str, str]] = []
+        for bubble_id, message in zip(bubble_ids, record.messages):
+            rows.append(
+                (
+                    f"bubbleId:{bubble_id}",
+                    json.dumps(
+                        {
+                            "bubbleId": bubble_id,
+                            "rawText": message.content,
+                            "timingInfo": {
+                                "clientEndTime": round(message.timestamp.timestamp() * 1000)
+                            },
+                        }
+                    ),
+                )
+            )
+
+        composer = {
+            "composerId": record.conversation_id,
+            "createdAt": round(record.created_at.timestamp() * 1000),
+            "lastUpdatedAt": round(record.updated_at.timestamp() * 1000),
+            "fullConversationHeadersOnly": [
+                {"bubbleId": bubble_id, "type": 1 if message.role == "user" else 2}
+                for bubble_id, message in zip(bubble_ids, record.messages)
+            ],
+        }
+        rows.insert(0, (f"composerData:{record.conversation_id}", json.dumps(composer)))
+
+        with tempfile.TemporaryDirectory(prefix="searchat-cursor-export-") as tmp:
+            db_path = Path(tmp) / "export.vscdb"
+            con = sqlite3.connect(str(db_path))
+            try:
+                con.execute("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)")
+                con.executemany("INSERT INTO ItemTable (key, value) VALUES (?, ?)", rows)
+                con.commit()
+            finally:
+                con.close()
+            return db_path.read_bytes()

--- a/src/searchat/core/connectors/gemini.py
+++ b/src/searchat/core/connectors/gemini.py
@@ -175,3 +175,25 @@ class GeminiCLIConnector(AgentProviderBase):
             return None
         return None
 
+
+    # -- V3: source lifecycle (M8) --
+
+    def export_original(self, record: ConversationRecord) -> bytes:
+        """Re-serialize as a Gemini CLI chat JSON (`history` array). Both
+        `conversation_id` (the file stem) and `project_id` (derived from
+        the grandparent directory name when the parent is named `chats`)
+        are recovered from the on-disk path `verify_roundtrip` writes this
+        export to -- which mirrors `record.file_path`'s directory
+        structure -- not from this payload.
+        """
+        payload = {
+            "history": [
+                {
+                    "role": message.role,
+                    "content": message.content,
+                    "timestamp": message.timestamp.isoformat(),
+                }
+                for message in record.messages
+            ]
+        }
+        return json.dumps(payload).encode("utf-8")

--- a/src/searchat/core/connectors/omp.py
+++ b/src/searchat/core/connectors/omp.py
@@ -43,6 +43,19 @@ _ROLE_MAP = {
     "bashexecution": "tool",
 }
 
+# Reverse of `_ROLE_MAP`, for `export_original`: `_normalize_role` looks up
+# RAW omp role names, not the normalized values this connector stores on
+# `MessageRecord.role` -- exporting a normalized "system"/"tool" role
+# literally would fail that lookup and silently drop the message on
+# re-parse. Picks one canonical raw spelling per normalized value
+# (`toolresult` for "tool", since `bashexecution` also maps there).
+_REVERSE_ROLE_MAP = {
+    "user": "user",
+    "assistant": "assistant",
+    "system": "developer",
+    "tool": "toolresult",
+}
+
 
 class OmpConnector(AgentProviderBase):
     name: str = "omp"
@@ -216,3 +229,32 @@ class OmpConnector(AgentProviderBase):
                 if isinstance(session_id, str) and session_id.strip():
                     return f"omp --resume {session_id.strip()}"
         return None
+
+    # -- V3: source lifecycle (M8) --
+
+    def export_original(self, record: ConversationRecord) -> bytes:
+        """Re-serialize as an omp session JSONL: a `session` line carrying
+        `record.conversation_id`/`record.title`, followed by one `message`
+        line per stored message. Roles are mapped back through
+        `_REVERSE_ROLE_MAP` to a raw spelling `_normalize_role` accepts --
+        the normalized value itself (e.g. `"system"`) is not a key in
+        `_ROLE_MAP` and would otherwise be silently dropped on re-parse.
+        """
+        lines: list[str] = [
+            json.dumps({"type": "session", "id": record.conversation_id, "title": record.title})
+        ]
+        for message in record.messages:
+            raw_role = _REVERSE_ROLE_MAP.get(message.role, message.role)
+            lines.append(
+                json.dumps(
+                    {
+                        "type": "message",
+                        "message": {
+                            "role": raw_role,
+                            "content": [{"type": "text", "text": message.content}],
+                        },
+                        "timestamp": message.timestamp.isoformat(),
+                    }
+                )
+            )
+        return ("\n".join(lines) + "\n").encode("utf-8")

--- a/src/searchat/core/connectors/opencode.py
+++ b/src/searchat/core/connectors/opencode.py
@@ -312,3 +312,33 @@ class OpenCodeConnector(AgentProviderBase):
         if isinstance(session_id, str) and session_id.strip():
             return f"opencode --session {session_id.strip()}"
         return None
+
+    # -- V3: source lifecycle (M8) --
+
+    def export_original(self, record: ConversationRecord) -> bytes:
+        """Re-serialize as a standalone OpenCode session JSON with messages
+        embedded inline (`session["messages"]`). `parse()` only reads
+        sibling `storage/message/<id>/*.json` files when they exist; when
+        they don't (as for a reconstructed export with no sibling
+        directories) it falls back to the inline `messages` array, which
+        this reproduces exactly.
+        """
+        project_id = record.project_id.removeprefix("opencode-")
+        payload = {
+            "id": record.conversation_id,
+            "projectID": project_id,
+            "title": record.title,
+            "time": {
+                "created": round(record.created_at.timestamp() * 1000),
+                "updated": round(record.updated_at.timestamp() * 1000),
+            },
+            "messages": [
+                {
+                    "role": message.role,
+                    "content": message.content,
+                    "time": {"created": round(message.timestamp.timestamp() * 1000)},
+                }
+                for message in record.messages
+            ],
+        }
+        return json.dumps(payload).encode("utf-8")

--- a/src/searchat/core/connectors/vibe.py
+++ b/src/searchat/core/connectors/vibe.py
@@ -148,3 +148,28 @@ class VibeConnector(AgentProviderBase):
         if isinstance(session_id, str) and session_id.strip():
             return f"vibe --session {session_id.strip()}"
         return None
+
+    # -- V3: source lifecycle (M8) --
+
+    def export_original(self, record: ConversationRecord) -> bytes:
+        """Re-serialize as a Vibe session JSON. `working_directory` is
+        reconstructed as the bare basename Vibe's `project_id` retains
+        (`project_id = f"vibe-{Path(working_dir).name}"`) -- the original
+        working directory's full path is not recoverable from `record`
+        alone, but `Path(basename).name == basename` reproduces the same
+        `project_id` on re-parse, which is all `verify_roundtrip` checks.
+        """
+        stripped = record.project_id.removeprefix("vibe-")
+        working_directory = "" if stripped == "vibe-session" else stripped
+        payload = {
+            "metadata": {
+                "session_id": record.conversation_id,
+                "environment": {"working_directory": working_directory},
+                "start_time": record.created_at.isoformat(),
+                "end_time": record.updated_at.isoformat(),
+            },
+            "messages": [
+                {"role": message.role, "content": message.content} for message in record.messages
+            ],
+        }
+        return json.dumps(payload).encode("utf-8")

--- a/src/searchat/services/source_lifecycle.py
+++ b/src/searchat/services/source_lifecycle.py
@@ -36,6 +36,7 @@ in place) or ``prune_source`` (delete) run.
 from __future__ import annotations
 
 import hashlib
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -43,6 +44,7 @@ import duckdb
 
 from searchat.core.connectors.base import AgentProviderBase
 from searchat.core.logging_config import get_logger
+from searchat.models import ConversationRecord
 
 logger = get_logger(__name__)
 
@@ -220,3 +222,94 @@ def verify_ingested(
         )
 
     return VerificationResult(True)
+
+
+@dataclass(frozen=True)
+class RoundtripResult:
+    """Verdict from `verify_roundtrip`: the reversibility proof gating
+    `archive_source`/`prune_source`. `ok=False` always carries a `reason`
+    and, when the two records were compared field-by-field, the exact
+    `mismatches` -- never a silent refusal."""
+
+    ok: bool
+    reason: str | None = None
+    mismatches: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {"ok": self.ok, "reason": self.reason, "mismatches": list(self.mismatches)}
+
+
+# Fields compared between the stored record and the export-then-reparse
+# result. Deliberately excludes `file_path` (the reparse always happens at
+# a throwaway mirrored path, never the original), `file_hash` (the
+# re-serialized bytes are a different, connector-native encoding of the
+# same content, not a byte-identical copy), `embedding_id` (passed through
+# unchanged, not derived), and `indexed_at` (a wall-clock stamp, not
+# content).
+_COMPARABLE_FIELDS: tuple[str, ...] = (
+    "conversation_id",
+    "project_id",
+    "title",
+    "created_at",
+    "updated_at",
+    "message_count",
+    "messages",
+    "full_text",
+    "files_mentioned",
+    "git_branch",
+)
+
+
+def _comparable(record: ConversationRecord) -> dict[str, object]:
+    return {name: getattr(record, name) for name in _COMPARABLE_FIELDS}
+
+
+def verify_roundtrip(connector: AgentProviderBase, record: ConversationRecord) -> RoundtripResult:
+    """Reversibility proof: `connector.export_original(record)` must produce
+    bytes that, once written back to a path preserving `record.file_path`'s
+    directory structure and re-parsed, reproduce a `ConversationRecord`
+    equal to `record` in every field forensic recovery could rely on.
+
+    The export is written under a throwaway `tempfile.TemporaryDirectory`,
+    mirroring `record.file_path`'s structure relative to its filesystem
+    root -- never the original path itself, and never any of its sibling
+    files -- so this function cannot write to, or otherwise disturb, the
+    real source file it is verifying. Some connectors derive part of a
+    conversation's identity from the parent (or grandparent) directory
+    name rather than file content (e.g. Claude's `project_id`, Gemini's
+    project hash); mirroring the full relative path, not just the
+    filename, preserves that identity without this function needing any
+    connector-specific knowledge.
+    """
+    try:
+        exported = connector.export_original(record)
+    except Exception as exc:
+        return RoundtripResult(False, reason=f"export_original raised: {exc}")
+
+    original_path = Path(record.file_path)
+    try:
+        with tempfile.TemporaryDirectory(prefix="searchat-roundtrip-") as tmp_dir:
+            anchor = original_path.anchor or "/"
+            relative = (
+                original_path.relative_to(anchor) if original_path.is_absolute() else original_path
+            )
+            target = Path(tmp_dir) / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(exported)
+            try:
+                reparsed = connector.parse(target, record.embedding_id)
+            except Exception as exc:
+                return RoundtripResult(False, reason=f"re-parse of exported bytes failed: {exc}")
+    except OSError as exc:
+        return RoundtripResult(False, reason=f"failed to materialize exported bytes: {exc}")
+
+    stored_view = _comparable(record)
+    reparsed_view = _comparable(reparsed)
+    mismatches = tuple(
+        sorted(name for name in _COMPARABLE_FIELDS if stored_view[name] != reparsed_view[name])
+    )
+    if mismatches:
+        return RoundtripResult(
+            False, reason="re-parsed record differs from the stored record", mismatches=mismatches
+        )
+    return RoundtripResult(True)

--- a/tests/unit/connectors/test_export_original_aider.py
+++ b/tests/unit/connectors/test_export_original_aider.py
@@ -1,0 +1,94 @@
+"""Unit tests for `AiderConnector.export_original` / round-trip verification (M8).
+
+Aider's `.aider.chat.history.md` format carries no session identity or
+timestamp of its own: `conversation_id` is `sha256(str(path.resolve()))[:16]`
+and every message/record timestamp is the file's OWN `st_mtime` at parse
+time (see `AiderConnector.export_original`'s docstring). `verify_roundtrip`
+always re-parses the exported bytes at a different, throwaway mirrored
+path, so those path/mtime-derived fields can never match -- the round trip
+must honestly fail rather than silently reporting success. Message content
+and title, which ARE derived from file content, must still be faithfully
+reconstructed -- verified separately here by calling `export_original`
+directly and comparing role+content pairs (excluding the legitimately
+mtime-derived timestamps).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from searchat.core.connectors.aider import AiderConnector
+from searchat.services.source_lifecycle import verify_roundtrip
+
+_HISTORY_MD = """#### user
+How do I write a for loop in Python?
+
+#### assistant
+Use `for item in iterable:` syntax.
+
+```python
+for item in [1, 2, 3]:
+    print(item)
+```
+"""
+
+
+@pytest.fixture
+def connector() -> AiderConnector:
+    return AiderConnector()
+
+
+def _write_history(directory: Path) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / ".aider.chat.history.md"
+    path.write_text(_HISTORY_MD, encoding="utf-8")
+    return path
+
+
+class TestAiderRoundtripConversationIdMismatch:
+    """`conversation_id` is a hash of the file's own absolute path, and
+    `verify_roundtrip` always re-parses at a different (mirrored) path --
+    so the round trip must fail, honestly reporting `conversation_id` as a
+    mismatch rather than a silent false success."""
+
+    def test_roundtrip_fails_with_conversation_id_mismatch(
+        self, connector: AiderConnector, tmp_path: Path
+    ) -> None:
+        path = _write_history(tmp_path / "myproject")
+        record = connector.parse(path, embedding_id=0)
+
+        result = verify_roundtrip(connector, record)
+
+        assert result.ok is False
+        assert "conversation_id" in result.mismatches
+
+
+class TestAiderExportPreservesMessagesAndTitle:
+    """Despite the identity/timestamp limitation above, message content and
+    title ARE faithfully reconstructed by `export_original` -- verified
+    directly here (bypassing `verify_roundtrip`, which would otherwise also
+    flag the expected, documented timestamp/id divergence) by comparing
+    role+content pairs and title only, deliberately excluding the
+    legitimately mtime-derived timestamps.
+    """
+
+    def test_export_then_reparse_preserves_role_content_and_title(
+        self, connector: AiderConnector, tmp_path: Path
+    ) -> None:
+        path = _write_history(tmp_path / "original")
+        record = connector.parse(path, embedding_id=0)
+
+        exported = connector.export_original(record)
+        assert exported
+
+        relocated_dir = tmp_path / "relocated"
+        relocated_dir.mkdir(parents=True, exist_ok=True)
+        new_path = relocated_dir / ".aider.chat.history.md"
+        new_path.write_bytes(exported)
+        reparsed = connector.parse(new_path, embedding_id=0)
+
+        original_pairs = [(m.role, m.content) for m in record.messages]
+        reparsed_pairs = [(m.role, m.content) for m in reparsed.messages]
+        assert original_pairs == reparsed_pairs
+        assert reparsed.title == record.title

--- a/tests/unit/connectors/test_export_original_claude.py
+++ b/tests/unit/connectors/test_export_original_claude.py
@@ -1,0 +1,104 @@
+"""Round-trip tests for `ClaudeConnector.export_original` via
+`services.source_lifecycle.verify_roundtrip` (M8).
+
+Every test here writes a real Claude-format `.jsonl` fixture to disk,
+parses it with the real connector, and feeds the resulting
+`ConversationRecord` through the real `verify_roundtrip` -- no mocking of
+`connector.parse`, `connector.export_original`, or `verify_roundtrip`
+itself. This is the reversibility proof gating future source-file
+deletion, so it has to exercise the actual re-serialize -> re-parse ->
+compare pipeline, not a stand-in for it.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from searchat.core.connectors.claude import ClaudeConnector
+from searchat.services.source_lifecycle import verify_roundtrip
+
+
+@pytest.fixture
+def connector() -> ClaudeConnector:
+    return ClaudeConnector()
+
+
+class TestClaudeExportOriginalRoundtrip:
+    def test_roundtrip_with_tool_use_files_mentioned(
+        self, connector: ClaudeConnector, tmp_path
+    ) -> None:
+        """An assistant message whose raw `message.content` mixes a `text`
+        block with a `tool_use` block (Edit) must survive export -> re-parse:
+        `files_mentioned` is not stored verbatim on `MessageRecord`, so
+        `export_original` has to reconstruct synthetic `tool_use` blocks for
+        `_extract_file_paths` to recover it identically on re-parse.
+        """
+        lines = [
+            {
+                "type": "user",
+                "timestamp": "2026-01-05T09:00:00",
+                "message": {"content": "Please fix the off-by-one bug in file.py"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-01-05T09:00:07",
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "Fixed it by adjusting the loop bound."},
+                        {
+                            "type": "tool_use",
+                            "name": "Edit",
+                            "input": {"file_path": "/some/file.py"},
+                        },
+                    ],
+                },
+            },
+        ]
+        # Claude derives project_id/conversation_id from the parent dir name
+        # and file stem, not file content -- use a real-looking parent dir.
+        path = tmp_path / "myproject" / "abc123.jsonl"
+        path.parent.mkdir(parents=True)
+        path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+
+        record = connector.parse(path, embedding_id=1)
+
+        # Sanity: the fixture actually exercises the files_mentioned round
+        # trip path, not a vacuous case with nothing to lose.
+        assert record.files_mentioned
+        assert record.files_mentioned == ["/some/file.py"]
+
+        exported = connector.export_original(record)
+        assert isinstance(exported, bytes)
+        assert exported
+
+        result = verify_roundtrip(connector, record)
+        assert result.ok is True, result.reason
+        assert result.mismatches == ()
+
+    def test_roundtrip_plain_text_only(self, connector: ClaudeConnector, tmp_path) -> None:
+        """A simpler conversation with no tool_use blocks at all also
+        round-trips cleanly -- the baseline case with nothing to reconstruct
+        beyond message text."""
+        lines = [
+            {
+                "type": "user",
+                "timestamp": "2026-01-06T14:00:00",
+                "message": {"content": "What does this function do?"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-01-06T14:00:03",
+                "message": {"content": "It sorts the list in place using quicksort."},
+            },
+        ]
+        path = tmp_path / "otherproject" / "def456.jsonl"
+        path.parent.mkdir(parents=True)
+        path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+
+        record = connector.parse(path, embedding_id=2)
+        assert record.files_mentioned is None
+
+        result = verify_roundtrip(connector, record)
+        assert result.ok is True, result.reason
+        assert result.mismatches == ()

--- a/tests/unit/connectors/test_export_original_codex.py
+++ b/tests/unit/connectors/test_export_original_codex.py
@@ -1,0 +1,62 @@
+"""Round-trip tests for `CodexConnector.export_original` via
+`services.source_lifecycle.verify_roundtrip` (M8).
+
+Writes a real Codex-format `.jsonl` fixture (a `session_meta` line followed
+by bare `{role, content, timestamp}` lines), parses it with the real
+connector, and feeds the resulting `ConversationRecord` through the real
+`verify_roundtrip` -- no mocking of `connector.parse`,
+`connector.export_original`, or `verify_roundtrip` itself.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from searchat.core.connectors.codex import CodexConnector
+from searchat.services.source_lifecycle import verify_roundtrip
+
+
+@pytest.fixture
+def connector() -> CodexConnector:
+    return CodexConnector()
+
+
+class TestCodexExportOriginalRoundtrip:
+    def test_roundtrip_session_meta_and_messages(self, connector: CodexConnector, tmp_path) -> None:
+        """A session_meta line carrying the session id, followed by a real
+        user/assistant exchange, must survive export -> re-parse: the
+        `session_meta` line is how `export_original` guarantees
+        `conversation_id` recovers exactly regardless of which of Codex's
+        on-disk shapes the original file used."""
+        session_id = "session-9f3c2a"
+        lines = [
+            {"type": "session_meta", "payload": {"id": session_id}},
+            {
+                "role": "user",
+                "content": "Please refactor the auth module for clarity.",
+                "timestamp": "2026-02-01T09:00:00",
+            },
+            {
+                "role": "assistant",
+                "content": "Sure, I split validate_token into two smaller helpers.",
+                "timestamp": "2026-02-01T09:00:12",
+            },
+        ]
+        path = tmp_path / "rollout-9f3c2a.jsonl"
+        path.write_text("\n".join(json.dumps(line) for line in lines), encoding="utf-8")
+
+        record = connector.parse(path, embedding_id=3)
+
+        # Sanity: conversation_id came from the session_meta payload, not a
+        # path-derived fallback.
+        assert record.conversation_id == session_id
+        assert record.message_count == 2
+
+        exported = connector.export_original(record)
+        assert isinstance(exported, bytes)
+        assert exported
+
+        result = verify_roundtrip(connector, record)
+        assert result.ok is True, result.reason
+        assert result.mismatches == ()

--- a/tests/unit/connectors/test_export_original_continue.py
+++ b/tests/unit/connectors/test_export_original_continue.py
@@ -1,0 +1,93 @@
+"""Unit tests for `ContinueConnector.export_original` / round-trip verification (M8).
+
+Continue's `project_id` is either the constant `"continue"` (no workspace
+recorded) or a one-way `continue-<sha1(workspaceDirectory)[:10]>` hash
+computed at parse time. The hash cannot be inverted back to the original
+`workspaceDirectory` from a `ConversationRecord` alone, so
+`ContinueConnector.export_original` deliberately omits `workspaceDirectory`
+from its re-serialized JSON in both cases (see its docstring). These tests
+prove both halves of that contract: the fully-reconstructible case round
+trips exactly, and the hash-derived case is honestly reported as a
+`project_id` mismatch rather than silently mis-reported as reversible.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from searchat.core.connectors.continue_cli import ContinueConnector
+from searchat.services.source_lifecycle import verify_roundtrip
+
+_HISTORY = [
+    {
+        "role": "user",
+        "content": "How do I implement a binary search in Python?",
+        "timestamp": "2024-01-15T10:00:00",
+    },
+    {
+        "role": "assistant",
+        "content": (
+            "Here's a binary search implementation:\n\n"
+            "```python\ndef binary_search(arr, target):\n    pass\n```"
+        ),
+        "timestamp": "2024-01-15T10:01:00",
+    },
+]
+
+
+@pytest.fixture
+def connector() -> ContinueConnector:
+    return ContinueConnector()
+
+
+def _write_session(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "session.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class TestContinueRoundtripNoWorkspace:
+    """No `workspaceDirectory` key in the source session -> `project_id`
+    is the constant `"continue"`, which IS fully reconstructible: the
+    round trip must succeed exactly, with no mismatches at all."""
+
+    def test_roundtrip_ok_with_no_mismatches(self, connector: ContinueConnector, tmp_path: Path) -> None:
+        path = _write_session(tmp_path, {"history": _HISTORY})
+        record = connector.parse(path, embedding_id=1)
+
+        assert record.project_id == "continue"
+
+        result = verify_roundtrip(connector, record)
+
+        assert result.ok is True
+        assert result.mismatches == ()
+
+
+class TestContinueRoundtripWithWorkspaceHash:
+    """A `workspaceDirectory` value present at parse time -> `project_id`
+    becomes the one-way hash `continue-<sha1[:10]>`. `export_original`
+    cannot invert that hash back to the original workspace path (its
+    docstring explains why), so `workspaceDirectory` is correctly omitted
+    from the re-serialized JSON and re-parsing necessarily recomputes
+    `project_id="continue"` -- a genuine, honestly-detected mismatch
+    against the stored `"continue-<hash>"`, not a silent false success.
+    Every other field (messages, title, timestamps, ...) must still match
+    exactly, proving `project_id` is the ONLY casualty of this limitation.
+    """
+
+    def test_roundtrip_reports_project_id_as_the_only_mismatch(
+        self, connector: ContinueConnector, tmp_path: Path
+    ) -> None:
+        payload = {"history": _HISTORY, "workspaceDirectory": "/Users/dev/my-project"}
+        path = _write_session(tmp_path, payload)
+        record = connector.parse(path, embedding_id=2)
+
+        assert re.fullmatch(r"continue-[0-9a-f]{10}", record.project_id)
+
+        result = verify_roundtrip(connector, record)
+
+        assert result.ok is False
+        assert result.mismatches == ("project_id",)

--- a/tests/unit/connectors/test_export_original_cursor.py
+++ b/tests/unit/connectors/test_export_original_cursor.py
@@ -1,0 +1,126 @@
+"""Unit tests for `CursorConnector.export_original` / round-trip reconstruction (M8).
+
+Cursor is NOT verified via `services.source_lifecycle.verify_roundtrip`:
+that helper mirrors `record.file_path` under a throwaway temp directory and
+re-parses at the mirrored path, which does not match Cursor's scheme.
+`record.file_path` here is a *pseudo path* (`<db_path>.cursor/<composer_id>.json`)
+that never exists on disk as a literal file -- `CursorConnector.parse`
+decodes it back into a real, shared, per-workspace `state.vscdb` SQLite
+file sitting one directory level up. Proving the round trip therefore
+means relocating a real SQLite file to a new real path and decoding a
+pseudo path built against ITS new location, which is what this module does
+directly instead of going through `verify_roundtrip`.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from searchat.core.connectors.cursor import CursorConnector
+
+
+@pytest.fixture
+def connector() -> CursorConnector:
+    return CursorConnector()
+
+
+def _make_vscdb(
+    db_path: Path,
+    composer_id: str,
+    created_at: datetime,
+    updated_at: datetime,
+    messages: list[tuple[str, str, datetime]],
+) -> None:
+    """Build a real `state.vscdb`-shaped SQLite file: an `ItemTable(key, value)`
+    holding one `composerData:<id>` row and one `bubbleId:<id>` row per
+    message, matching the exact shapes `CursorConnector._load_composer` /
+    `_load_bubbles` expect -- including `timingInfo.clientEndTime`, without
+    which a bubble's timestamp falls back to file mtime and would not
+    round-trip.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(db_path))
+    try:
+        con.execute("CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)")
+        bubble_ids = [f"bubble-{i}" for i in range(len(messages))]
+        headers: list[dict] = []
+        rows: list[tuple[str, str]] = []
+        for bubble_id, (role, content, timestamp) in zip(bubble_ids, messages):
+            bubble_type = 1 if role == "user" else 2
+            headers.append({"bubbleId": bubble_id, "type": bubble_type})
+            rows.append(
+                (
+                    f"bubbleId:{bubble_id}",
+                    json.dumps(
+                        {
+                            "bubbleId": bubble_id,
+                            "rawText": content,
+                            "timingInfo": {"clientEndTime": round(timestamp.timestamp() * 1000)},
+                        }
+                    ),
+                )
+            )
+        composer = {
+            "composerId": composer_id,
+            "createdAt": round(created_at.timestamp() * 1000),
+            "lastUpdatedAt": round(updated_at.timestamp() * 1000),
+            "fullConversationHeadersOnly": headers,
+        }
+        rows.insert(0, (f"composerData:{composer_id}", json.dumps(composer)))
+        con.executemany("INSERT INTO ItemTable (key, value) VALUES (?, ?)", rows)
+        con.commit()
+    finally:
+        con.close()
+
+
+def _pseudo_path(db_path: Path, composer_id: str) -> Path:
+    return Path(f"{db_path.as_posix()}.cursor/{composer_id}.json")
+
+
+class TestCursorExportRoundtrip:
+    def test_export_then_relocate_preserves_content_not_project_id(
+        self, connector: CursorConnector, tmp_path: Path
+    ) -> None:
+        composer_id = "composer-abc123"
+        created_at = datetime(2024, 1, 15, 9, 0, 0)
+        updated_at = datetime(2024, 1, 15, 9, 5, 0)
+        messages = [
+            ("user", "How do I sort a list in Python?", datetime(2024, 1, 15, 9, 0, 0)),
+            ("assistant", "Use `sorted(lst)` or `lst.sort()`.", datetime(2024, 1, 15, 9, 1, 0)),
+        ]
+
+        original_db_path = tmp_path / "original_workspace" / "state.vscdb"
+        _make_vscdb(original_db_path, composer_id, created_at, updated_at, messages)
+        record = connector.parse(_pseudo_path(original_db_path, composer_id), embedding_id=0)
+
+        exported = connector.export_original(record)
+        assert exported  # non-empty bytes: a real SQLite file
+
+        relocated_db_path = tmp_path / "relocated_workspace" / "state.vscdb"
+        relocated_db_path.parent.mkdir(parents=True, exist_ok=True)
+        relocated_db_path.write_bytes(exported)
+        reparsed = connector.parse(
+            _pseudo_path(relocated_db_path, record.conversation_id), embedding_id=0
+        )
+
+        assert reparsed.conversation_id == record.conversation_id
+        assert reparsed.messages == record.messages
+        assert reparsed.title == record.title
+        assert reparsed.created_at == record.created_at
+        assert reparsed.updated_at == record.updated_at
+
+        # `project_id` is deliberately asserted UNEQUAL, not equal. Per
+        # `CursorConnector.export_original`'s docstring: `project_id` is
+        # derived by `parse()` from the real `.vscdb` file's OWN
+        # filesystem path (`_project_id_from_db_path`), which cannot be
+        # reconstructed from `record` alone -- it is recomputed fresh from
+        # wherever the exported bytes happen to land. Having relocated the
+        # database to a different directory here, that path-derived
+        # identity necessarily changes; asserting inequality proves the
+        # connector is honest about this documented limitation instead of
+        # coincidentally matching.
+        assert reparsed.project_id != record.project_id

--- a/tests/unit/connectors/test_export_original_gemini.py
+++ b/tests/unit/connectors/test_export_original_gemini.py
@@ -1,0 +1,71 @@
+"""Round-trip export/re-parse tests for `GeminiCLIConnector.export_original` (M8).
+
+Exercises `export_original` only via `services.source_lifecycle.verify_roundtrip`
+against a real parsed `ConversationRecord` -- never a hand-constructed one.
+The fixture is placed at `<tmp>/<project_hash>/chats/<id>.json`, matching
+`_project_hash_from_path`'s expectation, so `record.project_id` is a real
+`gemini-<hash>` value rather than the bare `gemini` fallback -- proving the
+path-derived-identity round trip (which `verify_roundtrip` covers by
+mirroring the full directory structure) is actually exercised.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from searchat.core.connectors.gemini import GeminiCLIConnector
+from searchat.services.source_lifecycle import verify_roundtrip
+
+
+@pytest.fixture
+def connector() -> GeminiCLIConnector:
+    return GeminiCLIConnector()
+
+
+def _write_chat(tmp_path: Path, project_hash: str, chat_id: str, history: list[dict]) -> Path:
+    chats_dir = tmp_path / project_hash / "chats"
+    chats_dir.mkdir(parents=True, exist_ok=True)
+    path = chats_dir / f"{chat_id}.json"
+    path.write_text(json.dumps({"history": history}), encoding="utf-8")
+    return path
+
+
+class TestGeminiExportOriginalRoundtrip:
+    def test_roundtrip_preserves_project_hash_and_messages(
+        self, connector: GeminiCLIConnector, tmp_path: Path
+    ) -> None:
+        # "model" is Gemini's native role spelling but GeminiCLIConnector.parse
+        # lowercases and only accepts user/assistant/system/tool -- "model"
+        # would be silently dropped, so "assistant" is used here instead.
+        history = [
+            {
+                "role": "user",
+                "content": "Summarize this repository's architecture.",
+                "timestamp": "2026-02-01T09:00:00",
+            },
+            {
+                "role": "assistant",
+                "content": "The repository uses a hybrid BM25 + FAISS search engine.",
+                "timestamp": "2026-02-01T09:01:00",
+            },
+        ]
+        path = _write_chat(tmp_path, "8f3c1a9b2d4e5f60", "chat-session-001", history)
+
+        record = connector.parse(path, embedding_id=5)
+
+        assert record.project_id.startswith("gemini-")
+        assert record.project_id == "gemini-8f3c1a9b2d4e5f60"
+        assert record.message_count == 2
+        assert [m.role for m in record.messages] == ["user", "assistant"]
+
+        result = verify_roundtrip(connector, record)
+
+        assert result.ok is True
+        assert result.mismatches == ()
+        assert result.reason is None
+
+        exported = connector.export_original(record)
+        assert isinstance(exported, bytes)
+        assert len(exported) > 0

--- a/tests/unit/connectors/test_export_original_omp.py
+++ b/tests/unit/connectors/test_export_original_omp.py
@@ -1,0 +1,89 @@
+"""Round-trip export/re-parse tests for `OmpConnector.export_original` (M8).
+
+Exercises `export_original` only via `services.source_lifecycle.verify_roundtrip`
+against a real parsed `ConversationRecord` -- never a hand-constructed one.
+The fixture covers all four raw omp roles (`user`, `assistant`, `developer`,
+`toolresult`/`bashexecution`) so `_REVERSE_ROLE_MAP` is actually exercised,
+including the many-to-one collapse of `toolresult`/`bashexecution` onto the
+normalized `"tool"` role.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from searchat.core.connectors.omp import OmpConnector
+from searchat.services.source_lifecycle import verify_roundtrip
+
+
+@pytest.fixture
+def connector() -> OmpConnector:
+    return OmpConnector()
+
+
+def _write_session(tmp_path: Path, slug: str, filename: str, lines: list[dict]) -> Path:
+    slug_dir = tmp_path / slug
+    slug_dir.mkdir(parents=True, exist_ok=True)
+    path = slug_dir / filename
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _text_message(role: str, text: str, timestamp: str) -> dict:
+    return {
+        "type": "message",
+        "message": {"role": role, "content": [{"type": "text", "text": text}]},
+        "timestamp": timestamp,
+    }
+
+
+class TestOmpExportOriginalRoundtrip:
+    def test_roundtrip_covers_all_four_raw_roles(self, connector: OmpConnector, tmp_path: Path) -> None:
+        lines = [
+            {
+                "type": "session",
+                "id": "01900000-0000-7000-8000-0000000000ff",
+                "title": "Investigate flaky test",
+            },
+            _text_message("user", "Why is test_foo flaky?", "2026-04-05T09:00:00"),
+            _text_message(
+                "assistant",
+                "It relies on wall-clock time; let's mock the clock.",
+                "2026-04-05T09:00:05",
+            ),
+            _text_message(
+                "developer",
+                "System policy: never delete source JSONLs without explicit --force.",
+                "2026-04-05T09:00:10",
+            ),
+            _text_message("toolresult", "pytest tests/test_foo.py -q\n1 passed", "2026-04-05T09:00:15"),
+            _text_message(
+                "bashexecution",
+                "$ pytest tests/test_foo.py -q -k flaky\n1 passed in 0.12s",
+                "2026-04-05T09:00:20",
+            ),
+        ]
+        filename = "2026-04-05T09-00-00-000Z_01900000-0000-7000-8000-0000000000ff.jsonl"
+        path = _write_session(tmp_path, "-tmp-demo-project", filename, lines)
+
+        record = connector.parse(path, embedding_id=7)
+
+        assert record.conversation_id == "01900000-0000-7000-8000-0000000000ff"
+        assert record.title == "Investigate flaky test"
+        assert record.message_count == 5
+        roles = [m.role for m in record.messages]
+        assert roles == ["user", "assistant", "system", "tool", "tool"]
+        assert any(m.role == "system" for m in record.messages)
+        assert any(m.role == "tool" for m in record.messages)
+
+        result = verify_roundtrip(connector, record)
+
+        assert result.ok is True
+        assert result.mismatches == ()
+        assert result.reason is None
+
+        exported = connector.export_original(record)
+        assert isinstance(exported, bytes)
+        assert len(exported) > 0

--- a/tests/unit/connectors/test_export_original_opencode.py
+++ b/tests/unit/connectors/test_export_original_opencode.py
@@ -1,0 +1,99 @@
+"""Round-trip tests for `OpenCodeConnector.export_original` via
+`services.source_lifecycle.verify_roundtrip` (M8).
+
+Writes a real OpenCode session JSON at its real on-disk location
+(`storage/session/<projectID>/<sessionID>.json`) alongside real sibling
+`storage/message/<sessionID>/*.json` files -- the on-disk shape
+`OpenCodeConnector.parse` reads first via `_load_opencode_messages`.
+`verify_roundtrip` mirrors only the exported session file itself into a
+throwaway temp dir (never the sibling message directory), so re-parsing it
+there can only succeed through `export_original`'s inline `messages`
+fallback -- proving that fallback, not the sibling-file path, reconstructs
+the conversation. No mocking of `connector.parse`,
+`connector.export_original`, or `verify_roundtrip` itself.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from searchat.core.connectors.opencode import OpenCodeConnector
+from searchat.services.source_lifecycle import verify_roundtrip
+
+
+@pytest.fixture
+def connector() -> OpenCodeConnector:
+    return OpenCodeConnector()
+
+
+class TestOpenCodeExportOriginalRoundtrip:
+    def test_roundtrip_inline_messages_fallback_when_sibling_dirs_absent(
+        self, connector: OpenCodeConnector, tmp_path
+    ) -> None:
+        session_id = "ses_7e2c9a"
+        project_id = "proj-9d1"
+
+        # Real on-disk layout: storage/session/<projectID>/<sessionID>.json
+        session_dir = tmp_path / "storage" / "session" / project_id
+        session_dir.mkdir(parents=True)
+        session_data = {
+            "id": session_id,
+            "sessionID": session_id,
+            "projectID": project_id,
+            "title": "Fix the fibonacci helper",
+            "time": {"created": 1750000000000, "updated": 1750000100000},
+        }
+        session_path = session_dir / f"{session_id}.json"
+        session_path.write_text(json.dumps(session_data), encoding="utf-8")
+
+        # Real on-disk layout: sibling storage/message/<sessionID>/*.json.
+        # This is what the ORIGINAL parse() reads -- session_data itself
+        # deliberately carries no inline "messages" key.
+        message_dir = tmp_path / "storage" / "message" / session_id
+        message_dir.mkdir(parents=True)
+        (message_dir / "msg1.json").write_text(
+            json.dumps(
+                {
+                    "id": "msg1",
+                    "role": "user",
+                    "content": "How do I write a fast fibonacci function?",
+                    "time": {"created": 1750000000000},
+                }
+            ),
+            encoding="utf-8",
+        )
+        (message_dir / "msg2.json").write_text(
+            json.dumps(
+                {
+                    "id": "msg2",
+                    "role": "assistant",
+                    "content": "Use memoization to avoid recomputation.",
+                    "time": {"created": 1750000050000},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        record = connector.parse(session_path, embedding_id=0)
+
+        # Sanity: the original parse actually pulled messages from the
+        # sibling files (session_data has no inline "messages" key at all),
+        # so this is a genuine test of the sibling-dir-reliant on-disk shape.
+        assert record.message_count == 2
+        assert [m.role for m in record.messages] == ["user", "assistant"]
+        assert record.messages[0].content == "How do I write a fast fibonacci function?"
+        assert record.messages[1].content == "Use memoization to avoid recomputation."
+
+        exported = connector.export_original(record)
+        assert isinstance(exported, bytes)
+        assert exported
+        exported_payload = json.loads(exported)
+        # export_original must embed messages inline -- this is the only
+        # data verify_roundtrip's temp-mirrored re-parse can rely on, since
+        # the sibling storage/message directory is never mirrored.
+        assert exported_payload.get("messages")
+
+        result = verify_roundtrip(connector, record)
+        assert result.ok is True, result.reason
+        assert result.mismatches == ()

--- a/tests/unit/connectors/test_export_original_vibe.py
+++ b/tests/unit/connectors/test_export_original_vibe.py
@@ -1,0 +1,104 @@
+"""Round-trip export/re-parse tests for `VibeConnector.export_original` (M8).
+
+Exercises `export_original` only via `services.source_lifecycle.verify_roundtrip`
+against a real parsed `ConversationRecord` -- never a hand-constructed one --
+so these tests actually prove the reversibility guarantee that gates
+archive/prune, not just that `export_original` returns *some* bytes.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from searchat.core.connectors.vibe import VibeConnector
+from searchat.services.source_lifecycle import verify_roundtrip
+
+
+@pytest.fixture
+def connector() -> VibeConnector:
+    return VibeConnector()
+
+
+def _write_session(
+    tmp_path: Path,
+    name: str,
+    session_id: str,
+    messages: list[dict],
+    working_directory: str | None = "",
+) -> Path:
+    """Write a native Vibe session JSON.
+
+    `working_directory=None` omits the key entirely (the "absent" case);
+    `working_directory=""` writes it as an empty string (the "empty" case).
+    Both make `VibeConnector.parse` fall back to the `vibe-session` project
+    basename.
+    """
+    environment: dict[str, str] = {}
+    if working_directory is not None:
+        environment["working_directory"] = working_directory
+    payload = {
+        "metadata": {
+            "session_id": session_id,
+            "environment": environment,
+            "start_time": "2026-01-15T10:00:00",
+            "end_time": "2026-01-15T10:45:00",
+        },
+        "messages": messages,
+    }
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class TestVibeExportOriginalRoundtrip:
+    def test_roundtrip_with_working_directory(self, connector: VibeConnector, tmp_path: Path) -> None:
+        messages = [
+            {"role": "user", "content": "How do I fix this bug in the parser?"},
+            {"role": "assistant", "content": "Let's look at the parser module and add a null check."},
+        ]
+        path = _write_session(
+            tmp_path,
+            "session.json",
+            "vibe-session-abc123",
+            messages,
+            working_directory="/home/x/somerepo",
+        )
+
+        record = connector.parse(path, embedding_id=1)
+        assert record.project_id == "vibe-somerepo"
+        assert record.message_count == 2
+
+        result = verify_roundtrip(connector, record)
+
+        assert result.ok is True
+        assert result.mismatches == ()
+        assert result.reason is None
+
+        exported = connector.export_original(record)
+        assert isinstance(exported, bytes)
+        assert len(exported) > 0
+
+    def test_roundtrip_without_working_directory(self, connector: VibeConnector, tmp_path: Path) -> None:
+        messages = [
+            {"role": "user", "content": "What does this function do?"},
+            {"role": "assistant", "content": "It parses the input and returns a list of tokens."},
+        ]
+        path = _write_session(
+            tmp_path,
+            "session2.json",
+            "vibe-session-def456",
+            messages,
+            working_directory=None,
+        )
+
+        record = connector.parse(path, embedding_id=2)
+        assert record.project_id == "vibe-vibe-session"
+        assert record.message_count == 2
+
+        result = verify_roundtrip(connector, record)
+
+        assert result.ok is True
+        assert result.mismatches == ()
+        assert result.reason is None


### PR DESCRIPTION
## Stack

Stack-Id: `m8-archive-then-prune`
Base: `feat/source-lifecycle-verify-ingested` (#108)
Position: 2/6

1. `feat/source-lifecycle-verify-ingested` -> #108
2. `feat/source-lifecycle-export-roundtrip` -> this PR
3. `feat/source-lifecycle-archive` -> PR-3
4. `feat/source-lifecycle-prune-tombstone` -> PR-4
5. `feat/source-lifecycle-policy-gates` -> PR-5
6. `feat/source-lifecycle-cli` -> PR-6

Depends on: #108
Upstack: PR-3

## Summary

M8, PR 2 of 6 — the second (and final) independent verification stage
that must pass before any source conversation file becomes
archive/prune-eligible.

- `core/connectors/base.py::AgentProviderBase.export_original` — new
  abstract method every connector must implement: re-serialize a stored
  `ConversationRecord` back into the connector's native on-disk format.
- Implemented for all 9 connectors (claude, codex, opencode, vibe,
  gemini, continue, cursor, aider, omp). Three connectors (continue,
  cursor, aider) have **documented, intentional** round-trip limitations
  on specific hash/path-derived identity fields — covered by tests that
  prove the gate correctly refuses reversibility for those fields rather
  than silently mis-reporting success.
- `services/source_lifecycle.py::verify_roundtrip` — re-parses each
  connector's `export_original` output at a throwaway temp path
  mirroring the original file's directory structure, then diffs the
  result against the stored record field-by-field. **Read-only**: never
  writes to the source file or its siblings, only to a
  `tempfile.TemporaryDirectory`.

## Verification

```
uv run pytest tests/unit/connectors/ -v --tb=short --no-cov -k export_original
```
13/13 passed (exact command from the M8 objective).

```
uv run pytest tests/unit/connectors/ tests/unit/services/test_source_lifecycle.py -v --tb=short --no-cov
```
151/151 passed.