### PR TITLE
feat(services): add change-detection skip logic for scheduled backups

### DIFF
--- a/src/searchat/services/backup_scheduler.py
+++ b/src/searchat/services/backup_scheduler.py
@@ -4,8 +4,11 @@ backup engine (`services/backup.py::BackupManager`), reused unchanged.
 Mirrors `services/compaction.py`'s auto-trigger shape: a pure decision
 function (`should_run_scheduled_backup`) takes an explicit `now`, so the
 interval gate is testable with a fixture clock instead of real
-`time.sleep` -- no time-mocking dependency needed. `BackupScheduler`
-wraps that decision function around `BackupManager.list_backups` and
+`time.sleep` -- no time-mocking dependency needed. A second gate,
+`has_data_changed_since`, skips a run when no source-of-truth file has
+been touched since the last backup, so an idle dataset doesn't
+accumulate no-op backups every interval. `BackupScheduler` wraps both
+decision functions around `BackupManager.list_backups` and
 `BackupManager.create_backup`, both used exactly as M4 shipped them;
 this module contributes no changes to backup content or retention
 logic, only the trigger that decides *when* to call `create_backup`.
@@ -16,8 +19,10 @@ import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Callable
 
+from searchat.config.constants import DEFAULT_DATA_SUBDIR
 from searchat.services.backup import BackupManager
 from searchat.services.storage_contracts import BackupMetadata
 
@@ -70,6 +75,65 @@ def should_run_scheduled_backup(
     return elapsed_hours >= interval_hours
 
 
+# Source-of-truth items a scheduled run checks for changes -- the same
+# top-level scope BackupManager._iter_live_backup_files(excludes_derived=True)
+# backs up (data/, config/, bookmarks.json, saved_queries.json,
+# dashboards.json, expertise/, knowledge_graph/, analytics/), except
+# that method deliberately EXCLUDES `data/searchat.duckdb` itself (its
+# source-of-truth tables are exported to fresh Parquet on every backup
+# instead of being copied verbatim -- see that method's docstring), so
+# the exported files' own mtimes are always "now" and useless for
+# diffing. The live database file's mtime is instead the correct,
+# cheap-to-stat proxy for "did the underlying data change" without
+# re-running that export. `data/indices/` (the derivable FAISS/metadata
+# index) is excluded, matching the backup's own scope -- it is never
+# protected by a backup and is irrelevant to source-of-truth change
+# detection.
+_SOURCE_TREE_ITEMS: tuple[str, ...] = (
+    DEFAULT_DATA_SUBDIR,
+    "config",
+    "bookmarks.json",
+    "saved_queries.json",
+    "dashboards.json",
+    "expertise",
+    "knowledge_graph",
+    "analytics",
+)
+
+
+def _latest_source_mtime(data_dir: Path) -> float | None:
+    """Latest mtime (epoch seconds) across every source-of-truth file
+    under `data_dir`. Returns `None` when nothing exists yet."""
+    skip_dir = (data_dir / DEFAULT_DATA_SUBDIR / "indices").resolve()
+    latest: float | None = None
+    for name in _SOURCE_TREE_ITEMS:
+        root = data_dir / name
+        if not root.exists():
+            continue
+        paths = [root] if root.is_file() else [p for p in root.rglob("*") if p.is_file()]
+        for path in paths:
+            if skip_dir in path.resolve().parents:
+                continue
+            mtime = path.stat().st_mtime
+            if latest is None or mtime > latest:
+                latest = mtime
+    return latest
+
+
+def has_data_changed_since(data_dir: Path, since: datetime) -> bool:
+    """True if any source-of-truth file under `data_dir` was modified
+    after `since` (typically the last backup's own creation time).
+
+    A dataset with no source files at all (nothing indexed yet) counts
+    as unchanged -- there is nothing new to protect, so a scheduled run
+    should skip rather than create an empty backup.
+    """
+    latest = _latest_source_mtime(Path(data_dir))
+    if latest is None:
+        return False
+    return latest > since.timestamp()
+
+
 @dataclass
 class BackupScheduler:
     """Cron-style interval trigger invoking M4's `BackupManager.create_backup`.
@@ -83,7 +147,8 @@ class BackupScheduler:
     now_fn: Callable[[], datetime] = _utc_now
 
     def run_once(self, *, now: datetime | None = None) -> BackupMetadata | None:
-        """Create a scheduled backup if the interval has elapsed.
+        """Create a scheduled backup if the interval has elapsed AND the
+        source-of-truth data has actually changed since the last backup.
 
         Returns the new backup's metadata, or `None` when skipped.
         """
@@ -99,6 +164,15 @@ class BackupScheduler:
             logger.debug(
                 "Scheduled backup skipped: interval not yet elapsed (last backup: %s)",
                 last_backup_at or "never",
+            )
+            return None
+
+        if last_backup_at is not None and not has_data_changed_since(
+            self.manager.data_dir, last_backup_at
+        ):
+            logger.info(
+                "Scheduled backup skipped: no data changed since last backup (%s)",
+                last.timestamp if last is not None else "never",
             )
             return None
 

--- a/tests/unit/services/test_backup_scheduler.py
+++ b/tests/unit/services/test_backup_scheduler.py
@@ -8,6 +8,7 @@ tests/unit/services/test_compaction.py's auto-trigger test shape.
 from __future__ import annotations
 
 import json
+import os
 import time as time_module
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -36,6 +37,17 @@ def _write_backup_metadata(mgr: BackupManager, *, name: str, timestamp: str) -> 
     )
     (backup_path / mgr.METADATA_FILE).write_text(json.dumps(metadata.to_dict()))
     return backup_path
