### PR TITLE
feat(services): implement archive_source zstd-compress-in-place

### DIFF
--- a/src/searchat/services/source_lifecycle.py
+++ b/src/searchat/services/source_lifecycle.py
@@ -45,6 +45,7 @@ import duckdb
 from searchat.core.connectors.base import AgentProviderBase
 from searchat.core.logging_config import get_logger
 from searchat.models import ConversationRecord
+from searchat.services.backup_compression import compress_file, decompress_file
 
 logger = get_logger(__name__)
 
@@ -313,3 +314,47 @@ def verify_roundtrip(connector: AgentProviderBase, record: ConversationRecord) -
             False, reason="re-parsed record differs from the stored record", mismatches=mismatches
         )
     return RoundtripResult(True)
+
+
+def archive_source(file_path: Path, *, compression_level: int = 3) -> Path:
+    """Zstd-compress `file_path` in place, replacing it with `<name>.zst`.
+
+    Verifies the compressed file decompresses back to byte-identical
+    content -- via a real decompress-to-a-temp-file round trip, not just
+    an in-memory hash -- BEFORE removing the original, mirroring
+    `services/compaction.py`'s verify-before-destructive-step pattern.
+    The original is left completely untouched on any failure: a missing
+    source, an existing `.zst` target, or a failed verification all raise
+    before `file_path.unlink()` is ever reached.
+
+    Callers (`services.source_lifecycle`'s own orchestration, never a
+    bare CLI flag) are responsible for having already confirmed
+    `verify_ingested` and `verify_roundtrip` both passed and the file is
+    age- and agent-gated; this function performs no gating of its own --
+    it only performs the compression, verification, and swap once called.
+    """
+    if not file_path.is_file():
+        raise FileNotFoundError(f"cannot archive missing file: {file_path}")
+
+    archived_path = file_path.with_name(file_path.name + ".zst")
+    if archived_path.exists():
+        raise FileExistsError(f"archive target already exists: {archived_path}")
+
+    original_hash = _sha256_file(file_path)
+    content_sha256, _stored_sha256, _stored_size = compress_file(
+        file_path, archived_path, level=compression_level
+    )
+    if content_sha256 != original_hash:
+        archived_path.unlink(missing_ok=True)
+        raise RuntimeError(f"compression content hash mismatch for {file_path}; original left untouched")
+
+    with tempfile.TemporaryDirectory(prefix="searchat-archive-verify-") as tmp_dir:
+        decompressed_path = Path(tmp_dir) / file_path.name
+        decompress_file(archived_path, decompressed_path)
+        if _sha256_file(decompressed_path) != original_hash:
+            archived_path.unlink(missing_ok=True)
+            raise RuntimeError(f"decompression verification failed for {file_path}; original left untouched")
+
+    file_path.unlink()
+    return archived_path
+

--- a/tests/unit/services/test_source_lifecycle.py
+++ b/tests/unit/services/test_source_lifecycle.py
@@ -23,7 +23,8 @@ import duckdb
 import pytest
 
 from searchat.core.connectors.claude import ClaudeConnector
-from searchat.services.source_lifecycle import VerificationResult, verify_ingested
+from searchat.services.backup_compression import decompress_file
+from searchat.services.source_lifecycle import VerificationResult, archive_source, verify_ingested
 from searchat.storage.schema import ensure_tables
 
 # ---------------------------------------------------------------------------
@@ -362,3 +363,90 @@ def test_verify_ingested_fails_when_conversation_id_has_no_matching_conversation
     assert result.reason
     assert conversation_id in result.reason
     assert "conversations" in result.reason.lower()
