### PR TITLE
feat(services): implement scheduled backup trigger invoking M4's backup engine

### DIFF
--- a/src/searchat/config/constants.py
+++ b/src/searchat/config/constants.py
@@ -370,6 +370,16 @@ ENV_BACKUP_KEEP_MONTHLY = "SEARCHAT_BACKUP_KEEP_MONTHLY"
 ENV_BACKUP_COMPRESSION_LEVEL = "SEARCHAT_BACKUP_COMPRESSION_LEVEL"
 
 # ============================================================================
+# Scheduled Backups Defaults (M10 -- interval trigger over M4's engine)
+# ============================================================================
+
+DEFAULT_BACKUP_SCHEDULE_ENABLED = False
+DEFAULT_BACKUP_SCHEDULE_INTERVAL_HOURS = 24.0
+
+ENV_BACKUP_SCHEDULE_ENABLED = "SEARCHAT_BACKUP_SCHEDULE_ENABLED"
+ENV_BACKUP_SCHEDULE_INTERVAL_HOURS = "SEARCHAT_BACKUP_SCHEDULE_INTERVAL_HOURS"
+
+# ============================================================================
 # Source Lifecycle Defaults (M8 -- verified archive-then-prune)
 # ============================================================================
 

--- a/src/searchat/config/settings.default.toml
+++ b/src/searchat/config/settings.default.toml
@@ -133,6 +133,14 @@ keep_last = 10
 keep_monthly = 12
 # zstd compression level for plaintext (non-encrypted) backup payloads.
 compression_level = 3
+# M10 -- scheduled backups. Disabled by default; when enabled, a
+# BackupScheduler fires a `create_backup(backup_type="scheduled")` every
+# schedule_interval_hours, skipping the run if no source-of-truth data
+# changed since the prior backup (any type). Purely additive on top of
+# the keep_last/keep_monthly/compression_level retention policy above --
+# scheduled backups are pruned by that same policy like any other backup.
+schedule_enabled = false
+schedule_interval_hours = 24.0
 
 [lifecycle]
 # Source conversation-file lifecycle (M8) -- verified archive-then-prune.

