### PR TITLE
feat(services): implement cross-connector near-duplicate detection via embedding similarity

### DIFF
--- a/src/searchat/config/constants.py
+++ b/src/searchat/config/constants.py
@@ -398,6 +398,18 @@ ENV_LIFECYCLE_ENABLED_AGENTS = "SEARCHAT_LIFECYCLE_ENABLED_AGENTS"
 ENV_LIFECYCLE_DRY_RUN = "SEARCHAT_LIFECYCLE_DRY_RUN"
 
 # ============================================================================
+# Cross-Agent Duplicate Detection Defaults (M11 -- report-only)
+# ============================================================================
+
+# Conservative default: only conversation pairs whose mean exchange-embedding
+# cosine similarity is at or above 0.92 are surfaced as suggestions. Report-
+# only -- services/dedup_detection.py never merges or deletes anything this
+# threshold gates.
+DEFAULT_DEDUP_SIMILARITY_THRESHOLD = 0.92
+
+ENV_DEDUP_SIMILARITY_THRESHOLD = "SEARCHAT_DEDUP_SIMILARITY_THRESHOLD"
+
+# ============================================================================
 # Query Expansion / Synonyms
 # ============================================================================
 

--- a/src/searchat/config/settings.default.toml
+++ b/src/searchat/config/settings.default.toml
@@ -159,3 +159,12 @@ enabled_agents = []
 # key exists for completeness and any future non-CLI caller; it cannot
 # by itself enable a real mutation from the CLI.
 dry_run = true
+
+[dedup]
+# Cross-agent duplicate detection (M11) -- report-only. A pair of
+# conversations ingested by two DIFFERENT connectors is surfaced as a
+# merge/ignore suggestion in the M6 dashboard when their mean
+# exchange-embedding cosine similarity meets or exceeds this threshold.
+# No code path in this milestone merges or deletes anything -- see
+# services/dedup_detection.py.
+similarity_threshold = 0.92

--- a/src/searchat/config/settings.py
+++ b/src/searchat/config/settings.py
@@ -183,6 +183,9 @@ from .constants import (
     ENV_LIFECYCLE_AGE_THRESHOLD_DAYS,
     ENV_LIFECYCLE_ENABLED_AGENTS,
     ENV_LIFECYCLE_DRY_RUN,
+    # Cross-Agent Duplicate Detection (M11)
+    DEFAULT_DEDUP_SIMILARITY_THRESHOLD,
+    ENV_DEDUP_SIMILARITY_THRESHOLD,
 )
 
 if TYPE_CHECKING:
@@ -863,6 +866,33 @@ class LifecycleConfig:
 
 
 @dataclass
+class DedupConfig:
+    """Cross-connector near-duplicate detection threshold for
+    `services/dedup_detection.py` (M11). Report-only: no code path this
+    threshold gates ever merges or deletes a conversation -- it only
+    decides which conversation pairs are similar enough to surface as a
+    suggestion in the M6 dashboard.
+    """
+
+    similarity_threshold: float
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DedupConfig":
+        return cls(
+            similarity_threshold=min(
+                max(
+                    _get_env_float(
+                        ENV_DEDUP_SIMILARITY_THRESHOLD,
+                        float(data.get("similarity_threshold", DEFAULT_DEDUP_SIMILARITY_THRESHOLD)),
+                    ),
+                    0.0,
+                ),
+                1.0,
+            ),
+        )
+
+
+@dataclass
 class ExpertiseConfig:
     enabled: bool
     auto_extract: bool
@@ -1095,6 +1125,7 @@ class Config:
     distillation: DistillationConfig
     palace: PalaceConfig
     lifecycle: LifecycleConfig
+    dedup: DedupConfig
 
     @classmethod
     def load(cls, config_path: Path | None = None) -> "Config":
@@ -1183,4 +1214,5 @@ class Config:
             distillation=DistillationConfig.from_dict(data.get("distillation", {})),
             palace=PalaceConfig.from_dict(data.get("palace", {})),
             lifecycle=LifecycleConfig.from_dict(data.get("lifecycle", {})),
+            dedup=DedupConfig.from_dict(data.get("dedup", {})),
         )

