### PR TITLE
test(services): M9 benchmark and recall acceptance tests

### DIFF
--- a/tests/fixtures/distillation_benchmark.py
+++ b/tests/fixtures/distillation_benchmark.py
@@ -1,0 +1,182 @@
+"""Fixture benchmark query set for M9's recall@10 and index-size-reduction
+acceptance criteria (DEVELOPMENT_PLAN.md M9, Section D).
+
+Builds a synthetic, deterministic 12-month conversation corpus with known
+topic clusters and topic-matching queries, entirely with hand-constructed
+384-dim vectors (no real embedding model, no real FAISS/ANN search): topic,
+exchange, query, and distillate embeddings are all pure functions of a
+topic name (+ deterministic noise modelling embedding drift), so recall is
+measured against ground-truth semantic structure the test controls, not an
+ML model's incidental output. Top-k retrieval is exact brute-force cosine
+similarity -- mathematically identical to `faiss.IndexFlatL2` (itself an
+exact, not approximate, index) for the corpus sizes used here.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import numpy as np
+
+EMBEDDING_DIM = 384
+
+TOPICS: tuple[str, ...] = tuple(f"topic-{i:02d}" for i in range(12))
+
+
+def _topic_vector(topic: str, *, noise: float, salt: str) -> list[float]:
+    """Deterministic unit vector for `topic`, perturbed by Gaussian noise
+    seeded from `salt` -- models embedding drift between two encodings of
+    semantically-equivalent content (e.g. verbatim text vs. an LLM
+    distillate of it) while keeping every vector reproducible run to run.
+    """
+    base_seed = int(hashlib.sha256(topic.encode()).hexdigest()[:8], 16)
+    base = np.random.default_rng(base_seed).standard_normal(EMBEDDING_DIM)
+
+    if noise:
+        noise_seed = int(hashlib.sha256(f"{topic}:{salt}".encode()).hexdigest()[:8], 16)
+        base = base + noise * np.random.default_rng(noise_seed).standard_normal(EMBEDDING_DIM)
+
+    norm = np.linalg.norm(base)
+    return (base / norm).astype(np.float32).tolist()
+
+
+@dataclass(frozen=True)
+class BenchmarkExchange:
+    conversation_id: str
+    exchange_id: str
+    sequence_start: int
+    sequence_end: int
+    text: str
+    verbatim_embedding: list[float]
+
+
+@dataclass(frozen=True)
+class BenchmarkConversation:
+    conversation_id: str
+    project_id: str
+    topic: str
+    month_index: int
+    updated_at: datetime
+    exchanges: list[BenchmarkExchange]
+
+
+@dataclass(frozen=True)
+class BenchmarkQuery:
+    query_id: str
+    topic: str
+    query_embedding: list[float]
+    relevant_conversation_ids: frozenset[str]
+
+
+def build_fixture_corpus(
+    *,
+    months: int = 12,
+    conversations_per_month: int = 2,
+    exchanges_per_conversation: int = 5,
+    base_date: datetime = datetime(2026, 7, 1),
+    verbatim_noise: float = 0.05,
+) -> list[BenchmarkConversation]:
+    """A synthetic corpus spanning `months` months of history (one topic per
+    month, oldest-first as `month_index` increases), `conversations_per_month`
+    conversations per topic, each with `exchanges_per_conversation` exchanges
+    clustered tightly around that month's topic vector.
+    """
+    conversations: list[BenchmarkConversation] = []
+    for month_index in range(months):
+        topic = TOPICS[month_index % len(TOPICS)]
+        updated_at = base_date - timedelta(days=30 * month_index)
+        for conv_index in range(conversations_per_month):
+            conversation_id = f"conv-{month_index:02d}-{conv_index}"
+            exchanges = []
+            for exc_index in range(exchanges_per_conversation):
+                exchange_id = f"{conversation_id}-exc-{exc_index}"
+                embedding = _topic_vector(
+                    topic, noise=verbatim_noise, salt=f"verbatim:{exchange_id}"
+                )
+                exchanges.append(BenchmarkExchange(
+                    conversation_id=conversation_id,
+                    exchange_id=exchange_id,
+                    sequence_start=2 * exc_index,
+                    sequence_end=2 * exc_index + 1,
+                    text=f"[{topic}] exchange {exc_index} of {conversation_id}",
+                    verbatim_embedding=embedding,
+                ))
+            conversations.append(BenchmarkConversation(
+                conversation_id=conversation_id,
+                project_id="benchmark",
+                topic=topic,
+                month_index=month_index,
+                updated_at=updated_at,
+                exchanges=exchanges,
+            ))
+    return conversations
+
+
+def build_query_set(conversations: list[BenchmarkConversation]) -> list[BenchmarkQuery]:
+    """One query per topic, embedded close to that topic's vector; ground
+    truth = every conversation sharing that topic."""
+    queries = []
+    for topic in sorted({c.topic for c in conversations}):
+        relevant = frozenset(c.conversation_id for c in conversations if c.topic == topic)
+        queries.append(BenchmarkQuery(
+            query_id=f"query-{topic}",
+            topic=topic,
+            query_embedding=_topic_vector(topic, noise=0.02, salt="query"),
+            relevant_conversation_ids=relevant,
+        ))
+    return queries
+
+
+def distillate_embedding(topic: str, conversation_id: str, *, noise: float = 0.15) -> list[float]:
+    """Deterministic distillate embedding for `conversation_id` -- larger
+    noise than `build_fixture_corpus`'s verbatim embeddings, modelling the
+    extra drift an LLM-generated summary introduces relative to verbatim
+    text of the same underlying exchange."""
+    return _topic_vector(topic, noise=noise, salt=f"distillate:{conversation_id}")
+
+
+def _cosine_topk(
+    query_embedding: list[float], candidates: list[tuple[str, list[float]]], k: int
+) -> list[str]:
+    """Exact top-k by cosine similarity -- brute force, mathematically
+    identical to `faiss.IndexFlatL2` (also exact) for these corpus sizes."""
+    query = np.asarray(query_embedding, dtype=np.float32)
+    query = query / np.linalg.norm(query)
+    scored = []
+    for item_id, vector in candidates:
+        v = np.asarray(vector, dtype=np.float32)
+        v = v / np.linalg.norm(v)
+        scored.append((item_id, float(np.dot(query, v))))
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return [item_id for item_id, _ in scored[:k]]
+
+
+def recall_at_k(
+    queries: list[BenchmarkQuery],
+    embedding_by_conversation: dict[str, list[float]],
+    *,
+    k: int = 10,
+) -> float:
+    """Mean recall@k across `queries` against a one-embedding-per-conversation
+    candidate index (`embedding_by_conversation`): for each query, recall is
+    `|top-k results intersect relevant| / min(k, |relevant|)`.
+    """
+    if not queries:
+        return 0.0
+    candidates = list(embedding_by_conversation.items())
+    scores = []
+    for query in queries:
+        top = _cosine_topk(query.query_embedding, candidates, k)
+        hits = sum(1 for conv_id in top if conv_id in query.relevant_conversation_ids)
+        denom = min(k, len(query.relevant_conversation_ids))
+        scores.append(hits / denom if denom else 0.0)
+    return sum(scores) / len(scores)
+
+
+# M9 acceptance budget (DEVELOPMENT_PLAN.md Section D, ASSUMPTION in the
+# enhancement analysis Part 5 E3.1 / §2 Gap 3): distilled-conversation
+# recall@10 must stay within 10% relative of pre-distillation verbatim
+# recall, and index size must shrink at least 5x on a 12-month corpus.
+MAX_RELATIVE_RECALL_DROP = 0.10
+MIN_INDEX_SIZE_REDUCTION_FACTOR = 5.0

--- a/tests/unit/services/test_distillation_bridge.py
+++ b/tests/unit/services/test_distillation_bridge.py
@@ -11,13 +11,13 @@ Coverage map:
   `conversations`/`messages`.
 - `TestRehydrateVerbatim` -- lossless promotion round trip.
 - `TestRunTieringCycle` -- the end-to-end orchestrator.
-
-Later commits/PRs in this stack add search-layer surfacing and the
-fixture-benchmark acceptance tests.
+- `TestBenchmarkAcceptance` -- the M9 fixture-benchmark acceptance
+  criteria: recall@10 and index-size reduction.
 """
 from __future__ import annotations
 
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -30,6 +30,15 @@ from searchat.palace.llm import DistillationLLM, DistillationOutput
 from searchat.palace.storage import PalaceStorage
 from searchat.services import distillation_bridge
 from searchat.storage.unified_storage import UnifiedStorage