+
+
+def _touch_source_file(temp_search_dir: Path, *, mtime: float) -> Path:
+    """Write a source-of-truth file and pin its mtime -- simulates a
+    data change at an exact instant, sidestepping filesystem mtime
+    granularity/precision differences across platforms."""
+    path = temp_search_dir / "data" / "conversations.parquet"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"PAR1")
+    os.utime(path, (mtime, mtime))
+    return path
 
 
 @pytest.mark.unit
@@ -139,6 +151,7 @@ class TestBackupSchedulerRunOnce:
         last = sched.last_backup_metadata(mgr)
         assert last is not None
         last_backup_at = sched._parse_backup_timestamp(last)
+        _touch_source_file(temp_search_dir, mtime=last_backup_at.timestamp() + 1)
 
         scheduler = sched.BackupScheduler(manager=mgr, interval_hours=6.0)
 
@@ -159,6 +172,11 @@ class TestBackupSchedulerRunOnce:
     def test_run_once_uses_now_fn_when_now_not_passed(self, temp_search_dir: Path) -> None:
         mgr = BackupManager(temp_search_dir)
         mgr.create_backup(backup_name="manual", backup_type="manual")
+        last = sched.last_backup_metadata(mgr)
+        assert last is not None
+        _touch_source_file(
+            temp_search_dir, mtime=sched._parse_backup_timestamp(last).timestamp() + 1
+        )
 
         # A fixture clock frozen well beyond the interval -- proves
         # run_once() falls back to now_fn() when `now=` is omitted.
@@ -171,3 +189,80 @@ class TestBackupSchedulerRunOnce:
 
         assert result is not None
         assert result.backup_type == "scheduled"