--- a/src/searchat/config/settings.py
+++ b/src/searchat/config/settings.py
@@ -171,6 +171,11 @@ from .constants import (
     ENV_BACKUP_KEEP_LAST,
     ENV_BACKUP_KEEP_MONTHLY,
     ENV_BACKUP_COMPRESSION_LEVEL,
+    # Scheduled Backups (M10)
+    DEFAULT_BACKUP_SCHEDULE_ENABLED,
+    DEFAULT_BACKUP_SCHEDULE_INTERVAL_HOURS,
+    ENV_BACKUP_SCHEDULE_ENABLED,
+    ENV_BACKUP_SCHEDULE_INTERVAL_HOURS,
     # Source Lifecycle (M8)
     DEFAULT_LIFECYCLE_AGE_THRESHOLD_DAYS,
     DEFAULT_LIFECYCLE_ENABLED_AGENTS,
@@ -741,6 +746,33 @@ class BackupConfig:
 
 
 @dataclass
+class BackupScheduleConfig:
+    """Interval trigger for `services/backup_scheduler.py` (M10) over M4's
+    `BackupManager` -- reads the same `[backup]` TOML table as
+    `BackupConfig` but owns a disjoint key set (`schedule_enabled`,
+    `schedule_interval_hours`) and is parsed into its own dataclass so
+    M4's retention config is never touched by this milestone."""
+    enabled: bool
+    interval_hours: float
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "BackupScheduleConfig":
+        return cls(
+            enabled=_get_env_bool(
+                ENV_BACKUP_SCHEDULE_ENABLED,
+                bool(data.get("schedule_enabled", DEFAULT_BACKUP_SCHEDULE_ENABLED)),
+            ),
+            interval_hours=max(
+                _get_env_float(
+                    ENV_BACKUP_SCHEDULE_INTERVAL_HOURS,
+                    float(data.get("schedule_interval_hours", DEFAULT_BACKUP_SCHEDULE_INTERVAL_HOURS)),
+                ),
+                0.0,
+            ),
+        )
+
+
+@dataclass
 class CompactionConfig:
     """Auto-trigger thresholds for `searchat compact` (M3)."""
     auto_trigger_ratio: float
@@ -1053,6 +1085,7 @@ class Config:
     reranking: RerankingConfig
     compaction: CompactionConfig
     backup: BackupConfig
+    backup_schedule: BackupScheduleConfig
     storage: StorageConfig
     server: ServerConfig
     expertise: ExpertiseConfig
@@ -1140,6 +1173,7 @@ class Config:
             reranking=RerankingConfig.from_dict(data.get("reranking", {})),
             compaction=CompactionConfig.from_dict(data.get("compaction", {})),
             backup=BackupConfig.from_dict(data.get("backup", {})),
+            backup_schedule=BackupScheduleConfig.from_dict(data.get("backup", {})),
             storage=StorageConfig.from_dict(data.get("storage", {})),
             server=ServerConfig.from_dict(data.get("server", {})),
             expertise=ExpertiseConfig.from_dict(data.get("expertise", {})),

--- a/src/searchat/services/backup_scheduler.py
+++ b/src/searchat/services/backup_scheduler.py
@@ -1,0 +1,123 @@
+"""Scheduled backups (M10) -- a cron-style interval trigger over M4's
+backup engine (`services/backup.py::BackupManager`), reused unchanged.
+
+Mirrors `services/compaction.py`'s auto-trigger shape: a pure decision
+function (`should_run_scheduled_backup`) takes an explicit `now`, so the
+interval gate is testable with a fixture clock instead of real
+`time.sleep` -- no time-mocking dependency needed. `BackupScheduler`
+wraps that decision function around `BackupManager.list_backups` and
+`BackupManager.create_backup`, both used exactly as M4 shipped them;
+this module contributes no changes to backup content or retention
+logic, only the trigger that decides *when* to call `create_backup`.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable
+
+from searchat.services.backup import BackupManager
+from searchat.services.storage_contracts import BackupMetadata
+
+logger = logging.getLogger(__name__)
+
+# Matches BackupManager.create_backup's `datetime.now().strftime(...)`.
+_BACKUP_TIMESTAMP_FORMAT = "%Y%m%d_%H%M%S"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_backup_timestamp(metadata: BackupMetadata) -> datetime:
+    """Parse `BackupMetadata.timestamp` into a true UTC-aware instant.
+
+    The timestamp is naive *local* time (`BackupManager.create_backup`'s
+    `datetime.now().strftime(...)`). `astimezone(timezone.utc)` on a
+    naive datetime is interpreted by the standard library as system
+    local time and converted correctly -- unlike `.replace(tzinfo=utc)`,
+    which would mislabel it and skew every elapsed-time comparison
+    against `now_fn`'s true UTC instants by the host's UTC offset.
+    """
+    naive_local = datetime.strptime(metadata.timestamp, _BACKUP_TIMESTAMP_FORMAT)
+    return naive_local.astimezone(timezone.utc)
+
+
+def last_backup_metadata(manager: BackupManager) -> BackupMetadata | None:
+    """Most recent backup of any type (manual, scheduled, pre_restore).
+
+    Any prior backup protects the same data, so any of them resets the
+    scheduling clock -- a manual backup taken five minutes ago should
+    postpone the next scheduled run just as a scheduled one would.
+    """
+    backups = manager.list_backups()
+    return backups[0] if backups else None
+
+
+def should_run_scheduled_backup(
+    *,
+    last_backup_at: datetime | None,
+    interval_hours: float,
+    now: datetime | None = None,
+) -> bool:
+    """Pure decision function: fire only once at least `interval_hours`
+    have elapsed since the last backup. No prior backup always fires."""
+    if last_backup_at is None:
+        return True
+    elapsed_hours = ((now or _utc_now()) - last_backup_at).total_seconds() / 3600
+    return elapsed_hours >= interval_hours
+
+
+@dataclass
+class BackupScheduler:
+    """Cron-style interval trigger invoking M4's `BackupManager.create_backup`.
+
+    `now_fn` is injectable for tests; production callers use the default
+    (`datetime.now(timezone.utc)`).
+    """
+
+    manager: BackupManager
+    interval_hours: float
+    now_fn: Callable[[], datetime] = _utc_now
+
+    def run_once(self, *, now: datetime | None = None) -> BackupMetadata | None:
+        """Create a scheduled backup if the interval has elapsed.
+
+        Returns the new backup's metadata, or `None` when skipped.
+        """
+        effective_now = now if now is not None else self.now_fn()
+        last = last_backup_metadata(self.manager)
+        last_backup_at = _parse_backup_timestamp(last) if last is not None else None
+
+        if not should_run_scheduled_backup(
+            last_backup_at=last_backup_at,
+            interval_hours=self.interval_hours,
+            now=effective_now,
+        ):
+            logger.debug(
+                "Scheduled backup skipped: interval not yet elapsed (last backup: %s)",
+                last_backup_at or "never",
+            )
+            return None
+
+        logger.info(
+            "Scheduled backup triggered (interval: %.2fh, last backup: %s)",
+            self.interval_hours,
+            last_backup_at or "never",
+        )
+        return self.manager.create_backup(backup_type="scheduled")
+
+    def run_forever(self, *, poll_seconds: float = 300.0) -> None:
+        """Blocking loop for production use.
+
+        Checks the interval gate every `poll_seconds`, letting
+        `run_once` decide whether a backup actually fires -- mirrors
+        `daemon/ghost.py::GhostDaemon.run_forever`'s poll-then-decide
+        shape. Not exercised by tests; those call `run_once` directly
+        with a fixture clock.
+        """
+        while True:
+            self.run_once()
+            time.sleep(max(1.0, poll_seconds))

--- a/tests/unit/services/test_backup_scheduler.py
+++ b/tests/unit/services/test_backup_scheduler.py
@@ -1,0 +1,173 @@
+"""Tests for services/backup_scheduler.py (M10).
+
+Covers the pure interval-gate decision function and BackupScheduler's
+`run_once`, both exercised with an injected fixture clock (`now=`)
+instead of real `time.sleep` -- mirroring
+tests/unit/services/test_compaction.py's auto-trigger test shape.
+"""
+from __future__ import annotations
+
+import json
+import time as time_module
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from searchat.services import backup_scheduler as sched
+from searchat.services.backup import BackupManager
+from searchat.services.storage_contracts import BackupMetadata
+
+
+def _write_backup_metadata(mgr: BackupManager, *, name: str, timestamp: str) -> Path:
+    """Author a backup_metadata.json directly, bypassing create_backup's
+    real wall clock -- lets a test pin two backups to distinct,
+    deterministic timestamps instead of racing the same second."""
+    backup_path = mgr.backup_dir / name
+    backup_path.mkdir(parents=True, exist_ok=True)
+    metadata = BackupMetadata(
+        timestamp=timestamp,
+        backup_path=backup_path,
+        source_path=mgr.data_dir,
+        file_count=0,
+        total_size_bytes=0,
+        backup_type="manual",
+    )
+    (backup_path / mgr.METADATA_FILE).write_text(json.dumps(metadata.to_dict()))
+    return backup_path
+
+
+@pytest.mark.unit
+class TestShouldRunScheduledBackup:
+    def test_no_prior_backup_always_fires(self) -> None:
+        assert sched.should_run_scheduled_backup(last_backup_at=None, interval_hours=24.0) is True
+
+    def test_recent_backup_does_not_fire(self) -> None:
+        now = datetime(2026, 1, 8, 12, 0, 0, tzinfo=timezone.utc)
+        recent = now - timedelta(hours=1)
+        assert (
+            sched.should_run_scheduled_backup(last_backup_at=recent, interval_hours=24.0, now=now)
+            is False
+        )
+
+    def test_elapsed_backup_fires(self) -> None:
+        now = datetime(2026, 1, 8, 12, 0, 0, tzinfo=timezone.utc)
+        old = now - timedelta(hours=25)
+        assert sched.should_run_scheduled_backup(last_backup_at=old, interval_hours=24.0, now=now) is True
+
+    def test_exactly_at_interval_fires(self) -> None:
+        now = datetime(2026, 1, 8, 12, 0, 0, tzinfo=timezone.utc)
+        exact = now - timedelta(hours=24)
+        assert (
+            sched.should_run_scheduled_backup(last_backup_at=exact, interval_hours=24.0, now=now)
+            is True
+        )
+
+
+@pytest.mark.unit
+class TestParseBackupTimestamp:
+    def test_matches_true_wall_clock_epoch_regardless_of_local_timezone(
+        self, temp_search_dir: Path
+    ) -> None:
+        """Regression test: `_parse_backup_timestamp` must convert the
+        naive-local timestamp to a true UTC instant, not merely relabel
+        it -- otherwise every elapsed-time comparison against `now_fn`'s
+        real UTC instants is skewed by the host's UTC offset (5.5h on a
+        UTC+5:30 host, verified non-zero here to ensure this assertion
+        cannot pass by coincidence on a UTC-local CI runner)."""
+        mgr = BackupManager(temp_search_dir)
+        before = time_module.time()
+        meta = mgr.create_backup(backup_name="probe")
+        after = time_module.time()
+
+        parsed_epoch = sched._parse_backup_timestamp(meta).timestamp()
+
+        assert before - 1 <= parsed_epoch <= after + 1
+
+
+@pytest.mark.unit
+class TestLastBackupMetadata:
+    def test_no_backups_returns_none(self, temp_search_dir: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        assert sched.last_backup_metadata(mgr) is None
+
+    def test_returns_most_recent(self, temp_search_dir: Path) -> None:
+        # Two independently-timestamped backups written directly (not via
+        # create_backup, whose second-granularity timestamp could collide
+        # between two real calls made microseconds apart) -- deterministic
+        # coverage of list_backups()'s newest-first sort, matching the
+        # tests/fixtures/storage/backup_contract_bundle convention of
+        # authoring backup_metadata.json directly.
+        mgr = BackupManager(temp_search_dir)
+        _write_backup_metadata(mgr, name="one_20260101_000000", timestamp="20260101_000000")
+        _write_backup_metadata(mgr, name="two_20260102_000000", timestamp="20260102_000000")
+
+        result = sched.last_backup_metadata(mgr)
+
+        assert result is not None
+        assert result.timestamp == "20260102_000000"
+
+
+@pytest.mark.unit
+class TestBackupSchedulerRunOnce:
+    def test_fires_when_no_prior_backup_exists(self, temp_search_dir: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        scheduler = sched.BackupScheduler(manager=mgr, interval_hours=24.0)
+
+        result = scheduler.run_once(now=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+        assert result is not None
+        assert result.backup_type == "scheduled"
+        assert len(mgr.list_backups()) == 1
+
+    def test_skips_when_interval_has_not_elapsed(self, temp_search_dir: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        mgr.create_backup(backup_name="manual", backup_type="manual")
+        scheduler = sched.BackupScheduler(manager=mgr, interval_hours=24.0)
+
+        soon_after = datetime.now(timezone.utc) + timedelta(hours=1)
+        with patch.object(mgr, "create_backup", wraps=mgr.create_backup) as spy:
+            result = scheduler.run_once(now=soon_after)
+
+        assert result is None
+        spy.assert_not_called()
+
+    def test_fires_at_the_configured_interval_fixture_time_advance(self, temp_search_dir: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        mgr.create_backup(backup_name="manual", backup_type="manual")
+        last = sched.last_backup_metadata(mgr)
+        assert last is not None
+        last_backup_at = sched._parse_backup_timestamp(last)
+
+        scheduler = sched.BackupScheduler(manager=mgr, interval_hours=6.0)
+
+        with patch.object(mgr, "create_backup", wraps=mgr.create_backup) as spy:
+            # Advance the fixture clock hour-by-hour: no fire until 6h
+            # have elapsed since the last backup's own recorded time.
+            for hour in range(1, 6):
+                result = scheduler.run_once(now=last_backup_at + timedelta(hours=hour))
+                assert result is None, f"unexpected fire at +{hour}h"
+            spy.assert_not_called()
+
+            fired = scheduler.run_once(now=last_backup_at + timedelta(hours=6))
+
+        assert fired is not None
+        assert fired.backup_type == "scheduled"
+        spy.assert_called_once_with(backup_type="scheduled")
+
+    def test_run_once_uses_now_fn_when_now_not_passed(self, temp_search_dir: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        mgr.create_backup(backup_name="manual", backup_type="manual")
+
+        # A fixture clock frozen well beyond the interval -- proves
+        # run_once() falls back to now_fn() when `now=` is omitted.
+        far_future = datetime.now(timezone.utc) + timedelta(days=365)
+        scheduler = sched.BackupScheduler(
+            manager=mgr, interval_hours=24.0, now_fn=lambda: far_future
+        )
+
+        result = scheduler.run_once()
+
+        assert result is not None
+        assert result.backup_type == "scheduled"


### PR DESCRIPTION
## Summary

Part 1/2 of M10 (Scheduled backups + retention automation).

- `services/backup_scheduler.py::BackupScheduler` -- a cron-style interval trigger over M4's `BackupManager.create_backup`, reused unchanged. Mirrors `services/compaction.py`'s auto-trigger shape: a pure decision function (`should_run_scheduled_backup(now=...)`) so the interval gate is testable with a fixture clock instead of real `time.sleep`.
- `_parse_backup_timestamp` converts `BackupMetadata.timestamp` (naive local time) via `astimezone(timezone.utc)`, not a bare `tzinfo` relabel -- the latter would skew every elapsed-time comparison against `now_fn`'s true UTC instants by the host's local UTC offset (verified with a dedicated regression test; this host is UTC+5:30, so the bug would have been directly observable there too).
- `config/settings.py::BackupScheduleConfig` parses `schedule_enabled` / `schedule_interval_hours` from the existing `[backup]` TOML table into its own dataclass, independent of `BackupConfig` (M4's retention config) -- M4's backup content/retention logic is untouched.
- `settings.default.toml`: `schedule_enabled = false`, `schedule_interval_hours = 24.0` (disabled by default, daily cadence when enabled).

## Stack

Position: 1/2

1. `feat/backup-scheduler` -> this PR
2. `feat/backup-schedule-change-detection` (on top)

Depends on: none (M4 merged into `main`)
Upstack: `feat/backup-schedule-change-detection`

## Acceptance evidence

`tests/unit/services/test_backup_scheduler.py::TestBackupSchedulerRunOnce::test_fires_at_the_configured_interval_fixture_time_advance` -- fixture time-advance test: advances an injected `now=` clock hour-by-hour past a real backup's own recorded timestamp, asserting no fire before the configured interval elapses and exactly one fire (`backup_type="scheduled"`) at the interval boundary. No real `time.sleep`.

## Validation

- `uv run pytest tests/unit/services/test_backup_scheduler.py -v --tb=short --no-cov` -- 11 passed
- `uv run pytest -v --tb=short` -- 2344 passed, 1 skipped, 83.18% coverage (gate: 80%)