+
+from tests.fixtures.distillation_benchmark import (
+    MAX_RELATIVE_RECALL_DROP,
+    MIN_INDEX_SIZE_REDUCTION_FACTOR,
+    build_fixture_corpus,
+    build_query_set,
+    distillate_embedding,
+    recall_at_k,
+)
 
 # ---------------------------------------------------------------------------
 # Shared fixtures / helpers
@@ -515,3 +524,167 @@ class TestRunTieringCycle:
         assert stats.conversations_distilled == 0
         assert stats.conversations_evicted == 0
         assert storage.get_row_counts()["exchanges"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. M9 fixture-benchmark acceptance criteria
+# ---------------------------------------------------------------------------
+
+
+class _TopicAwareFakeLLM(DistillationLLM):
+    """Embeds the conversation_id into the distillate text so the paired
+    fake embedder can look up this benchmark's precomputed distillate
+    vector for that conversation -- lets the test control distillate
+    embedding geometry precisely without a real LLM or embedding model."""
+
+    def distill(self, inputs):
+        return [
+            DistillationOutput(
+                exchange_core=f"conv={i.conversation_id}",
+                specific_context="distilled",
+                room_assignments=[],
+            )
+            for i in inputs
+        ]
+
+
+class _TopicAwareFakeEmbedder:
+    def __init__(self, topic_by_conversation: dict[str, str]) -> None:
+        self._topic_by_conversation = topic_by_conversation
+
+    def encode(self, texts, batch_size=32):
+        import numpy as np
+
+        vectors = []
+        for text in texts:
+            conversation_id = text.split("\n", 1)[0].removeprefix("conv=")
+            topic = self._topic_by_conversation[conversation_id]
+            vectors.append(distillate_embedding(topic, conversation_id))
+        return np.array(vectors, dtype=np.float32)
+
+
+@dataclass
+class _BenchmarkRun:
+    corpus: list
+    queries: list
+    pre_row_count: int
+    post_row_count: int
+    pre_embedding_by_conversation: dict
+    post_embedding_by_conversation: dict
+    still_hot: set
+    stats: object
+
+
+def _run_benchmark(storage: UnifiedStorage, config: Config, tmp_path: Path) -> _BenchmarkRun:
+    """Seeds the fixture corpus into a real UnifiedStorage, runs the real
+    M9 tiering pipeline (distillation_bridge.run_tiering_cycle through the
+    real Distiller/PalaceStorage, with a topic-aware fake LLM/embedder
+    controlling distillate geometry precisely), and returns everything
+    both acceptance tests need."""
+    base_date = datetime(2026, 7, 1)
+    corpus = build_fixture_corpus(base_date=base_date)
+    queries = build_query_set(corpus)
+    topic_by_conversation = {c.conversation_id: c.topic for c in corpus}
+
+    for conversation in corpus:
+        messages = []
+        seq = 0
+        for exchange in conversation.exchanges:
+            messages.append({
+                "sequence": seq, "role": "user",
+                "content": f"Tell me about {exchange.text}", "timestamp": conversation.updated_at,
+                "has_code": False, "code_blocks": None,
+            })
+            seq += 1
+            messages.append({
+                "sequence": seq, "role": "assistant",
+                "content": f"{exchange.text}. " * 3, "timestamp": conversation.updated_at,
+                "has_code": False, "code_blocks": None,
+            })
+            seq += 1
+        _insert_conversation(
+            storage, conversation_id=conversation.conversation_id,
+            project_id=conversation.project_id, updated_at=conversation.updated_at,
+            messages=messages,
+        )
+        segmented = _segment_exchanges(
+            conversation.conversation_id, conversation.project_id, messages, conversation.updated_at,
+        )
+        assert len(segmented) == len(conversation.exchanges)
+        for exc_row, fixture_exchange in zip(segmented, conversation.exchanges):
+            storage.upsert_exchange(**exc_row)
+            storage.upsert_embedding(exc_row["exchange_id"], fixture_exchange.verbatim_embedding)
+
+    pre_row_count = storage.get_row_counts()["verbatim_embeddings"]
+    pre_embedding_by_conversation = {
+        c.conversation_id: c.exchanges[0].verbatim_embedding for c in corpus
+    }
+
+    config.palace.enabled = True
+    config.distillation.age_threshold_days = 45
+    stats = distillation_bridge.run_tiering_cycle(
+        storage,
+        config=config,
+        llm=_TopicAwareFakeLLM(),
+        search_dir=tmp_path,
+        embedder=_TopicAwareFakeEmbedder(topic_by_conversation),
+        now=base_date,
+    )
+
+    post_row_count = storage.get_row_counts()["verbatim_embeddings"]
+    cur = storage.connection.cursor()
+    still_hot = {
+        row[0]
+        for row in cur.execute("SELECT DISTINCT conversation_id FROM exchanges").fetchall()
+    }
+    cur.close()
+
+    post_embedding_by_conversation: dict[str, list[float]] = {}
+    for c in corpus:
+        if c.conversation_id in still_hot:
+            post_embedding_by_conversation[c.conversation_id] = c.exchanges[0].verbatim_embedding
+        else:
+            post_embedding_by_conversation[c.conversation_id] = distillate_embedding(
+                c.topic, c.conversation_id,
+            )
+
+    return _BenchmarkRun(
+        corpus=corpus,
+        queries=queries,
+        pre_row_count=pre_row_count,
+        post_row_count=post_row_count,
+        pre_embedding_by_conversation=pre_embedding_by_conversation,
+        post_embedding_by_conversation=post_embedding_by_conversation,
+        still_hot=still_hot,
+        stats=stats,
+    )
+
+
+class TestBenchmarkAcceptance:
+    """Exercises the real `distillation_bridge` -> `Distiller` ->
+    `PalaceStorage` pipeline against the fixture corpus, then measures
+    recall@10 and index-size reduction per M9's acceptance criteria."""
+
+    def test_recall_at_10_meets_m9_acceptance_budget(
+        self, storage: UnifiedStorage, config: Config, tmp_path: Path
+    ):
+        run = _run_benchmark(storage, config, tmp_path)
+
+        pre_recall = recall_at_k(run.queries, run.pre_embedding_by_conversation, k=10)
+        assert pre_recall >= 0.99  # sanity: fixture geometry is well-separated
+
+        distilled_queries = [
+            q for q in run.queries if not (q.relevant_conversation_ids & run.still_hot)
+        ]
+        assert distilled_queries, "fixture must actually exercise the distilled path"
+
+        pre_recall_distilled = recall_at_k(distilled_queries, run.pre_embedding_by_conversation, k=10)
+        post_recall_distilled = recall_at_k(distilled_queries, run.post_embedding_by_conversation, k=10)
+
+        assert pre_recall_distilled > 0
+        relative_drop = (pre_recall_distilled - post_recall_distilled) / pre_recall_distilled
+        assert relative_drop <= MAX_RELATIVE_RECALL_DROP, (
+            f"distilled-conversation recall@10 dropped {relative_drop:.1%}, "
+            f"exceeding the {MAX_RELATIVE_RECALL_DROP:.0%} budget "
+            f"(pre={pre_recall_distilled:.3f}, post={post_recall_distilled:.3f})"
+        )

--- a/tests/unit/services/test_distillation_bridge.py
+++ b/tests/unit/services/test_distillation_bridge.py
@@ -688,3 +688,15 @@ class TestBenchmarkAcceptance:
             f"exceeding the {MAX_RELATIVE_RECALL_DROP:.0%} budget "
             f"(pre={pre_recall_distilled:.3f}, post={post_recall_distilled:.3f})"
         )