+
+
+@pytest.mark.unit
+class TestHasDataChangedSince:
+    def test_no_source_files_is_unchanged(self, tmp_path: Path) -> None:
+        assert sched.has_data_changed_since(tmp_path, datetime.now(timezone.utc)) is False
+
+    def test_file_modified_after_since_is_changed(self, temp_search_dir: Path) -> None:
+        since = datetime.now(timezone.utc) - timedelta(hours=1)
+        _touch_source_file(temp_search_dir, mtime=since.timestamp() + 60)
+
+        assert sched.has_data_changed_since(temp_search_dir, since) is True
+
+    def test_file_modified_before_since_is_unchanged(self, temp_search_dir: Path) -> None:
+        since = datetime.now(timezone.utc)
+        _touch_source_file(temp_search_dir, mtime=since.timestamp() - 3600)
+
+        assert sched.has_data_changed_since(temp_search_dir, since) is False
+
+    def test_derived_indices_changes_are_ignored(self, temp_search_dir: Path) -> None:
+        """`data/indices/` is the legacy FAISS/metadata index -- derived,
+        never part of a backup, and irrelevant to source-of-truth change
+        detection (mirrors BackupManager._iter_live_backup_files's own
+        exclusion of this directory)."""
+        since = datetime.now(timezone.utc)
+        stale_source = temp_search_dir / "data" / "conversations.parquet"
+        stale_source.parent.mkdir(parents=True, exist_ok=True)
+        stale_source.write_bytes(b"PAR1")
+        os.utime(stale_source, (since.timestamp() - 3600, since.timestamp() - 3600))
+
+        fresh_derived = temp_search_dir / "data" / "indices" / "faiss.index"
+        fresh_derived.parent.mkdir(parents=True, exist_ok=True)
+        fresh_derived.write_bytes(b"IDX1")
+        os.utime(fresh_derived, (since.timestamp() + 60, since.timestamp() + 60))
+
+        assert sched.has_data_changed_since(temp_search_dir, since) is False
+
+
+@pytest.mark.unit
+class TestBackupSchedulerChangeDetectionGate:
+    def test_second_scheduled_run_with_no_data_changes_is_skipped(
+        self, temp_search_dir: Path
+    ) -> None:
+        """M10 acceptance: a second scheduled run, one full interval
+        after the first, with no source-of-truth writes in between, is
+        skipped -- and the backup engine's create function is never
+        called for it."""
+        mgr = BackupManager(temp_search_dir)
+        scheduler = sched.BackupScheduler(manager=mgr, interval_hours=6.0)
+
+        first = scheduler.run_once(now=datetime.now(timezone.utc))
+        assert first is not None
+        last_backup_at = sched._parse_backup_timestamp(first)
+
+        with patch.object(mgr, "create_backup", wraps=mgr.create_backup) as spy:
+            second = scheduler.run_once(now=last_backup_at + timedelta(hours=6))
+
+        assert second is None
+        spy.assert_not_called()
+
+    def test_second_scheduled_run_fires_when_data_changed(self, temp_search_dir: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        scheduler = sched.BackupScheduler(manager=mgr, interval_hours=6.0)
+
+        first = scheduler.run_once(now=datetime.now(timezone.utc))
+        assert first is not None
+        last_backup_at = sched._parse_backup_timestamp(first)
+
+        t1 = last_backup_at + timedelta(hours=6)
+        _touch_source_file(temp_search_dir, mtime=t1.timestamp() - 60)
+
+        with patch.object(mgr, "create_backup", wraps=mgr.create_backup) as spy:
+            second = scheduler.run_once(now=t1)
+
+        assert second is not None
+        assert second.backup_type == "scheduled"
+        spy.assert_called_once_with(backup_type="scheduled")


### PR DESCRIPTION
## Summary

Part 2/2 of M10 (Scheduled backups + retention automation).

- `services/backup_scheduler.py::has_data_changed_since(data_dir, since)` -- true if any source-of-truth file's mtime is newer than `since` (the last backup's own creation time). `BackupScheduler.run_once()` consults it after the interval gate: when a prior backup exists and no source file changed since it, the run is skipped and `BackupManager.create_backup` is never invoked.
- The live `searchat.duckdb` file's mtime stands in for the exported `duckdb_source/*.parquet` tables -- `BackupManager._iter_live_backup_files` deliberately excludes the live db file itself, since its source-of-truth tables are exported to Parquet fresh on every backup instead of copied verbatim, so the exported files' own mtimes are always "now" and useless for diffing. `data/indices/` (the derivable FAISS/metadata index, already outside backup scope) is excluded from the change signal for the same reason.
- No changes to M4's backup content or retention logic (`services/backup.py`, `BackupConfig`) -- this PR only adds a second gate in front of the existing `create_backup` call added in PR-1.

## Stack

Position: 2/2 (top of stack)

1. `feat/backup-scheduler` (#119)
2. `feat/backup-schedule-change-detection` -> this PR

Depends on: #119 (base branch)

## Acceptance evidence

M10 acceptance is the pair of tests in `TestBackupSchedulerChangeDetectionGate`:

- `test_second_scheduled_run_with_no_data_changes_is_skipped` -- a second scheduled run, one full interval after the first, with no source-of-truth writes in between, returns `None` and `BackupManager.create_backup` is asserted never called for it (`unittest.mock.patch.object` spy).
- `test_second_scheduled_run_fires_when_data_changed` -- the same scenario with a source file write in between fires and calls `create_backup(backup_type="scheduled")` exactly once.

`TestHasDataChangedSince` covers the change-detection function directly: no source files (unchanged), a file modified after `since` (changed), a file modified before `since` (unchanged), and `data/indices/` writes being ignored (derived, out of scope).

## Validation

- `uv run pytest tests/unit/services/test_backup_scheduler.py -v --tb=short --no-cov` -- 17 passed
- `uv run pytest -v --tb=short` -- 2351 passed, 1 skipped, 83.21% coverage (gate: 80%)