+
+# ---------------------------------------------------------------------------
+# archive_source: zstd-compress-then-verify-then-delete (M8).
+#
+# These tests exercise the real zstandard compress/decompress round trip
+# against real files on disk -- no mocking -- because a bug here can
+# destroy user data (see module docstring). Every scenario asserts the
+# original file's fate: deleted only on a fully verified success, left
+# byte-for-byte untouched on any failure.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_archive_source_compresses_deletes_original_and_roundtrips(tmp_path: Path) -> None:
+    source_file = _write_claude_jsonl(tmp_path / "conv-archive.jsonl", num_exchanges=200)
+    original_bytes = source_file.read_bytes()
+    assert len(original_bytes) > 2000  # "a few KB", not a token fixture
+
+    result = archive_source(source_file)
+
+    assert result == source_file.with_name(source_file.name + ".zst")
+    assert result.exists()
+    assert not source_file.exists()
+
+    decompressed = tmp_path / "roundtrip-decompressed.jsonl"
+    decompress_file(result, decompressed)
+    assert decompressed.read_bytes() == original_bytes
+    assert _sha256(decompressed) == hashlib.sha256(original_bytes).hexdigest()
+
+
+@pytest.mark.unit
+def test_archive_source_raises_file_not_found_for_missing_source(tmp_path: Path) -> None:
+    missing_file = tmp_path / "never-written.jsonl"
+
+    with pytest.raises(FileNotFoundError):
+        archive_source(missing_file)
+
+    assert not missing_file.with_name(missing_file.name + ".zst").exists()
+
+
+@pytest.mark.unit
+def test_archive_source_raises_file_exists_and_leaves_both_files_untouched(tmp_path: Path) -> None:
+    source_file = _write_claude_jsonl(tmp_path / "conv-target-exists.jsonl")
+    archived_path = source_file.with_name(source_file.name + ".zst")
+    archived_path.write_bytes(b"not a real zst archive -- arbitrary pre-existing content")
+
+    source_bytes_before = source_file.read_bytes()
+    archived_bytes_before = archived_path.read_bytes()
+
+    with pytest.raises(FileExistsError):
+        archive_source(source_file)
+
+    assert source_file.read_bytes() == source_bytes_before
+    assert archived_path.read_bytes() == archived_bytes_before
+
+
+@pytest.mark.unit
+def test_archive_source_with_custom_compression_level_still_roundtrips(tmp_path: Path) -> None:
+    source_file = _write_claude_jsonl(tmp_path / "conv-archive-level9.jsonl", num_exchanges=200)
+    original_bytes = source_file.read_bytes()
+
+    result = archive_source(source_file, compression_level=9)
+
+    assert result == source_file.with_name(source_file.name + ".zst")
+    assert result.exists()
+    assert not source_file.exists()
+
+    decompressed = tmp_path / "roundtrip-decompressed-level9.jsonl"
+    decompress_file(result, decompressed)
+    assert decompressed.read_bytes() == original_bytes
+
+
+@pytest.mark.unit
+def test_archive_source_roundtrips_empty_file(tmp_path: Path) -> None:
+    empty_file = tmp_path / "empty.jsonl"
+    empty_file.write_bytes(b"")
+
+    result = archive_source(empty_file)
+
+    assert result == empty_file.with_name(empty_file.name + ".zst")
+    assert result.exists()
+    assert not empty_file.exists()
+
+    decompressed = tmp_path / "roundtrip-decompressed-empty.jsonl"
+    decompress_file(result, decompressed)
+    assert decompressed.exists()
+    assert decompressed.read_bytes() == b""


### PR DESCRIPTION
## Stack

Stack-Id: `m8-archive-then-prune`
Base: `feat/source-lifecycle-export-roundtrip` (#109)
Position: 3/6

1. `feat/source-lifecycle-verify-ingested` -> #108
2. `feat/source-lifecycle-export-roundtrip` -> #109
3. `feat/source-lifecycle-archive` -> this PR
4. `feat/source-lifecycle-prune-tombstone` -> PR-4
5. `feat/source-lifecycle-policy-gates` -> PR-5
6. `feat/source-lifecycle-cli` -> PR-6

Depends on: #109
Upstack: PR-4

## Summary

M8, PR 3 of 6 — the first mutating action, gated on the two prior PRs' verification stages (not yet wired to them; wiring lands in PR-5's `run_lifecycle_action`).

`services/source_lifecycle.py::archive_source(file_path, *, compression_level=3) -> Path`:
- Compresses `file_path` to `<name>.zst` via the existing `backup_compression` streaming API (already used by M4's backup engine).
- Verifies a **real decompress round trip to a temp file**, comparing full SHA-256 — not just the in-memory compression hash — before ever deleting the original.
- Any failure (missing source, an existing `.zst` target, or a failed verification) leaves the original completely untouched and never leaves behind a partial `.zst` file.
- Performs no gating of its own; callers (PR-5's orchestration) are responsible for `verify_ingested`/`verify_roundtrip`/age/agent gating having already passed.

## Verification

```
uv run pytest tests/unit/services/test_source_lifecycle.py -v --tb=short --no-cov
```

15/15 passed.
