### PR TITLE
feat(cli): add sources archive/prune CLI and close out M8 verification proofs

### DIFF
--- a/src/searchat/cli/main.py
+++ b/src/searchat/cli/main.py
@@ -470,6 +470,11 @@ def main():
 
             raise SystemExit(run_disk(argv[1:]))
 
+        if argv and argv[0] == "sources":
+            from searchat.cli.sources_cmd import run_sources
+
+            raise SystemExit(run_sources(argv[1:]))
+
         if "-h" in argv_set or "--help" in argv_set:
             print("Usage: searchat")
             print()
@@ -506,6 +511,8 @@ def main():
             print("  searchat compact [--json] [--in-process]")
             print("  searchat ci-check [--fail-on-contradictions] [--fail-on-staleness-threshold FLOAT]")
             print("  searchat disk [--json]")
+            print("  searchat sources archive [--dry-run=true|false] [--json]")
+            print("  searchat sources prune [--dry-run=true|false] [--json]")
             print()
             return
 

--- a/src/searchat/cli/sources_cmd.py
+++ b/src/searchat/cli/sources_cmd.py
@@ -1,0 +1,131 @@
+"""CLI command: searchat sources archive / searchat sources prune -- M8
+verified archive-then-prune of source conversation files.
+
+Both subcommands are dry-run by default: they report which files WOULD be
+archived/pruned without touching disk. A real mutation requires the
+explicit `--dry-run=false` flag -- there is no other way to opt out of
+dry-run mode from this CLI, independent of any `lifecycle.dry_run` config
+value. Neither subcommand ever acts on a file that hasn't passed BOTH
+`verify_ingested` and `verify_roundtrip`; that gate is enforced inside
+`services.source_lifecycle.run_lifecycle_action`, not here.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def _parse_dry_run(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in ("true", "1", "yes"):
+        return True
+    if normalized in ("false", "0", "no"):
+        return False
+    raise argparse.ArgumentTypeError(f"--dry-run must be 'true' or 'false', got {value!r}")
+
+
+def _build_parser(action: str) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=f"searchat sources {action}",
+        description=(
+            f"{action.capitalize()} source conversation files that are both age-gated "
+            "(lifecycle.age_threshold_days) and explicitly opted in per connector "
+            "(lifecycle.enabled_agents), after verifying each one is fully ingested "
+            "(checksum + message-count parity) and losslessly reversible (export "
+            "round trip). Neither verification is skippable in code; a file failing "
+            f"either is never {action}d."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        type=_parse_dry_run,
+        default=True,
+        metavar="{true,false}",
+        help=(
+            "Defaults to true: report what WOULD happen without touching disk. "
+            "Pass --dry-run=false explicitly to perform the real action -- there is "
+            "no other way to enable it from this command."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Output raw JSON instead of a summary.")
+    return parser
+
+
+def _run(argv: list[str], *, action: str) -> int:
+    parser = _build_parser(action)
+    args = parser.parse_args(argv)
+
+    from searchat.config import Config, PathResolver
+    from searchat.services.source_lifecycle import run_lifecycle_action
+
+    config = Config.load()
+    search_dir = PathResolver.get_shared_search_dir(config)
+    db_path = config.storage.resolve_duckdb_path(search_dir)
+    tombstone_dir = search_dir / "tombstones"
+
+    try:
+        decisions = run_lifecycle_action(
+            db_path=db_path,
+            policy=config.lifecycle,
+            action=action,
+            dry_run=args.dry_run,
+            tombstone_dir=tombstone_dir,
+        )
+    except Exception as exc:
+        print(f"Error: failed to run sources {action}: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps([d.to_dict() for d in decisions], indent=2))
+        return 0
+
+    from rich.console import Console
+
+    console = Console()
+
+    if args.dry_run:
+        console.print(
+            f"[bold yellow]Dry run[/bold yellow] -- searchat sources {action} "
+            "(pass --dry-run=false to act)"
+        )
+    else:
+        console.print(f"[bold green]searchat sources {action}[/bold green]")
+
+    if not decisions:
+        console.print("[dim]No indexed source files found.[/dim]")
+        return 0
+
+    acted = [d for d in decisions if d.action_taken]
+    pending = [d for d in decisions if d.eligible and not d.action_taken]
+    skipped = [d for d in decisions if not d.eligible]
+
+    for decision in acted:
+        console.print(f"  [green]{decision.action_taken}d[/green]  {decision.file_path}")
+    for decision in pending:
+        console.print(f"  [yellow]would {action}[/yellow]  {decision.file_path}")
+
+    console.print(
+        f"\n{len(acted)} {action}d, {len(pending)} eligible (dry run), "
+        f"{len(skipped)} skipped, {len(decisions)} total."
+    )
+    return 0
+
+
+def run_sources_archive(argv: list[str]) -> int:
+    return _run(argv, action="archive")
+
+
+def run_sources_prune(argv: list[str]) -> int:
+    return _run(argv, action="prune")
+
+
+def run_sources(argv: list[str]) -> int:
+    """Dispatch `searchat sources <archive|prune> ...`."""
+    if not argv or argv[0] not in ("archive", "prune"):
+        print("Usage: searchat sources <archive|prune> [--dry-run=true|false] [--json]", file=sys.stderr)
+        return 1
+    subcommand, rest = argv[0], argv[1:]
+    if subcommand == "archive":
+        return run_sources_archive(rest)
+    return run_sources_prune(rest)

--- a/tests/unit/services/test_source_lifecycle.py
+++ b/tests/unit/services/test_source_lifecycle.py
@@ -15,6 +15,7 @@ and get their own test coverage in this same file at that point.
 from __future__ import annotations
 
 import hashlib
+import itertools
 import json
 import os
 from datetime import datetime, timedelta, timezone
@@ -26,6 +27,7 @@ import pytest
 from searchat.config.settings import LifecycleConfig
 from searchat.core.connectors import registry
 from searchat.core.connectors.claude import ClaudeConnector
+from searchat.core.connectors.continue_cli import ContinueConnector
 from searchat.services.backup_compression import decompress_file
 from searchat.services.source_lifecycle import (
     LifecycleDecision,
@@ -1263,3 +1265,221 @@ def test_run_lifecycle_action_returns_one_decision_per_indexed_file_with_correct
     assert len(disabled) == 1
     assert disabled[0].eligible is False
     assert disabled[0].agent_enabled is False
+
+# ---------------------------------------------------------------------------
+# evaluate_and_act_on_source: core M8 safety invariant, exhaustively
+# proven across the full boolean state space (M8, closing PR).
+#
+# The whole point of the M8 gate chain is that NO code path can reach a
+# real archive/prune action unless every gate explicitly allowed it. This
+# is the formal statement of that invariant:
+#
+#     decision.action_taken is not None
+#         <=>
+#     agent_enabled AND age_gated AND ingested.ok AND roundtrip.ok
+#         AND (dry_run is False)
+#
+# Every one of the 2**5 = 32 combinations of the five independent axes is
+# built as a REAL fixture -- a real DuckDB via `ensure_tables`, a real
+# Continue-format session JSON, a real on-disk mtime, and a real (correct
+# or deliberately wrong) `source_file_state.file_hash` -- and run through
+# the unmocked `evaluate_and_act_on_source`. `ContinueConnector` is used
+# (rather than `ClaudeConnector`, used everywhere else in this file) so
+# the `roundtrip.ok` axis can be driven by a real, already-documented
+# connector behaviour rather than a mock: per
+# `ContinueConnector.export_original`'s docstring, a session with
+# `workspaceDirectory` unset round-trips (`project_id="continue"` both
+# ways), while the same session WITH `workspaceDirectory` set fails
+# round trip on `project_id` alone (`"continue-<hash>"` vs re-parsed
+# `"continue"`) -- `workspaceDirectory` has no effect on the checksum or
+# message count `verify_ingested` checks, so it isolates the roundtrip
+# axis cleanly from the ingested axis.
+# ---------------------------------------------------------------------------
+
+
+def _write_continue_json(
+    path: Path, *, workspace_directory: str | None, num_exchanges: int = 1
+) -> Path:
+    """Write a real, minimal Continue-format session JSON fixture -- the
+    exact shape `ContinueConnector.parse()` expects: a `history` list of
+    `{"role", "content", "timestamp"}` entries. `workspace_directory`,
+    when not `None`, is Continue's `workspaceDirectory` field, which
+    `parse()` hashes into `project_id` as `f"continue-{sha1(...)[:10]}"`
+    -- and which `export_original` can never reproduce (see its
+    docstring), making it the deliberate lever for the roundtrip axis.
+    """
+    base = datetime(2025, 1, 15, 10, 0, 0)
+    history: list[dict[str, object]] = []
+    for i in range(num_exchanges):
+        history.append(
+            {
+                "role": "user",
+                "content": f"Question {i}",
+                "timestamp": (base + timedelta(minutes=2 * i)).isoformat(),
+            }
+        )
+        history.append(
+            {
+                "role": "assistant",
+                "content": f"Answer {i}",
+                "timestamp": (base + timedelta(minutes=2 * i, seconds=30)).isoformat(),
+            }
+        )
+    payload: dict[str, object] = {
+        "sessionId": path.stem,
+        "title": "Continue property test session",
+        "history": history,
+    }
+    if workspace_directory is not None:
+        payload["workspaceDirectory"] = workspace_directory
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+_GATE_INVARIANT_AGE_THRESHOLD_DAYS = 30
+
+
+def _build_gate_invariant_fixture(
+    tmp_path: Path,
+    *,
+    agent_enabled_axis: bool,
+    age_gated_axis: bool,
+    ingested_ok_axis: bool,
+    roundtrip_ok_axis: bool,
+) -> tuple[Path, Path, LifecycleConfig]:
+    """Build one real (db_path, source_file, policy) fixture for the given
+    axis combination. `dry_run` is deliberately NOT part of this fixture
+    -- it is passed straight through to `evaluate_and_act_on_source` by
+    the caller, per the M8 contract that it is a call-time argument, not
+    a fixture property.
+    """
+    connector = ContinueConnector()
+    workspace_directory = None if roundtrip_ok_axis else "/home/user/real-project"
+    source_file = _write_continue_json(
+        tmp_path / "conv-gate-invariant.json", workspace_directory=workspace_directory
+    )
+    real_hash = _sha256(source_file)
+    real_message_count = connector.parse(source_file, embedding_id=0).message_count
+    conversation_id = source_file.stem
+
+    db_path = _new_db(tmp_path)
+    stored_hash = real_hash if ingested_ok_axis else "0" * 64
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=conversation_id,
+        file_hash=stored_hash,
+        connector_name="continue",
+    )
+    _insert_conversation(
+        db_path,
+        conversation_id=conversation_id,
+        file_path=str(source_file),
+        message_count=real_message_count,
+    )
+
+    if age_gated_axis:
+        mtime = (
+            datetime.now() - timedelta(days=_GATE_INVARIANT_AGE_THRESHOLD_DAYS + 10)
+        ).timestamp()
+    else:
+        mtime = (datetime.now() - timedelta(days=1)).timestamp()
+    os.utime(source_file, (mtime, mtime))
+
+    enabled_agents = frozenset({"continue"}) if agent_enabled_axis else frozenset()
+    policy = LifecycleConfig(
+        age_threshold_days=_GATE_INVARIANT_AGE_THRESHOLD_DAYS,
+        enabled_agents=enabled_agents,
+        dry_run=True,  # unused: dry_run is always passed explicitly below
+    )
+    return db_path, source_file, policy
+
+
+_GATE_INVARIANT_AXES = list(itertools.product([True, False], repeat=5))
+_GATE_INVARIANT_IDS = [
+    f"agent_enabled={a}-age_gated={b}-ingested_ok={c}-roundtrip_ok={d}-dry_run={e}"
+    for a, b, c, d, e in _GATE_INVARIANT_AXES
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "agent_enabled_axis,age_gated_axis,ingested_ok_axis,roundtrip_ok_axis,dry_run_axis",
+    _GATE_INVARIANT_AXES,
+    ids=_GATE_INVARIANT_IDS,
+)
+def test_evaluate_and_act_on_source_action_taken_iff_every_gate_passes_and_not_dry_run(
+    tmp_path: Path,
+    agent_enabled_axis: bool,
+    age_gated_axis: bool,
+    ingested_ok_axis: bool,
+    roundtrip_ok_axis: bool,
+    dry_run_axis: bool,
+) -> None:
+    """Exhaustive property test over all 2**5 = 32 combinations of the
+    five independent axes: proves `action_taken is not None` if and only
+    if every gate passed AND `dry_run` is `False` -- for every point in
+    the boolean state space, not just the hand-picked scenarios the other
+    gate-order tests in this file cover individually.
+    """
+    if registry.get_connector_by_name("continue") is None:
+        registry.register_connector(ContinueConnector())
+
+    db_path, source_file, policy = _build_gate_invariant_fixture(
+        tmp_path,
+        agent_enabled_axis=agent_enabled_axis,
+        age_gated_axis=age_gated_axis,
+        ingested_ok_axis=ingested_ok_axis,
+        roundtrip_ok_axis=roundtrip_ok_axis,
+    )
+
+    decision = evaluate_and_act_on_source(
+        db_path=db_path,
+        connector_name="continue",
+        file_path=source_file,
+        policy=policy,
+        action="prune",
+        dry_run=dry_run_axis,
+        tombstone_dir=tmp_path / "tombstones",
+    )
+
+    expected_action_taken = (
+        agent_enabled_axis
+        and age_gated_axis
+        and ingested_ok_axis
+        and roundtrip_ok_axis
+        and not dry_run_axis
+    )
+
+    assert (decision.action_taken is not None) == expected_action_taken, (
+        f"invariant violated for agent_enabled={agent_enabled_axis}, "
+        f"age_gated={age_gated_axis}, ingested_ok={ingested_ok_axis}, "
+        f"roundtrip_ok={roundtrip_ok_axis}, dry_run={dry_run_axis}: "
+        f"action_taken={decision.action_taken!r}, skip_reason={decision.skip_reason!r}"
+    )
+
+    # `action="prune"` deletes unconditionally once reached, so the file's
+    # fate on disk is the same invariant viewed from a second, independent
+    # angle: gone iff the action fired, byte-for-byte present otherwise.
+    assert source_file.exists() != expected_action_taken
+    if expected_action_taken:
+        assert decision.action_taken == "prune"
+    else:
+        assert decision.action_taken is None
+
+
+# ---------------------------------------------------------------------------
+# NOTE on the "verify_roundtrip never runs when dry_run=True" invariant:
+# this file's earlier gate-order tests already cover every distinct point
+# on that claim --
+# `test_evaluate_and_act_on_source_skips_before_any_gate_when_connector_not_enabled`
+# (agent_enabled=False), `test_evaluate_and_act_on_source_skips_at_age_gate_before_verify_ingested_runs`
+# (age_gated=False), `test_evaluate_and_act_on_source_blocks_action_when_verify_ingested_fails_checksum`
+# (ingested.ok=False, parametrized over both `dry_run` values), and
+# `test_evaluate_and_act_on_source_dry_run_is_eligible_but_takes_no_action_and_writes_nothing`
+# (every other gate passing) -- each already asserts `decision.roundtrip
+# is None` for its scenario with `dry_run=True`. Together they are the
+# exhaustive case split (which of agent_enabled/age_gated/ingested.ok is
+# the first to fail, or none of them), so a further standalone test would
+# only restate them; deliberately not duplicated here.
+# ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_sources.py
+++ b/tests/unit/test_cli_sources.py
@@ -1,0 +1,376 @@
+"""Unit tests for `searchat sources archive` / `searchat sources prune` CLI
+commands (`searchat.cli.sources_cmd.run_sources`) -- the M8 verified
+archive-then-prune of source conversation files.
+
+`tests/unit/services/test_source_lifecycle.py` covers
+`services.source_lifecycle` in isolation. This file covers the CLI layer
+on top of it: argument parsing (`--help`, subcommand dispatch, `--json`,
+bad `--dry-run` values) and full end-to-end wiring through the real
+`Config.load()` / `PathResolver.get_shared_search_dir()` / DuckDB path
+resolution -- including a real fixture DuckDB, a real backdated Claude
+`.jsonl` file, and the real `ClaudeConnector`, with no mocking of the
+lifecycle service itself. The default-dry-run end-to-end test proves the
+CLI entry point itself (not just the service function) makes zero
+filesystem-destroying writes until `--dry-run=false` is passed.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from searchat.cli.sources_cmd import run_sources
+from searchat.config import Config, PathResolver
+from searchat.core.connectors import registry
+from searchat.core.connectors.claude import ClaudeConnector
+from searchat.storage.schema import ensure_tables
+
+# ---------------------------------------------------------------------------
+# Fixture helpers -- mirror the pattern established in
+# tests/unit/services/test_source_lifecycle.py, duplicated locally (rather
+# than imported) so this file has no dependency on that one's internals.
+# ---------------------------------------------------------------------------
+
+
+def _write_claude_jsonl(path: Path, num_exchanges: int = 1) -> Path:
+    """Write a real, minimal Claude-format JSONL fixture -- the exact shape
+    `ClaudeConnector.parse()` expects: `type` in {"user", "assistant"},
+    `message.content` as a plain string, and an ISO `timestamp`.
+
+    Each exchange is one user line + one assistant line, so the real
+    message count a fresh parse will count is `2 * num_exchanges`.
+    """
+    base = datetime(2025, 1, 15, 10, 0, 0)
+    entries: list[dict[str, object]] = []
+    for i in range(num_exchanges):
+        entries.append(
+            {
+                "type": "user",
+                "message": {"content": f"Question {i}"},
+                "timestamp": (base + timedelta(minutes=2 * i)).isoformat(),
+            }
+        )
+        entries.append(
+            {
+                "type": "assistant",
+                "message": {"content": f"Answer {i}"},
+                "timestamp": (base + timedelta(minutes=2 * i, seconds=30)).isoformat(),
+            }
+        )
+    path.write_text("\n".join(json.dumps(entry) for entry in entries) + "\n", encoding="utf-8")
+    return path
+
+
+def _resolve_db_path() -> Path:
+    """The exact DuckDB path `run_sources` will resolve at call time,
+    given whatever SEARCHAT_DATA_DIR currently is -- computed the same
+    way `sources_cmd._run` computes it, so a fixture DB built here is
+    found by the real CLI entry point."""
+    config = Config.load()
+    search_dir = PathResolver.get_shared_search_dir(config)
+    return config.storage.resolve_duckdb_path(search_dir)
+
+
+def _new_db_at(db_path: Path) -> None:
+    """Create an empty but fully-migrated fixture DuckDB file at the
+    exact path the CLI will look for it."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = duckdb.connect(str(db_path))
+    try:
+        ensure_tables(conn)
+    finally:
+        conn.close()
+
+
+def _insert_source_file_state(
+    db_path: Path,
+    *,
+    file_path: str,
+    conversation_id: str | None,
+    project_id: str = "proj",
+    connector_name: str = "claude",
+    status: str = "indexed",
+    file_size: int = 0,
+    file_hash: str | None,
+    updated_at: datetime | None = None,
+) -> None:
+    conn = duckdb.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO source_file_state "
+            "(file_path, conversation_id, project_id, connector_name, status, "
+            "file_size, file_hash, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                file_path,
+                conversation_id,
+                project_id,
+                connector_name,
+                status,
+                file_size,
+                file_hash,
+                updated_at or datetime.now(),
+            ],
+        )
+    finally:
+        conn.close()
+
+
+def _insert_conversation(
+    db_path: Path,
+    *,
+    conversation_id: str,
+    file_path: str,
+    message_count: int,
+    project_id: str = "proj",
+    title: str = "Test conversation",
+    full_text: str = "some indexed text",
+    file_hash: str = "unused-in-conversations-lookup",
+) -> None:
+    now = datetime.now()
+    conn = duckdb.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO conversations "
+            "(conversation_id, project_id, file_path, title, created_at, updated_at, "
+            "message_count, full_text, file_hash, indexed_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                conversation_id,
+                project_id,
+                file_path,
+                title,
+                now,
+                now,
+                message_count,
+                full_text,
+                file_hash,
+                now,
+            ],
+        )
+    finally:
+        conn.close()
+
+
+def _sha256(path: Path) -> str:
+    import hashlib
+
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _ensure_claude_connector_registered() -> None:
+    """Register the real `ClaudeConnector` exactly once for the whole
+    test session -- `registry` is process-global module state, and a
+    sibling test module (test_source_lifecycle.py) may have already
+    registered it first."""
+    if registry.get_connector_by_name("claude") is None:
+        registry.register_connector(ClaudeConnector())
+
+
+# ---------------------------------------------------------------------------
+# 1. --help mentions --dry-run and the default-to-true safety framing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("subcommand", ["archive", "prune"])
+def test_help_output_mentions_dry_run_and_default_safety_framing(subcommand: str, capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        run_sources([subcommand, "--help"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    normalized = " ".join(captured.out.split())
+    assert "--dry-run" in captured.out
+    assert "Defaults to true" in normalized
+    assert "--dry-run=false" in normalized
+
+
+# ---------------------------------------------------------------------------
+# 2. Invalid / empty subcommand.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_invalid_subcommand_returns_one_and_prints_usage_to_stderr(capsys) -> None:
+    exit_code = run_sources(["bogus"])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Usage: searchat sources" in captured.err
+    assert captured.out == ""
+
+
+@pytest.mark.unit
+def test_empty_argv_returns_one_and_prints_usage_to_stderr(capsys) -> None:
+    exit_code = run_sources([])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Usage: searchat sources" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# 3. No indexed files at all (no DuckDB file yet): real Config/PathResolver
+#    path, isolated from the real user's ~/.searchat.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_prune_json_with_no_db_file_prints_empty_array(temp_search_dir: Path, capsys) -> None:
+    # `temp_search_dir` pre-creates an empty `.searchat/{data,config,backups}`
+    # structure under `tmp_path`, and the autouse `_isolate_searchat_data_dir`
+    # fixture (same tmp_path) already points SEARCHAT_DATA_DIR at it -- no
+    # DuckDB file exists there, so `run_lifecycle_action` sees a missing db
+    # and returns an empty decision list without ever touching the real
+    # user's home directory.
+    assert not (temp_search_dir / "data" / "searchat.duckdb").exists()
+
+    exit_code = run_sources(["prune", "--json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "[]"
+    assert json.loads(captured.out) == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Real end-to-end prune: default dry run first (eligible, no action, file
+#    untouched), then --dry-run=false against the SAME fixture (file gone,
+#    tombstone written).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_prune_dry_run_then_real_prune_full_cli_roundtrip(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("SEARCHAT_LIFECYCLE_ENABLED_AGENTS", "claude")
+    _ensure_claude_connector_registered()
+
+    source_file = _write_claude_jsonl(tmp_path / "conv-cli-prune.jsonl", num_exchanges=2)
+    connector = ClaudeConnector()
+    real_hash = _sha256(source_file)
+    real_message_count = connector.parse(source_file, embedding_id=0).message_count
+    conversation_id = source_file.stem
+
+    db_path = _resolve_db_path()
+    _new_db_at(db_path)
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=conversation_id,
+        file_hash=real_hash,
+    )
+    _insert_conversation(
+        db_path,
+        conversation_id=conversation_id,
+        file_path=str(source_file),
+        message_count=real_message_count,
+    )
+
+    # Back-date well past the (default) 60-day age threshold so this is the
+    # strongest possible dry-run candidate: it passes every gate up to the
+    # dry-run check, not one that was refused earlier for an unrelated
+    # reason.
+    old_mtime = (datetime.now() - timedelta(days=70)).timestamp()
+    os.utime(source_file, (old_mtime, old_mtime))
+    original_bytes = source_file.read_bytes()
+
+    # --- (a) default dry run: eligible, no action, zero writes ---
+    exit_code = run_sources(["prune", "--json"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    decisions = json.loads(captured.out)
+    assert len(decisions) == 1
+    assert decisions[0]["eligible"] is True
+    assert decisions[0]["action_taken"] is None
+
+    assert source_file.exists()
+    assert source_file.read_bytes() == original_bytes
+
+    # --- (b) --dry-run=false against the same fixture: real prune ---
+    exit_code = run_sources(["prune", "--dry-run=false", "--json"])
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    decisions = json.loads(captured.out)
+    assert len(decisions) == 1
+    decision = decisions[0]
+    assert decision["eligible"] is True
+    assert decision["action_taken"] == "prune"
+    assert decision["tombstone_path"] is not None
+
+    assert not source_file.exists()
+
+    tombstone_path = Path(decision["tombstone_path"])
+    assert tombstone_path.exists()
+    lines = tombstone_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["action"] == "prune"
+    assert entry["conversation_id"] == conversation_id
+
+
+# ---------------------------------------------------------------------------
+# 5. Real end-to-end archive: --dry-run=false, non-JSON rich console output.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_archive_dry_run_false_full_cli_roundtrip_rich_output(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setenv("SEARCHAT_LIFECYCLE_ENABLED_AGENTS", "claude")
+    _ensure_claude_connector_registered()
+
+    source_file = _write_claude_jsonl(tmp_path / "conv-cli-archive.jsonl", num_exchanges=2)
+    connector = ClaudeConnector()
+    real_hash = _sha256(source_file)
+    real_message_count = connector.parse(source_file, embedding_id=0).message_count
+    conversation_id = source_file.stem
+
+    db_path = _resolve_db_path()
+    _new_db_at(db_path)
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=conversation_id,
+        file_hash=real_hash,
+    )
+    _insert_conversation(
+        db_path,
+        conversation_id=conversation_id,
+        file_path=str(source_file),
+        message_count=real_message_count,
+    )
+
+    old_mtime = (datetime.now() - timedelta(days=70)).timestamp()
+    os.utime(source_file, (old_mtime, old_mtime))
+
+    exit_code = run_sources(["archive", "--dry-run=false"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "archived" in captured.out
+
+    assert not source_file.exists()
+    archived_path = source_file.with_name(source_file.name + ".zst")
+    assert archived_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# 6. Bad --dry-run value: argparse's own validation rejects it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_invalid_dry_run_value_exits_non_zero_via_argparse_validation(capsys) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        run_sources(["prune", "--dry-run=maybe"])
+
+    assert exc_info.value.code != 0
+    captured = capsys.readouterr()
+    assert "--dry-run" in captured.err


### PR DESCRIPTION
## Stack

Stack-Id: `m8-archive-then-prune`
Base: `feat/source-lifecycle-policy-gates` (#112)
Position: 6/6 (leaf)

1. `feat/source-lifecycle-verify-ingested` -> #108
2. `feat/source-lifecycle-export-roundtrip` -> #109
3. `feat/source-lifecycle-archive` -> #110
4. `feat/source-lifecycle-prune-tombstone` -> #111
5. `feat/source-lifecycle-policy-gates` -> #112
6. `feat/source-lifecycle-cli` -> this PR

Depends on: #112
Upstack: none (leaf)

## Summary

M8, PR 6 of 6 — the closing PR. Ships the user-facing CLI and the milestone's final safety-property proofs.

**⚠️ This feature deletes user data when enabled.** `searchat sources prune --dry-run=false` permanently deletes source conversation files (and `searchat sources archive --dry-run=false` replaces them in place with a `.zst`). Recovery after a real prune is only possible via the append-only tombstone log at `~/.searchat/tombstones/tombstones.jsonl` plus each connector's `export_original` re-serialization — there is no other undo path.

- `cli/sources_cmd.py` — new `searchat sources archive|prune` subcommand group. **Both default to `--dry-run=true`** regardless of the `lifecycle.dry_run` config value; a real mutation requires the explicit literal `--dry-run=false` flag on the command line, with no other way to enable it.
- `tests/unit/test_cli_sources.py` — end-to-end CLI tests (help text, invalid subcommand/argv, empty-store JSON, a full dry-run-then-real-prune round trip against a real fixture, a real archive round trip, and argparse's own `--dry-run` value validation).
- `tests/unit/services/test_source_lifecycle.py` — an exhaustive property test parametrized over the **full `2**5 = 32`-point boolean state space** (`agent_enabled` x `age_gated` x `ingested.ok` x `roundtrip.ok` x `dry_run`), proving against the real, unmocked gate chain that `decision.action_taken is not None` **if and only if** every gate passed and `dry_run` is `False`. The `roundtrip.ok` axis is driven by `ContinueConnector`'s real, documented `workspaceDirectory` → `project_id` one-way-hash limitation (not a mock).

## Verification

```
uv run pytest tests/unit/services/test_source_lifecycle.py tests/unit/test_cli_sources.py -v --tb=short --no-cov
```

69/69 passed.

```
uv run pytest -v --tb=short
```

Full suite: 2334 passed, 1 skipped, 83.13% coverage (80% gate).

## Stack-wide review checklist

- **Verification-before-action gate cannot be bypassed by any code path**: confirmed by this PR's 32-case exhaustive property test against the real `evaluate_and_act_on_source` — every combination where `ingested.ok` or `roundtrip.ok` is `False`, or `dry_run` is `True`, or the connector isn't in `enabled_agents`, or the file is too young, produces `action_taken is None`. `archive_source`/`prune_source` are only ever called from the single gate chain in `evaluate_and_act_on_source`; nothing else in the stack calls them.
- **`dry_run=true` is the shipped default**: `settings.default.toml`'s `[lifecycle]` section (`dry_run = true`, `enabled_agents = []`), `LifecycleConfig`'s dataclass default resolution, and this PR's CLI both independently default to dry-run — the CLI's default is hardcoded and does not even delegate to the config's `dry_run` value, so a misconfigured `lifecycle.dry_run = false` in a user's `settings.toml` still cannot make the CLI mutate without the explicit flag.
- **Tombstone log location for recovery**: `~/.searchat/tombstones/tombstones.jsonl` (append-only JSONL, one line per archive/prune action, recording path, checksum, connector, Parquet `conversation_id`/`message_count` provenance, and timestamp).


## Post-review fix (rebased onto amended PR-5)

An independent stack review found zero blocking issues (the verification-before-action gate and the dry-run zero-write guarantee both hold as structural invariants, corroborated by the exhaustive 32-case property test and the write-blocking monkeypatch test in this PR). Two non-blocking concerns were fixed upstream in PR-5 (tombstone-before-action reordering; `LifecycleConfig.dry_run` docstring clarified as intentionally CLI-inert) and this branch was rebased on top — no changes were needed in this PR's own files.