--- a/src/searchat/services/dedup_detection.py
+++ b/src/searchat/services/dedup_detection.py
@@ -1,0 +1,210 @@
+"""Cross-connector near-duplicate conversation detection (M11).
+
+Report-only: `find_near_duplicates` never merges, deletes, or otherwise
+mutates a conversation -- it only reads `verbatim_embeddings` (the existing
+HNSW-backed table, see `storage/schema.py`), `exchanges`, `conversations`,
+and `source_file_state`, and returns similarity-ranked suggestions for a
+human (or the M6 dashboard) to review. Every DB call in this module is a
+SELECT; there is no INSERT/UPDATE/DELETE/MERGE/DROP anywhere here.
+
+Detection approach: for each conversation, mean-pool the embeddings of its
+own exchanges (already computed by the embedding pipeline and stored in
+`verbatim_embeddings`) into one L2-normalized conversation-level vector,
+then compare vectors pairwise across conversations ingested by two
+DIFFERENT connectors -- same-connector pairs are out of scope per the
+milestone ("cross-agent duplicate detection"). A pair whose cosine
+similarity meets or exceeds `similarity_threshold` is reported as a
+suggestion, most-similar first.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import numpy as np
+
+from searchat.core.connectors.registry import detect_connector
+
+# Fallback default for standalone/CLI callers of `find_near_duplicates` that
+# don't thread a `Config` through. The M6 dashboard integration instead
+# passes `config.dedup.similarity_threshold` (see `settings.default.toml`'s
+# `[dedup] similarity_threshold`).
+DEFAULT_SIMILARITY_THRESHOLD: float = 0.92
+
+
+@dataclass(frozen=True)
+class DuplicateSuggestion:
+    """One cross-connector near-duplicate conversation pair -- reported,
+    never acted on. `similarity` is a cosine similarity, in practice within
+    [0.0, 1.0] for the non-negative sentence embeddings this project
+    stores.
+    """
+
+    conversation_id_a: str
+    connector_a: str
+    title_a: str
+    conversation_id_b: str
+    connector_b: str
+    title_b: str
+    similarity: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "conversation_id_a": self.conversation_id_a,
+            "connector_a": self.connector_a,
+            "title_a": self.title_a,
+            "conversation_id_b": self.conversation_id_b,
+            "connector_b": self.connector_b,
+            "title_b": self.title_b,
+            "similarity": self.similarity,
+        }
+
+
+@dataclass(frozen=True)
+class _ConversationVector:
+    conversation_id: str
+    connector: str
+    title: str
+    vector: np.ndarray  # L2-normalized, shape (embedding_dim,)
+
+
+def _resolve_connector(connector_name: str | None, file_path: str) -> str:
+    """`connector_name` when present; otherwise fall back to detecting it
+    from the stored file path -- the same fallback
+    `disk_accounting._group_indexed_rows` uses for rows written before
+    `connector_name` was threaded through `source_file_state`.
+    """
+    if connector_name:
+        return connector_name
+    try:
+        return detect_connector(Path(file_path)).name
+    except ValueError:
+        return "unknown"
+
+
+def _fetch_conversation_vectors(
+    connection: duckdb.DuckDBPyConnection,
+) -> list[_ConversationVector]:
+    """Mean-pool every conversation's exchange embeddings into one
+    L2-normalized vector, paired with its connector and title. A
+    conversation with no indexed exchanges (no embeddings yet) is excluded
+    -- there is nothing to compare it against. Every statement here is a
+    SELECT.
+    """
+    try:
+        meta_rows = connection.execute(
+            """
+            SELECT
+                c.conversation_id,
+                c.title,
+                c.file_path,
+                any_value(sfs.connector_name) AS connector_name
+            FROM conversations c
+            LEFT JOIN source_file_state sfs ON sfs.conversation_id = c.conversation_id
+            GROUP BY c.conversation_id, c.title, c.file_path
+            """
+        ).fetchall()
+    except duckdb.Error:
+        return []
+    if not meta_rows:
+        return []
+
+    try:
+        embedding_rows = connection.execute(
+            """
+            SELECT e.conversation_id, ve.embedding
+            FROM exchanges e
+            JOIN verbatim_embeddings ve ON ve.exchange_id = e.exchange_id
+            """
+        ).fetchall()
+    except duckdb.Error:
+        return []
+
+    embeddings_by_conversation: dict[str, list[Any]] = {}
+    for conversation_id, embedding in embedding_rows:
+        embeddings_by_conversation.setdefault(conversation_id, []).append(embedding)
+
+    vectors: list[_ConversationVector] = []
+    for conversation_id, title, file_path, connector_name in meta_rows:
+        raw_embeddings = embeddings_by_conversation.get(conversation_id)
+        if not raw_embeddings:
+            continue
+        mean_vector = np.asarray(raw_embeddings, dtype=np.float64).mean(axis=0)
+        norm = float(np.linalg.norm(mean_vector))
+        if norm == 0.0:
+            continue
+        vectors.append(
+            _ConversationVector(
+                conversation_id=conversation_id,
+                connector=_resolve_connector(connector_name, file_path),
+                title=title,
+                vector=mean_vector / norm,
+            )
+        )
+    return vectors
+
+
+def find_near_duplicates(
+    db_path: Path,
+    *,
+    connection: duckdb.DuckDBPyConnection | None = None,
+    similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+) -> tuple[DuplicateSuggestion, ...]:
+    """Report-only cross-connector near-duplicate conversation suggestions.
+
+    Every conversation ingested by connector A is compared against every
+    conversation ingested by a DIFFERENT connector B; pairs whose mean
+    exchange-embedding cosine similarity meets or exceeds
+    `similarity_threshold` are returned, most-similar first. Same-connector
+    pairs are never compared -- this milestone is cross-agent duplicate
+    detection specifically, not general within-connector dedup.
+
+    Never merges, deletes, or writes anything: `_fetch_conversation_vectors`
+    issues only SELECT statements, and the pairwise comparison below is pure
+    in-memory numpy. `connection`: pass the live server's own open
+    connection when available (mirrors
+    `disk_accounting._read_indexed_paths_by_connector`) -- DuckDB refuses a
+    second same-process connection to a file already opened with
+    non-default config. When `connection` is not given (CLI/standalone
+    use), a short-lived READ-ONLY connection to `db_path` is opened instead
+    -- `read_only=True` additionally makes any accidental mutation
+    impossible at the DB layer for that path, on top of this module never
+    issuing one. Returns an empty tuple if `db_path` doesn't exist yet.
+    """
+    if connection is not None:
+        vectors = _fetch_conversation_vectors(connection)
+    else:
+        if not db_path.exists():
+            return ()
+        own_connection = duckdb.connect(str(db_path), read_only=True)
+        try:
+            vectors = _fetch_conversation_vectors(own_connection)
+        finally:
+            own_connection.close()
+
+    suggestions: list[DuplicateSuggestion] = []
+    for i in range(len(vectors)):
+        vector_a = vectors[i]
+        for j in range(i + 1, len(vectors)):
+            vector_b = vectors[j]
+            if vector_a.connector == vector_b.connector:
+                continue
+            similarity = float(np.dot(vector_a.vector, vector_b.vector))
+            if similarity >= similarity_threshold:
+                suggestions.append(
+                    DuplicateSuggestion(
+                        conversation_id_a=vector_a.conversation_id,
+                        connector_a=vector_a.connector,
+                        title_a=vector_a.title,
+                        conversation_id_b=vector_b.conversation_id,
+                        connector_b=vector_b.connector,
+                        title_b=vector_b.title,
+                        similarity=similarity,
+                    )
+                )
+
+    suggestions.sort(key=lambda s: (-s.similarity, s.conversation_id_a, s.conversation_id_b))
+    return tuple(suggestions)

--- a/tests/unit/services/test_dedup_detection.py
+++ b/tests/unit/services/test_dedup_detection.py
@@ -1,0 +1,468 @@
+"""Unit tests for `searchat.services.dedup_detection` (M11).
+
+Covers the milestone acceptance criteria: a fixture near-duplicate pair
+(same content ingested via two different connectors) is flagged above
+`similarity_threshold`; a fixture pair of genuinely distinct conversations
+is not flagged; same-connector pairs are never compared (cross-agent
+detection only); the standalone (no live connection) path opens its own
+READ-ONLY connection and degrades gracefully when the database doesn't
+exist yet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import pytest
+
+from searchat.services.dedup_detection import (
+    DEFAULT_SIMILARITY_THRESHOLD,
+    DuplicateSuggestion,
+    find_near_duplicates,
+)
+
+
+def _seed_connection(
+    con: duckdb.DuckDBPyConnection,
+    *,
+    conversations: tuple[dict[str, Any], ...],
+    embedding_dim: int,
+) -> None:
+    """Minimal hand-built schema covering only what `find_near_duplicates`
+    reads: `conversations`, `exchanges`, `verbatim_embeddings`,
+    `source_file_state`. Mirrors `test_compaction.py`'s `_seed_minimal_db`
+    convention of a small fixed-width embedding column rather than the
+    full 384-dim production schema.
+    """
+    con.execute(
+        "CREATE TABLE conversations(conversation_id VARCHAR PRIMARY KEY, "
+        "title VARCHAR, file_path VARCHAR)"
+    )
+    con.execute("CREATE TABLE exchanges(exchange_id VARCHAR PRIMARY KEY, conversation_id VARCHAR)")
+    con.execute(
+        f"CREATE TABLE verbatim_embeddings(exchange_id VARCHAR PRIMARY KEY, "
+        f"embedding FLOAT[{embedding_dim}])"
+    )
+    con.execute(
+        "CREATE TABLE source_file_state(file_path VARCHAR PRIMARY KEY, "
+        "conversation_id VARCHAR, connector_name VARCHAR, status VARCHAR)"
+    )
+    for conv in conversations:
+        con.execute(
+            "INSERT INTO conversations VALUES (?, ?, ?)",
+            [conv["conversation_id"], conv["title"], conv["file_path"]],
+        )
+        con.execute(
+            "INSERT INTO source_file_state VALUES (?, ?, ?, 'indexed')",
+            [conv["file_path"], conv["conversation_id"], conv.get("connector_name")],
+        )
+        for idx, embedding in enumerate(conv.get("embeddings", ())):
+            exchange_id = f"{conv['conversation_id']}-e{idx}"
+            con.execute(
+                "INSERT INTO exchanges VALUES (?, ?)", [exchange_id, conv["conversation_id"]]
+            )
+            con.execute(
+                "INSERT INTO verbatim_embeddings VALUES (?, ?)", [exchange_id, embedding]
+            )
+
+
+def _build_fixture_db(db_path: Path, *, conversations: tuple[dict[str, Any], ...], embedding_dim: int) -> None:
+    con = duckdb.connect(str(db_path))
+    try:
+        _seed_connection(con, conversations=conversations, embedding_dim=embedding_dim)
+        con.execute("CHECKPOINT")
+    finally:
+        con.close()
+
+
+# ---------------------------------------------------------------------------
+# Milestone acceptance: near-duplicate pair flagged, distinct pair is not.
+# ---------------------------------------------------------------------------
+
+
+_SAME_CONTENT_VECTOR = [1.0, 0.0, 0.0, 0.0]
+_DISTINCT_VECTOR_A = [1.0, 0.0, 0.0, 0.0]
+_DISTINCT_VECTOR_B = [0.0, 1.0, 0.0, 0.0]
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_flags_cross_connector_near_duplicate_pair() -> None:
+    """Same content ingested via two different connectors (claude, codex) is
+    flagged above the default similarity threshold."""
+    con = duckdb.connect(":memory:")
+    _seed_connection(
+        con,
+        conversations=(
+            {
+                "conversation_id": "claude-conv-1",
+                "title": "Debugging the auth flow",
+                "file_path": "/home/user/.claude/projects/p/conv1.jsonl",
+                "connector_name": "claude",
+                "embeddings": [_SAME_CONTENT_VECTOR, _SAME_CONTENT_VECTOR],
+            },
+            {
+                "conversation_id": "codex-conv-1",
+                "title": "Debugging the auth flow",
+                "file_path": "/home/user/.codex/sessions/conv1.jsonl",
+                "connector_name": "codex",
+                "embeddings": [_SAME_CONTENT_VECTOR, _SAME_CONTENT_VECTOR],
+            },
+        ),
+        embedding_dim=4,
+    )
+
+    suggestions = find_near_duplicates(Path("unused"), connection=con, similarity_threshold=0.92)
+
+    assert len(suggestions) == 1
+    suggestion = suggestions[0]
+    assert isinstance(suggestion, DuplicateSuggestion)
+    assert {suggestion.connector_a, suggestion.connector_b} == {"claude", "codex"}
+    assert {suggestion.conversation_id_a, suggestion.conversation_id_b} == {
+        "claude-conv-1",
+        "codex-conv-1",
+    }
+    assert suggestion.similarity == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_does_not_flag_genuinely_distinct_conversations() -> None:
+    """Orthogonal embeddings (unrelated content) across two connectors stay
+    below threshold and are never flagged."""
+    con = duckdb.connect(":memory:")
+    _seed_connection(
+        con,
+        conversations=(
+            {
+                "conversation_id": "claude-conv-2",
+                "title": "Refactoring the parser",
+                "file_path": "/home/user/.claude/projects/p/conv2.jsonl",
+                "connector_name": "claude",
+                "embeddings": [_DISTINCT_VECTOR_A],
+            },
+            {
+                "conversation_id": "codex-conv-2",
+                "title": "Deploying the CI pipeline",
+                "file_path": "/home/user/.codex/sessions/conv2.jsonl",
+                "connector_name": "codex",
+                "embeddings": [_DISTINCT_VECTOR_B],
+            },
+        ),
+        embedding_dim=4,
+    )
+
+    suggestions = find_near_duplicates(Path("unused"), connection=con, similarity_threshold=0.92)
+
+    assert suggestions == ()
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_ignores_same_connector_pairs() -> None:
+    """Identical content from the SAME connector is never compared -- this
+    milestone is cross-agent duplicate detection specifically."""
+    con = duckdb.connect(":memory:")
+    _seed_connection(
+        con,
+        conversations=(
+            {
+                "conversation_id": "claude-conv-3",
+                "title": "Debugging the auth flow",
+                "file_path": "/home/user/.claude/projects/p/conv3.jsonl",
+                "connector_name": "claude",
+                "embeddings": [_SAME_CONTENT_VECTOR],
+            },
+            {
+                "conversation_id": "claude-conv-4",
+                "title": "Debugging the auth flow (copy)",
+                "file_path": "/home/user/.claude/projects/p/conv4.jsonl",
+                "connector_name": "claude",
+                "embeddings": [_SAME_CONTENT_VECTOR],
+            },
+        ),
+        embedding_dim=4,
+    )
+
+    suggestions = find_near_duplicates(Path("unused"), connection=con, similarity_threshold=0.5)
+
+    assert suggestions == ()
+
+
+# ---------------------------------------------------------------------------
+# Threshold boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_includes_pair_exactly_at_threshold() -> None:
+    con = duckdb.connect(":memory:")
+    _seed_connection(
+        con,
+        conversations=(
+            {
+                "conversation_id": "a",
+                "title": "A",
+                "file_path": "/a.jsonl",
+                "connector_name": "claude",
+                "embeddings": [[1.0, 0.0]],
+            },
+            {
+                "conversation_id": "b",
+                "title": "B",
+                "file_path": "/b.jsonl",
+                "connector_name": "codex",
+                "embeddings": [[0.6, 0.8]],
+            },
+        ),
+        embedding_dim=2,
+    )
+
+    suggestions = find_near_duplicates(Path("unused"), connection=con, similarity_threshold=0.6)
+
+    assert len(suggestions) == 1
+    assert suggestions[0].similarity == pytest.approx(0.6)
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_excludes_pair_just_below_threshold() -> None:
+    con = duckdb.connect(":memory:")
+    _seed_connection(
+        con,
+        conversations=(
+            {
+                "conversation_id": "a",
+                "title": "A",
+                "file_path": "/a.jsonl",
+                "connector_name": "claude",
+                "embeddings": [[1.0, 0.0]],
+            },
+            {
+                "conversation_id": "b",
+                "title": "B",
+                "file_path": "/b.jsonl",
+                "connector_name": "codex",
+                "embeddings": [[0.6, 0.8]],
+            },
+        ),
+        embedding_dim=2,
+    )
+
+    suggestions = find_near_duplicates(Path("unused"), connection=con, similarity_threshold=0.61)
+
+    assert suggestions == ()
+
+
+# ---------------------------------------------------------------------------
+# Connection modes and edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_returns_empty_tuple_when_db_path_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "no-such.duckdb"
+    assert find_near_duplicates(missing) == ()
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_opens_own_readonly_connection_when_none_given(tmp_path: Path) -> None:
+    db_path = tmp_path / "standalone.duckdb"
+    _build_fixture_db(
+        db_path,
+        conversations=(
+            {
+                "conversation_id": "claude-conv-5",
+                "title": "Same session",
+                "file_path": "/home/user/.claude/projects/p/conv5.jsonl",
+                "connector_name": "claude",
+                "embeddings": [_SAME_CONTENT_VECTOR],
+            },
+            {
+                "conversation_id": "codex-conv-5",
+                "title": "Same session",
+                "file_path": "/home/user/.codex/sessions/conv5.jsonl",
+                "connector_name": "codex",
+                "embeddings": [_SAME_CONTENT_VECTOR],
+            },
+        ),
+        embedding_dim=4,
+    )
+
+    suggestions = find_near_duplicates(db_path, similarity_threshold=0.92)
+
+    assert len(suggestions) == 1
+    assert suggestions[0].similarity == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_uses_default_threshold_constant_when_unspecified() -> None:
+    con = duckdb.connect(":memory:")
+    _seed_connection(
+        con,
+        conversations=(
+            {
+                "conversation_id": "a",
+                "title": "A",
+                "file_path": "/a.jsonl",
+                "connector_name": "claude",
+                "embeddings": [_SAME_CONTENT_VECTOR],
+            },
+            {
+                "conversation_id": "b",
+                "title": "B",
+                "file_path": "/b.jsonl",
+                "connector_name": "codex",
+                "embeddings": [_SAME_CONTENT_VECTOR],
+            },
+        ),
+        embedding_dim=4,
+    )
+
+    suggestions = find_near_duplicates(Path("unused"), connection=con)
+
+    assert DEFAULT_SIMILARITY_THRESHOLD == pytest.approx(0.92)
+    assert len(suggestions) == 1
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_excludes_conversations_without_embeddings() -> None:
+    """A conversation with no indexed exchanges yet has nothing to compare
+    against and must never crash the comparison."""
+    con = duckdb.connect(":memory:")
+    _seed_connection(
+        con,
+        conversations=(
+            {
+                "conversation_id": "claude-conv-6",
+                "title": "Not yet embedded",
+                "file_path": "/home/user/.claude/projects/p/conv6.jsonl",
+                "connector_name": "claude",
+                "embeddings": [],
+            },
+            {
+                "conversation_id": "codex-conv-6",
+                "title": "Not yet embedded",
+                "file_path": "/home/user/.codex/sessions/conv6.jsonl",
+                "connector_name": "codex",
+                "embeddings": [_SAME_CONTENT_VECTOR],
+            },
+        ),
+        embedding_dim=4,
+    )
+
+    suggestions = find_near_duplicates(Path("unused"), connection=con, similarity_threshold=0.5)
+
+    assert suggestions == ()
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_falls_back_to_detect_connector_for_null_connector_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rows written before `connector_name` was threaded through
+    `source_file_state` (null/empty) are routed via `detect_connector`, the
+    same fallback `disk_accounting.py` uses."""
+    from types import SimpleNamespace
+
+    def fake_detect_connector(path: Path):
+        if path.suffix == ".jsonl" and ".codex" in path.parts:
+            return SimpleNamespace(name="codex")
+        raise ValueError(f"No connector found for {path}")
+
+    monkeypatch.setattr(
+        "searchat.services.dedup_detection.detect_connector", fake_detect_connector
+    )
+
+    con = duckdb.connect(":memory:")
+    _seed_connection(
+        con,
+        conversations=(
+            {
+                "conversation_id": "claude-conv-7",
+                "title": "Null connector_name row",
+                "file_path": "/home/user/.claude/projects/p/conv7.jsonl",
+                "connector_name": "claude",
+                "embeddings": [_SAME_CONTENT_VECTOR],
+            },
+            {
+                "conversation_id": "codex-conv-7",
+                "title": "Null connector_name row",
+                "file_path": "/home/user/.codex/sessions/conv7.jsonl",
+                "connector_name": None,
+                "embeddings": [_SAME_CONTENT_VECTOR],
+            },
+        ),
+        embedding_dim=4,
+    )
+
+    suggestions = find_near_duplicates(Path("unused"), connection=con, similarity_threshold=0.92)
+
+    assert len(suggestions) == 1
+    assert {suggestions[0].connector_a, suggestions[0].connector_b} == {"claude", "codex"}
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_sorts_suggestions_by_similarity_descending() -> None:
+    con = duckdb.connect(":memory:")
+    _seed_connection(
+        con,
+        conversations=(
+            {
+                "conversation_id": "claude-1",
+                "title": "T1",
+                "file_path": "/c1.jsonl",
+                "connector_name": "claude",
+                "embeddings": [[1.0, 0.0, 0.0]],
+            },
+            {
+                "conversation_id": "codex-1",
+                "title": "T1",
+                "file_path": "/x1.jsonl",
+                "connector_name": "codex",
+                "embeddings": [[1.0, 0.0, 0.0]],
+            },
+            {
+                "conversation_id": "claude-2",
+                "title": "T2",
+                "file_path": "/c2.jsonl",
+                "connector_name": "claude",
+                "embeddings": [[0.0, 1.0, 0.0]],
+            },
+            {
+                "conversation_id": "codex-2",
+                "title": "T2",
+                "file_path": "/x2.jsonl",
+                "connector_name": "codex",
+                "embeddings": [[0.1, 0.9, 0.0]],
+            },
+        ),
+        embedding_dim=3,
+    )
+
+    suggestions = find_near_duplicates(Path("unused"), connection=con, similarity_threshold=0.5)
+
+    assert len(suggestions) == 2
+    assert suggestions[0].similarity >= suggestions[1].similarity
+    assert suggestions[0].similarity == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+def test_duplicate_suggestion_to_dict_roundtrips_all_fields() -> None:
+    suggestion = DuplicateSuggestion(
+        conversation_id_a="a",
+        connector_a="claude",
+        title_a="Title A",
+        conversation_id_b="b",
+        connector_b="codex",
+        title_b="Title B",
+        similarity=0.97,
+    )
+
+    assert suggestion.to_dict() == {
+        "conversation_id_a": "a",
+        "connector_a": "claude",
+        "title_a": "Title A",
+        "conversation_id_b": "b",
+        "connector_b": "codex",
+        "title_b": "Title B",
+        "similarity": 0.97,
+    }


### PR DESCRIPTION
## Stack

Position: 1/3 (M11 -- Cross-agent duplicate detection)

1. `feat/m11-dedup-detection-engine` -> this PR
2. `feat/m11-dashboard-surfacing` -> depends on this
3. `feat/m11-mutation-guard` -> depends on #2

## Summary

New `services/dedup_detection.py::find_near_duplicates`: mean-pools each conversation's exchange embeddings (`verbatim_embeddings`, the existing HNSW-backed table) into one L2-normalized vector, then compares vectors pairwise across conversations ingested by two **different** connectors only (cross-agent, not general dedup). A pair whose cosine similarity meets or exceeds `similarity_threshold` is returned as a `DuplicateSuggestion`, most-similar first.

Report-only: every DB call in the module is a `SELECT`; there is no merge/delete code path anywhere here. When no live connection is supplied, the standalone path additionally opens the DB with `read_only=True`.

Threshold wired through the standard `Config` precedence chain: `DedupConfig` (`config/settings.py`), `settings.default.toml`'s `[dedup] similarity_threshold = 0.92`, and a `SEARCHAT_DEDUP_SIMILARITY_THRESHOLD` env override, clamped to `[0.0, 1.0]`.

## Tests

`tests/unit/services/test_dedup_detection.py` (new, 12 tests): the milestone acceptance pair (near-duplicate flagged, distinct pair not flagged), same-connector exclusion, threshold boundary (exactly-at vs. just-below), standalone read-only connection path, missing-database graceful empty result, conversations without embeddings, null-`connector_name` fallback via `detect_connector`, descending-similarity ordering, `to_dict()` round-trip.

## Verification

```
uv run pytest tests/unit/services/test_dedup_detection.py -v --tb=short --no-cov
# 12 passed

uv run pytest -v --tb=short
# 2363 passed, 1 skipped
```

## Preconditions

M6 (disk manager dashboard, PR #105 + #107) already merged to `main`.