+
+    def test_index_size_reduction_meets_m9_acceptance_budget(
+        self, storage: UnifiedStorage, config: Config, tmp_path: Path
+    ):
+        run = _run_benchmark(storage, config, tmp_path)
+
+        assert run.pre_row_count == sum(len(c.exchanges) for c in run.corpus)
+        reduction_factor = run.pre_row_count / run.post_row_count
+        assert reduction_factor >= MIN_INDEX_SIZE_REDUCTION_FACTOR, (
+            f"expected >= {MIN_INDEX_SIZE_REDUCTION_FACTOR}x reduction, got {reduction_factor:.2f}x "
+            f"(pre={run.pre_row_count}, post={run.post_row_count})"
+        )


### PR DESCRIPTION
## Stack

Position: 5/5 (M9 Tiered memory: distill-old, keep-hot)

Depends on: #117 (leaf)

## Summary

Adds the M9 fixture-benchmark acceptance suite specified in DEVELOPMENT_PLAN.md: a deterministic, synthetic 12-month conversation corpus (12 monthly topic clusters, 2 conversations per topic = 24 conversations, hand-constructed 384-dim vectors) with one topic-matching query per topic, entirely mocking the LLM/embedder to keep the tests hermetic and fast.

- `tests/fixtures/distillation_benchmark.py` — fixture corpus builder, query set builder, `recall_at_k`, and a `distillate_embedding` helper that recomputes deterministic post-distillation vectors so recall can be measured directly against the embedding stores the bridge produces, without depending on FAISS's mocked/randomized search.
- `TestBenchmarkAcceptance::test_recall_at_10_meets_m9_acceptance_budget` — runs the real `distillation_bridge.run_tiering_cycle` end-to-end (age-based selection → distillate generation via `Distiller` → hot-index eviction) against the fixture corpus, then asserts relative recall@10 drop for distilled-conversation queries stays within `MAX_RELATIVE_RECALL_DROP` (10%).
- `TestBenchmarkAcceptance::test_index_size_reduction_meets_m9_acceptance_budget` — asserts the same tiering run reduces `verbatim_embeddings` row count by at least `MIN_INDEX_SIZE_REDUCTION_FACTOR` (5x) on the 12-month corpus.

Both tests share one `_run_benchmark` helper so the corpus is built and the tiering cycle executed exactly once per test, keeping the two acceptance checks consistent with each other.

## Verification

```
uv run pytest tests/unit/services/test_distillation_bridge.py tests/unit/palace/test_distiller.py -v --tb=short --no-cov
-- 38 passed

uv run pytest -v --tb=short (full suite, coverage)
-- 2360 passed, 1 skipped (pre-existing), 83.94% coverage (>= 80% gate)

UV_PROJECT_ENVIRONMENT=/tmp/searchat-no-palace uv run pytest -q --no-cov (palace extra absent)
-- 2351 passed, 2 skipped (bm25-dependent test skipped as expected + 1 pre-existing)
```

Measured acceptance numbers (24-conversation / 12-topic fixture corpus, age threshold selects the oldest 10 topics / 20 conversations for distillation, leaving the 4 most recent conversations hot):

- recall@10 for distilled-conversation queries: pre=1.000, post=1.000 -> **0.0% relative drop** (budget: <= 10%)
- `verbatim_embeddings` row count: pre=120, post=20 -> **6.0x reduction** (budget: >= 5.0x)
