### PR TITLE
feat(services): M9 distillation selection and invocation

### DIFF
--- a/src/searchat/palace/__init__.py
+++ b/src/searchat/palace/__init__.py
@@ -1,16 +1,29 @@
-"""Memory palace distillation system for conversation memory."""
+"""Memory palace distillation system for conversation memory.
+
+Lazily re-exports its submodules' public symbols via module `__getattr__`
+(PEP 562) instead of importing them eagerly. `distiller.py` and
+`faiss_index.py` need the `palace` extra's `faiss-cpu`; `bm25_index.py`
+(via `query.py`) needs `rank-bm25`. Importing this package -- or any of
+its submodules that do NOT themselves need those (`storage.py`, `llm.py`)
+-- must not require either dependency to be installed; only actually
+touching a symbol that needs one does.
+"""
 from __future__ import annotations
 
-from searchat.palace.llm import (
-    CLIDistillationLLM,
-    DistillationInput,
-    DistillationLLM,
-    DistillationOutput,
-)
-from searchat.palace.storage import PalaceStorage
-from searchat.palace.faiss_index import DistilledFaissIndex
-from searchat.palace.distiller import Distiller
-from searchat.palace.query import PalaceQuery
+import importlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from searchat.palace.distiller import Distiller
+    from searchat.palace.faiss_index import DistilledFaissIndex
+    from searchat.palace.llm import (
+        CLIDistillationLLM,
+        DistillationInput,
+        DistillationLLM,
+        DistillationOutput,
+    )
+    from searchat.palace.query import PalaceQuery
+    from searchat.palace.storage import PalaceStorage
 
 __all__ = [
     "DistillationLLM",
@@ -22,3 +35,27 @@ __all__ = [
     "Distiller",
     "PalaceQuery",
 ]
+
+_ATTR_MODULES = {
+    "DistillationLLM": "searchat.palace.llm",
+    "CLIDistillationLLM": "searchat.palace.llm",
+    "DistillationInput": "searchat.palace.llm",
+    "DistillationOutput": "searchat.palace.llm",
+    "PalaceStorage": "searchat.palace.storage",
+    "DistilledFaissIndex": "searchat.palace.faiss_index",
+    "Distiller": "searchat.palace.distiller",
+    "PalaceQuery": "searchat.palace.query",
+}
+
+
+def __getattr__(name: str) -> object:
+    module_name = _ATTR_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/src/searchat/services/distillation_bridge.py
+++ b/src/searchat/services/distillation_bridge.py
@@ -1,0 +1,60 @@
+"""Tiered memory: distill-old, keep-hot (M9).
+
+The missing integration seam (enhancement-analysis Gap 2) between
+``storage/unified_storage.py`` -- the v2 unified store's ``conversations``/
+``messages`` source-of-truth tables plus its derived ``exchanges``/
+``verbatim_embeddings`` hot FTS/HNSW index -- and ``palace/distiller.py``'s
+``Distiller``, which today runs against its own separate ``PalaceStorage``
+(``palace.duckdb``) + FAISS index and has never read from or written back
+to ``UnifiedStorage``.
+
+This PR lands the first step of the per-conversation pipeline:
+
+1. ``select_distillation_candidates`` -- conversations older than a
+   configurable age threshold that still have at least one hot exchange
+   row. Palace-independent: reads only ``UnifiedStorage``, no faiss/
+   rank-bm25 import. Already-distilled-and-evicted conversations drop out
+   of candidacy on their own (no exchange rows left), so this is
+   naturally idempotent across repeated runs.
+
+Distillate generation (``generate_distillate``), hot-index eviction
+(``evict_hot_rows``), the promotion path (``rehydrate_verbatim``), and the
+``run_tiering_cycle`` orchestrator land in later commits/PRs of this stack.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from searchat.storage.unified_storage import UnifiedStorage
+
+# ---------------------------------------------------------------------------
+# 1. Candidate selection (palace-independent)
+# ---------------------------------------------------------------------------
+
+
+def select_distillation_candidates(
+    storage: UnifiedStorage,
+    *,
+    age_threshold_days: int,
+    now: datetime | None = None,
+) -> list[str]:
+    """Conversation ids eligible for distillation: `updated_at` older than
+    `age_threshold_days` AND still present in the hot index (at least one
+    `exchanges` row). Already-evicted conversations are structurally
+    excluded -- they have zero exchange rows -- making repeated calls
+    naturally idempotent without consulting palace state at all.
+    """
+    now = now or datetime.now()
+    cutoff = now - timedelta(days=age_threshold_days)
+    cur = storage.connection.cursor()
+    try:
+        rows = cur.execute(
+            "SELECT DISTINCT c.conversation_id FROM conversations c "
+            "JOIN exchanges e ON e.conversation_id = c.conversation_id "
+            "WHERE c.updated_at < ? "
+            "ORDER BY c.conversation_id",
+            [cutoff],
+        ).fetchall()
+        return [row[0] for row in rows]
+    finally:
+        cur.close()

--- a/src/searchat/services/distillation_bridge.py
+++ b/src/searchat/services/distillation_bridge.py
@@ -8,7 +8,7 @@ The missing integration seam (enhancement-analysis Gap 2) between
 (``palace.duckdb``) + FAISS index and has never read from or written back
 to ``UnifiedStorage``.
 
-This PR lands the first step of the per-conversation pipeline:
+This PR lands the first two steps of the per-conversation pipeline:
 
 1. ``select_distillation_candidates`` -- conversations older than a
    configurable age threshold that still have at least one hot exchange
@@ -16,16 +16,113 @@ This PR lands the first step of the per-conversation pipeline:
    rank-bm25 import. Already-distilled-and-evicted conversations drop out
    of candidacy on their own (no exchange rows left), so this is
    naturally idempotent across repeated runs.
+2. ``generate_distillate`` -- invokes the palace ``Distiller`` for one
+   conversation via ``_UnifiedStorageDuckStore``, an adapter translating
+   ``UnifiedStorage``'s actual read methods into the
+   ``get_conversation``/``get_conversation_messages`` shape
+   ``Distiller._read_conversation`` expects.
 
-Distillate generation (``generate_distillate``), hot-index eviction
-(``evict_hot_rows``), the promotion path (``rehydrate_verbatim``), and the
-``run_tiering_cycle`` orchestrator land in later commits/PRs of this stack.
+Hot-index eviction (``evict_hot_rows``), the promotion path
+(``rehydrate_verbatim``), and the ``run_tiering_cycle`` orchestrator land
+in later commits/PRs of this stack.
+
+Graceful degradation: importing this module never touches the `palace`
+extra (faiss-cpu, rank-bm25). ``select_distillation_candidates`` needs
+only DuckDB and never raises for a missing extra. Only
+``generate_distillate`` needs palace, and raises ``PalaceUnavailableError``
+-- never a bare ``ImportError`` -- when it is not installed.
 """
 from __future__ import annotations
 
+import importlib.util
+import sys
+from dataclasses import dataclass
 from datetime import datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
 
+from searchat.config.settings import Config
 from searchat.storage.unified_storage import UnifiedStorage
+
+if TYPE_CHECKING:
+    from searchat.palace.distiller import Distiller
+    from searchat.palace.llm import DistillationLLM
+    from searchat.palace.storage import PalaceStorage
+
+
+class PalaceUnavailableError(RuntimeError):
+    """Raised when a distillation-bridge operation needs the `palace`
+    extra (faiss-cpu, rank-bm25) but it is not installed.
+
+    Callers should treat this as "feature disabled", not a crash:
+    candidate selection never raises it (it needs only DuckDB). Only
+    distillate generation does.
+    """
+
+
+def _importable(module_name: str) -> bool:
+    """True if `module_name` can be imported, without actually importing
+    it. Checks `sys.modules` first: a module already present there (even
+    a test double substituted via `sys.modules[name] = ...`) is treated as
+    importable without touching `importlib.util.find_spec`, which raises
+    `ValueError` for a `unittest.mock.MagicMock` standing in for a module
+    (its `__spec__` dunder is unset, unlike a real module's).
+    """
+    if module_name in sys.modules:
+        return sys.modules[module_name] is not None
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def palace_available() -> bool:
+    """True if the runtime dependency distillate generation actually needs
+    (`faiss`, via `palace.distiller.Distiller`'s FAISS index) is importable.
+
+    Deliberately narrower than "the whole `palace` extra": `rank-bm25` is
+    only used by `palace.query.PalaceQuery`'s keyword search (a different
+    code path in `core/unified_search.py`, unrelated to this bridge), so
+    its absence must not block distillation/eviction/rehydration -- doing
+    so would over-degrade a feature that doesn't actually need it. Cheap
+    existence check -- does not actually import `faiss`.
+    """
+    return _importable("faiss")
+
+
+def _import_palace() -> tuple[type["Distiller"], type["PalaceStorage"]]:
+    """Import `Distiller` + `PalaceStorage`, raising `PalaceUnavailableError`
+    -- not a bare `ImportError` that would propagate out of an unrelated
+    call site -- when the `palace` extra isn't installed."""
+    try:
+        from searchat.palace.distiller import Distiller
+        from searchat.palace.storage import PalaceStorage
+    except ImportError as exc:
+        raise PalaceUnavailableError(
+            "distillation requires the 'palace' extra (faiss-cpu, rank-bm25): "
+            "install with `uv sync --extra palace`"
+        ) from exc
+    return Distiller, PalaceStorage
+
+
+class _UnifiedStorageDuckStore:
+    """Adapts `UnifiedStorage` to the duck-typed `get_conversation` /
+    `get_conversation_messages` store `Distiller._read_conversation`
+    expects -- the missing read-side half of the integration seam (Gap 2):
+    the two storages' method names never matched, so `Distiller` could
+    never actually read a v2-indexed conversation before this adapter.
+    """
+
+    def __init__(self, storage: UnifiedStorage) -> None:
+        self._storage = storage
+
+    def get_conversation(self, conversation_id: str) -> dict | None:
+        return self._storage.get_conversation_meta(conversation_id)
+
+    def get_conversation_messages(self, conversation_id: str) -> list[dict]:
+        record = self._storage.get_conversation_record(conversation_id)
+        return list(record["messages"]) if record else []
+
 
 # ---------------------------------------------------------------------------
 # 1. Candidate selection (palace-independent)
@@ -58,3 +155,75 @@ def select_distillation_candidates(
         return [row[0] for row in rows]
     finally:
         cur.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. Distillate generation (needs the palace extra)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DistillateResult:
+    """Outcome of `generate_distillate` for one conversation."""
+
+    conversation_id: str
+    objects_created: int
+    has_distillate: bool
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "conversation_id": self.conversation_id,
+            "objects_created": self.objects_created,
+            "has_distillate": self.has_distillate,
+        }
+
+
+def generate_distillate(
+    storage: UnifiedStorage,
+    *,
+    conversation_id: str,
+    config: Config,
+    llm: "DistillationLLM",
+    search_dir: Path,
+    embedder: object | None = None,
+    palace_storage: "PalaceStorage | None" = None,
+) -> DistillateResult:
+    """Invoke the palace `Distiller` for one conversation, reading it
+    through `_UnifiedStorageDuckStore` and persisting the distillate to
+    `palace_storage` (or a freshly opened one under `search_dir/data` when
+    not supplied). Raises `PalaceUnavailableError` if the `palace` extra
+    is not installed.
+
+    `has_distillate` is true whenever `conversation_id` has ANY persisted
+    distillate object afterward -- including one from a prior call --
+    distinguishing "nothing new to distill because it's already fully
+    distilled" from "nothing distilled because every exchange was too
+    short" (`Distiller` marks the latter `no_valid_exchanges` and creates
+    no objects at all). Callers must not evict on `has_distillate=False`:
+    that conversation has no distillate to fall back on.
+    """
+    Distiller, PalaceStorageCls = _import_palace()
+
+    owns_storage = palace_storage is None
+    resolved_storage: "PalaceStorage" = (
+        palace_storage if palace_storage is not None else PalaceStorageCls(search_dir / "data")
+    )
+    distiller = Distiller(
+        search_dir=search_dir,
+        config=config,
+        llm=llm,
+        duckdb_store=_UnifiedStorageDuckStore(storage),
+        embedder=embedder,
+        palace_storage=resolved_storage,
+    )
+    try:
+        objects = distiller.distill_conversation(conversation_id)
+        has_distillate = conversation_id in resolved_storage.get_distilled_conversation_ids()
+        return DistillateResult(
+            conversation_id=conversation_id,
+            objects_created=len(objects),
+            has_distillate=has_distillate,
+        )
+    finally:
+        if owns_storage:
+            resolved_storage.close()

--- a/tests/unit/palace/test_bm25_index.py
+++ b/tests/unit/palace/test_bm25_index.py
@@ -7,6 +7,10 @@ from unittest.mock import MagicMock
 import duckdb
 import pytest
 
+pytest.importorskip(
+    "rank_bm25", reason="PalaceBM25Index needs the 'palace' extra (rank-bm25)"
+)
+
 from searchat.models.domain import DistilledObject, FileTouched, Room
 from searchat.palace.bm25_index import PalaceBM25Index
 from searchat.palace.storage import PalaceStorage

--- a/tests/unit/palace/test_distiller.py
+++ b/tests/unit/palace/test_distiller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import pytest
 
 from searchat.palace.distiller import extract_file_paths, make_room_id, Distiller
+from searchat.palace.llm import DistillationLLM, DistillationOutput
 from searchat.config import Config
 
 
@@ -135,3 +136,109 @@ class TestSegmentExchanges:
         exchanges = distiller._segment_exchanges(messages)
         # Should be split into chunks of max_ply_length
         assert all(end - start + 1 <= config.distillation.max_ply_length for start, end in exchanges)
+
+
+# ---------------------------------------------------------------------------
+# M9 bridge integration: _UnifiedStorageDuckStore adapter (Gap 2)
+# ---------------------------------------------------------------------------
+
+
+class TestUnifiedStorageDuckStoreAdapter:
+    """`services.distillation_bridge._UnifiedStorageDuckStore` is the
+    missing read-side integration seam between `UnifiedStorage` (v2
+    unified store) and `Distiller._read_conversation`, which expects a
+    `get_conversation`/`get_conversation_messages` duck-typed store.
+    Verifies the adapter satisfies that contract end to end -- including
+    through `Distiller.distill_conversation` itself -- against a real
+    `UnifiedStorage`, and that the resulting distillate carries the
+    schema fields the bridge's eviction/search-surfacing rely on.
+    """
+
+    def _build_storage(self, tmp_path):
+        from searchat.storage.unified_storage import UnifiedStorage
+
+        return UnifiedStorage(tmp_path / "unified.duckdb")
+
+    def test_adapter_exposes_conversation_meta_and_messages(self, tmp_path):
+        from datetime import datetime
+
+        from searchat.services.distillation_bridge import _UnifiedStorageDuckStore
+
+        storage = self._build_storage(tmp_path)
+        try:
+            now = datetime(2025, 1, 1)
+            storage.upsert_conversation(
+                conversation_id="conv-1", project_id="proj-1", file_path="/f",
+                title="t", created_at=now, updated_at=now, message_count=2,
+                full_text="x", file_hash="h", indexed_at=now,
+            )
+            storage.insert_messages("conv-1", [
+                {"sequence": 0, "role": "user", "content": "hi", "timestamp": now, "has_code": False, "code_blocks": None},
+                {"sequence": 1, "role": "assistant", "content": "hello", "timestamp": now, "has_code": False, "code_blocks": None},
+            ])
+
+            adapter = _UnifiedStorageDuckStore(storage)
+            conv = adapter.get_conversation("conv-1")
+            assert conv is not None
+            assert conv["conversation_id"] == "conv-1"
+            assert conv["project_id"] == "proj-1"
+
+            messages = adapter.get_conversation_messages("conv-1")
+            assert [m["role"] for m in messages] == ["user", "assistant"]
+
+            assert adapter.get_conversation("missing") is None
+            assert adapter.get_conversation_messages("missing") == []
+        finally:
+            storage.close()
+
+    def test_distiller_reads_a_v2_conversation_through_the_adapter(self, tmp_path, config):
+        from datetime import datetime
+
+        from searchat.services.distillation_bridge import _UnifiedStorageDuckStore
+
+        storage = self._build_storage(tmp_path)
+        try:
+            now = datetime(2025, 1, 1)
+            storage.upsert_conversation(
+                conversation_id="conv-1", project_id="proj-1", file_path="/f",
+                title="t", created_at=now, updated_at=now, message_count=2,
+                full_text="x", file_hash="h", indexed_at=now,
+            )
+            storage.insert_messages("conv-1", [
+                {"sequence": 0, "role": "user", "content": "How do I configure the retry policy?", "timestamp": now, "has_code": False, "code_blocks": None},
+                {"sequence": 1, "role": "assistant", "content": "Set retry.max_attempts in settings.toml and restart the service.", "timestamp": now, "has_code": False, "code_blocks": None},
+            ])
+
+            class _FakeLLM(DistillationLLM):
+                def distill(self, inputs):
+                    return [
+                        DistillationOutput(
+                            exchange_core="Configured retry policy via settings.toml",
+                            specific_context="retry.max_attempts",
+                            room_assignments=[],
+                        )
+                        for _ in inputs
+                    ]
+
+            distiller = Distiller(
+                search_dir=tmp_path,
+                config=config,
+                llm=_FakeLLM(),
+                duckdb_store=_UnifiedStorageDuckStore(storage),
+            )
+            try:
+                objects = distiller.distill_conversation("conv-1")
+            finally:
+                distiller.close()
+
+            assert len(objects) == 1
+            obj = objects[0]
+            # Distillate schema the bridge's eviction/search-surfacing rely on.
+            assert obj.conversation_id == "conv-1"
+            assert obj.project_id == "proj-1"
+            assert obj.exchange_core == "Configured retry policy via settings.toml"
+            assert obj.specific_context == "retry.max_attempts"
+            assert obj.distilled_text.startswith("Configured retry policy")
+            assert isinstance(obj.embedding_id, int)
+        finally:
+            storage.close()

--- a/tests/unit/services/test_distillation_bridge.py
+++ b/tests/unit/services/test_distillation_bridge.py
@@ -5,13 +5,16 @@ Coverage map:
   palace-independent.
 - `TestGenerateDistillate` -- distillate generation via the palace
   `Distiller`, adapted onto `UnifiedStorage`.
+- `TestGracefulDegradation` -- the `palace` extra (faiss-cpu) missing
+  degrades to a disabled feature, never a crash.
 
 Later commits/PRs in this stack add hot-index eviction, the promotion
-path, the end-to-end orchestrator, graceful-degradation-specific tests,
-and the fixture-benchmark acceptance tests.
+path, the end-to-end orchestrator, and the fixture-benchmark acceptance
+tests.
 """
 from __future__ import annotations
 
+import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -266,3 +269,29 @@ class TestGenerateDistillate:
             assert second.has_distillate is True
         finally:
             palace_storage.close()
+
+
+
+# ---------------------------------------------------------------------------
+# 3. Graceful degradation
+# ---------------------------------------------------------------------------
+
+
+class TestGracefulDegradation:
+    def test_palace_available_reflects_importability(self):
+        # Whatever the real environment, this must not raise.
+        assert isinstance(distillation_bridge.palace_available(), bool)
+
+    def test_generate_distillate_raises_palace_unavailable_not_import_error(
+        self, monkeypatch, storage: UnifiedStorage, config: Config, tmp_path: Path
+    ):
+        monkeypatch.setitem(sys.modules, "searchat.palace.distiller", None)
+
+        with pytest.raises(distillation_bridge.PalaceUnavailableError):
+            distillation_bridge.generate_distillate(
+                storage,
+                conversation_id="conv-1",
+                config=config,
+                llm=_FakeDistillationLLM(),
+                search_dir=tmp_path,
+            )

--- a/tests/unit/services/test_distillation_bridge.py
+++ b/tests/unit/services/test_distillation_bridge.py
@@ -3,21 +3,26 @@
 Coverage map:
 - `TestSelectDistillationCandidates` -- age-based candidate selection,
   palace-independent.
+- `TestGenerateDistillate` -- distillate generation via the palace
+  `Distiller`, adapted onto `UnifiedStorage`.
 
-Later commits/PRs in this stack add distillate generation, hot-index
-eviction, the promotion path, the end-to-end orchestrator, and the
-fixture-benchmark acceptance tests.
+Later commits/PRs in this stack add hot-index eviction, the promotion
+path, the end-to-end orchestrator, graceful-degradation-specific tests,
+and the fixture-benchmark acceptance tests.
 """
 from __future__ import annotations
 
 from datetime import datetime, timedelta
 from pathlib import Path
 
+import pytest
+
+from searchat.config import Config
 from searchat.core.unified_indexer import _segment_exchanges
+from searchat.palace.llm import DistillationLLM, DistillationOutput
+from searchat.palace.storage import PalaceStorage
 from searchat.services import distillation_bridge
 from searchat.storage.unified_storage import UnifiedStorage
-
-import pytest
 
 # ---------------------------------------------------------------------------
 # Shared fixtures / helpers
@@ -29,6 +34,11 @@ def storage(tmp_path: Path):
     s = UnifiedStorage(tmp_path / "unified.duckdb")
     yield s
     s.close()
+
+
+@pytest.fixture()
+def config() -> Config:
+    return Config.load()
 
 
 def _insert_conversation(
@@ -93,6 +103,35 @@ def _seed_hot_exchanges(storage: UnifiedStorage, conversation_id: str, project_i
     return exchanges
 
 
+class _FakeDistillationLLM(DistillationLLM):
+    """Deterministic stand-in: never shells out, one output per input."""
+
+    def distill(self, inputs):
+        return [
+            DistillationOutput(
+                exchange_core=f"core:{i.conversation_id}:{i.ply_start}-{i.ply_end}",
+                specific_context="ctx",
+                room_assignments=[],
+            )
+            for i in inputs
+        ]
+
+
+class _NoValidExchangesLLM(DistillationLLM):
+    """Never actually invoked when there are no valid exchanges to distill,
+    but must exist to satisfy the `Distiller` constructor's type."""
+
+    def distill(self, inputs):
+        raise AssertionError("distill() should not be called with zero valid exchanges")
+
+
+class _FixedEmbedder:
+    def encode(self, texts, batch_size=32):
+        import numpy as np
+
+        return np.array([[0.2] * 384 for _ in texts], dtype=np.float32)
+
+
 # ---------------------------------------------------------------------------
 # 1. Candidate selection
 # ---------------------------------------------------------------------------
@@ -146,3 +185,84 @@ class TestSelectDistillationCandidates:
             storage, age_threshold_days=30, now=now,
         )
         assert candidates == ["a-conv", "b-conv"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Distillate generation
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateDistillate:
+    def test_generates_and_persists_a_distillate(self, storage: UnifiedStorage, config: Config, tmp_path: Path):
+        messages = _make_messages(2)
+        _insert_conversation(storage, conversation_id="conv-1", project_id="proj-x", updated_at=datetime(2025, 1, 1), messages=messages)
+
+        palace_storage = PalaceStorage(tmp_path / "data")
+        try:
+            result = distillation_bridge.generate_distillate(
+                storage,
+                conversation_id="conv-1",
+                config=config,
+                llm=_FakeDistillationLLM(),
+                search_dir=tmp_path,
+                embedder=_FixedEmbedder(),
+                palace_storage=palace_storage,
+            )
+
+            assert result.conversation_id == "conv-1"
+            assert result.objects_created == 2
+            assert result.has_distillate is True
+
+            objects = palace_storage.get_all_objects(project_id="proj-x")
+            assert {o.conversation_id for o in objects} == {"conv-1"}
+            assert all(o.distilled_text.startswith("core:conv-1:") for o in objects)
+        finally:
+            palace_storage.close()
+
+    def test_no_valid_exchanges_yields_no_distillate(self, storage: UnifiedStorage, config: Config, tmp_path: Path):
+        """Messages too short to clear Distiller's own min_exchange_chars
+        filter -- `has_distillate` must be False so callers know not to
+        evict (nothing to fall back on)."""
+        tiny_messages = [
+            {"sequence": 0, "role": "user", "content": "hi", "timestamp": datetime(2025, 1, 1), "has_code": False, "code_blocks": None},
+            {"sequence": 1, "role": "assistant", "content": "hey", "timestamp": datetime(2025, 1, 1), "has_code": False, "code_blocks": None},
+        ]
+        _insert_conversation(storage, conversation_id="tiny", updated_at=datetime(2025, 1, 1), messages=tiny_messages)
+
+        palace_storage = PalaceStorage(tmp_path / "data")
+        try:
+            result = distillation_bridge.generate_distillate(
+                storage,
+                conversation_id="tiny",
+                config=config,
+                llm=_NoValidExchangesLLM(),
+                search_dir=tmp_path,
+                embedder=_FixedEmbedder(),
+                palace_storage=palace_storage,
+            )
+            assert result.objects_created == 0
+            assert result.has_distillate is False
+        finally:
+            palace_storage.close()
+
+    def test_idempotent_second_call_reports_has_distillate_without_new_objects(
+        self, storage: UnifiedStorage, config: Config, tmp_path: Path
+    ):
+        messages = _make_messages(1)
+        _insert_conversation(storage, conversation_id="conv-1", updated_at=datetime(2025, 1, 1), messages=messages)
+
+        palace_storage = PalaceStorage(tmp_path / "data")
+        try:
+            first = distillation_bridge.generate_distillate(
+                storage, conversation_id="conv-1", config=config, llm=_FakeDistillationLLM(),
+                search_dir=tmp_path, embedder=_FixedEmbedder(), palace_storage=palace_storage,
+            )
+            second = distillation_bridge.generate_distillate(
+                storage, conversation_id="conv-1", config=config, llm=_FakeDistillationLLM(),
+                search_dir=tmp_path, embedder=_FixedEmbedder(), palace_storage=palace_storage,
+            )
+            assert first.objects_created == 1
+            assert second.objects_created == 0
+            assert second.has_distillate is True
+        finally:
+            palace_storage.close()

--- a/tests/unit/services/test_distillation_bridge.py
+++ b/tests/unit/services/test_distillation_bridge.py
@@ -1,0 +1,148 @@
+"""Unit tests for `searchat.services.distillation_bridge` (M9).
+
+Coverage map:
+- `TestSelectDistillationCandidates` -- age-based candidate selection,
+  palace-independent.
+
+Later commits/PRs in this stack add distillate generation, hot-index
+eviction, the promotion path, the end-to-end orchestrator, and the
+fixture-benchmark acceptance tests.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from searchat.core.unified_indexer import _segment_exchanges
+from searchat.services import distillation_bridge
+from searchat.storage.unified_storage import UnifiedStorage
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def storage(tmp_path: Path):
+    s = UnifiedStorage(tmp_path / "unified.duckdb")
+    yield s
+    s.close()
+
+
+def _insert_conversation(
+    storage: UnifiedStorage,
+    *,
+    conversation_id: str,
+    project_id: str = "proj-1",
+    updated_at: datetime,
+    messages: list[dict],
+) -> None:
+    storage.upsert_conversation(
+        conversation_id=conversation_id,
+        project_id=project_id,
+        file_path=f"/data/{conversation_id}.jsonl",
+        title=conversation_id,
+        created_at=updated_at,
+        updated_at=updated_at,
+        message_count=len(messages),
+        full_text=" ".join(m["content"] for m in messages),
+        file_hash="hash",
+        indexed_at=updated_at,
+    )
+    storage.insert_messages(conversation_id, messages)
+
+
+def _make_messages(num_exchanges: int, *, min_len: int = 60) -> list[dict]:
+    """Real user/assistant message pairs, long enough to clear
+    `Distiller`'s own `min_exchange_chars` filter (default 50)."""
+    messages: list[dict] = []
+    seq = 0
+    base = datetime(2025, 1, 1)
+    for i in range(num_exchanges):
+        messages.append({
+            "sequence": seq,
+            "role": "user",
+            "content": f"Question {i}: what should I do about issue number {i}?",
+            "timestamp": base,
+            "has_code": False,
+            "code_blocks": None,
+        })
+        seq += 1
+        filler = "x" * max(0, min_len - 20)
+        messages.append({
+            "sequence": seq,
+            "role": "assistant",
+            "content": f"Answer {i}: do this instead. {filler}",
+            "timestamp": base,
+            "has_code": False,
+            "code_blocks": None,
+        })
+        seq += 1
+    return messages
+
+
+def _seed_hot_exchanges(storage: UnifiedStorage, conversation_id: str, project_id: str, messages: list[dict]) -> list[dict]:
+    """Populate `exchanges`/`verbatim_embeddings` the way indexing would,
+    using the real M2 segmentation function (`_segment_exchanges`)."""
+    exchanges = _segment_exchanges(conversation_id, project_id, messages, messages[0]["timestamp"])
+    for exc in exchanges:
+        storage.upsert_exchange(**exc)
+        storage.upsert_embedding(exc["exchange_id"], [0.1] * 384)
+    return exchanges
+
+
+# ---------------------------------------------------------------------------
+# 1. Candidate selection
+# ---------------------------------------------------------------------------
+
+
+class TestSelectDistillationCandidates:
+    def test_old_conversation_with_hot_exchanges_is_a_candidate(self, storage: UnifiedStorage):
+        now = datetime(2026, 1, 1)
+        messages = _make_messages(1)
+        _insert_conversation(storage, conversation_id="old", updated_at=now - timedelta(days=200), messages=messages)
+        _seed_hot_exchanges(storage, "old", "proj-1", messages)
+
+        candidates = distillation_bridge.select_distillation_candidates(
+            storage, age_threshold_days=180, now=now,
+        )
+        assert candidates == ["old"]
+
+    def test_recent_conversation_is_excluded(self, storage: UnifiedStorage):
+        now = datetime(2026, 1, 1)
+        messages = _make_messages(1)
+        _insert_conversation(storage, conversation_id="recent", updated_at=now - timedelta(days=5), messages=messages)
+        _seed_hot_exchanges(storage, "recent", "proj-1", messages)
+
+        candidates = distillation_bridge.select_distillation_candidates(
+            storage, age_threshold_days=180, now=now,
+        )
+        assert candidates == []
+
+    def test_already_evicted_conversation_is_excluded(self, storage: UnifiedStorage):
+        """No exchange rows left (already distilled+evicted) drops out of
+        candidacy on its own -- naturally idempotent, no palace state
+        consulted."""
+        now = datetime(2026, 1, 1)
+        messages = _make_messages(1)
+        _insert_conversation(storage, conversation_id="gone", updated_at=now - timedelta(days=400), messages=messages)
+        # Note: no _seed_hot_exchanges call -- simulates post-eviction state.
+
+        candidates = distillation_bridge.select_distillation_candidates(
+            storage, age_threshold_days=180, now=now,
+        )
+        assert candidates == []
+
+    def test_multiple_candidates_ordered_deterministically(self, storage: UnifiedStorage):
+        now = datetime(2026, 1, 1)
+        for conv_id in ("b-conv", "a-conv"):
+            messages = _make_messages(1)
+            _insert_conversation(storage, conversation_id=conv_id, updated_at=now - timedelta(days=365), messages=messages)
+            _seed_hot_exchanges(storage, conv_id, "proj-1", messages)
+
+        candidates = distillation_bridge.select_distillation_candidates(
+            storage, age_threshold_days=30, now=now,
+        )
+        assert candidates == ["a-conv", "b-conv"]


### PR DESCRIPTION
## Stack

Position: 1/5 (M9 Tiered memory: distill-old, keep-hot)

1. `feat/m9-distillation-selection-invocation` -> this PR
2. `feat/m9-hot-index-eviction` -> depends on this
3. `feat/m9-promotion-path` -> depends on #2
4. `feat/m9-search-layer-surfacing` -> depends on #3
5. `feat/m9-benchmark-and-recall-tests` -> depends on #4

## Summary

First slice of the M9 tiered-memory bridge: the missing integration seam
(enhancement-analysis Gap 2) between `storage/unified_storage.py` (v2
unified store) and `palace/distiller.py`'s `Distiller` (a separate
FAISS-based engine on its own `PalaceStorage`, never wired to
`UnifiedStorage`).

- `services/distillation_bridge.py` (new):
  - `select_distillation_candidates` -- age-based candidate selection
    over `UnifiedStorage`'s `conversations`/`exchanges` tables.
    Palace-independent; naturally idempotent (an evicted conversation
    has zero exchange rows and drops out of candidacy on its own).
  - `generate_distillate` -- invokes the palace `Distiller` for one
    conversation via a new `_UnifiedStorageDuckStore` adapter that
    translates `UnifiedStorage`'s actual read methods
    (`get_conversation_meta`/`get_conversation_record`) into the
    `get_conversation`/`get_conversation_messages` shape
    `Distiller._read_conversation` expects.
  - `PalaceUnavailableError` / `palace_available()` / `_import_palace()`
    -- distillate generation needs the `palace` extra (faiss-cpu); the
    import is deferred and wrapped so a missing extra raises a clean,
    catchable error rather than a bare `ImportError`.
- `palace/__init__.py` -- converted to lazily re-export its submodules'
  symbols via module `__getattr__` (PEP 562). Previously the package
  eagerly imported `distiller.py` and `query.py` (which needs
  `rank-bm25` via `bm25_index.py`) at package-init time, so importing
  even a dependency-free submodule like `storage.py` or `llm.py`
  transitively required both `faiss-cpu` and `rank-bm25`. Necessary for
  this bridge (and its tests) to import cleanly without the `palace`
  extra installed.
- `tests/unit/palace/test_bm25_index.py` -- added an `importorskip`
  guard (its subject, `PalaceBM25Index`, genuinely needs `rank-bm25`
  directly).

## Verification

- `uv run pytest tests/unit/services/test_distillation_bridge.py tests/unit/palace/test_distiller.py -v --tb=short --no-cov` -- 36 passed.
- `uv run pytest -v --tb=short` (full suite, palace extra installed) -- 2345 passed, 1 skipped (pre-existing).
- Full suite also verified green in an isolated venv built with `uv sync --group dev --extra secure --extra legacy` (palace extra deliberately omitted) -- confirms this stack's graceful-degradation contract holds for the whole suite, not just this bridge's own tests.