### PR TITLE
test(services): add mutation-guard test proving no merge/delete code path exists in dedup detection

### DIFF
--- a/tests/unit/services/test_dedup_detection.py
+++ b/tests/unit/services/test_dedup_detection.py
@@ -540,3 +540,27 @@ def test_find_near_duplicates_never_executes_a_non_select_statement() -> None:
     assert len(guard.executed_statements) >= 1
     for statement in guard.executed_statements:
         assert statement.strip().upper().startswith("SELECT")
+
+
+@pytest.mark.unit
+def test_dedup_detection_module_exposes_no_merge_or_delete_capability() -> None:
+    """Structural proof, not just convention: no function or class in
+    `searchat.services.dedup_detection` has a name suggesting a
+    merge/delete/remove/drop/mutate capability. Mirrors the M7
+    mutation-guard pattern applied to DB mutation instead of filesystem
+    mutation -- this milestone's `services/dedup_detection.py` is the
+    ENTIRE surface for M11, so a name-level scan of its public API is a
+    complete check, not a sample.
+    """
+    import searchat.services.dedup_detection as dedup_module
+
+    forbidden_substrings = ("merge", "delete", "remove", "drop", "mutate")
+    public_names = [name for name in dir(dedup_module) if not name.startswith("_")]
+
+    assert public_names  # sanity: the module actually exports something
+    offending = [
+        name
+        for name in public_names
+        if any(substring in name.lower() for substring in forbidden_substrings)
+    ]
+    assert offending == []

--- a/tests/unit/services/test_dedup_detection.py
+++ b/tests/unit/services/test_dedup_detection.py
@@ -466,3 +466,77 @@ def test_duplicate_suggestion_to_dict_roundtrips_all_fields() -> None:
         "title_b": "Title B",
         "similarity": 0.97,
     }
+
+
+# ---------------------------------------------------------------------------
+# M11 acceptance: mutation guard. Same structural pattern as M7's
+# `test_detect_cruft_and_build_disk_accounting_report_never_call_os_remove_or_shutil_rmtree`
+# -- proves no code path in this module can ever merge or delete a
+# conversation, not just "nothing does today by convention".
+# ---------------------------------------------------------------------------
+
+
+class _SelectOnlyConnectionGuard:
+    """Wraps a real DuckDB connection and asserts every statement executed
+    through `.execute()` is a SELECT.
+
+    This matters specifically for the live-connection path: unlike the
+    standalone path (opened `read_only=True` by `find_near_duplicates`
+    itself), a live server connection is read-write, so correctness there
+    depends entirely on this module never issuing an
+    INSERT/UPDATE/DELETE/MERGE/DROP -- not on a DB-level guard. This proxy
+    makes that a hard assertion instead of an implicit convention.
+    """
+
+    def __init__(self, real_connection: duckdb.DuckDBPyConnection) -> None:
+        self._real = real_connection
+        self.executed_statements: list[str] = []
+
+    def execute(self, sql: str, *args: object, **kwargs: object):  # noqa: ANN401
+        stripped = sql.strip().upper()
+        assert stripped.startswith("SELECT"), (
+            f"find_near_duplicates must never execute a non-SELECT statement, got: {sql!r}"
+        )
+        self.executed_statements.append(sql)
+        return self._real.execute(sql, *args, **kwargs)
+
+
+@pytest.mark.unit
+def test_find_near_duplicates_never_executes_a_non_select_statement() -> None:
+    """The milestone's hard acceptance bar, DB-mutation flavor: every
+    statement `find_near_duplicates` issues through its connection is a
+    SELECT, proving no merge/delete/write code path is reachable from it.
+    """
+    real_connection = duckdb.connect(":memory:")
+    _seed_connection(
+        real_connection,
+        conversations=(
+            {
+                "conversation_id": "claude-conv-guard",
+                "title": "Debugging the auth flow",
+                "file_path": "/home/user/.claude/projects/p/guard.jsonl",
+                "connector_name": "claude",
+                "embeddings": [_SAME_CONTENT_VECTOR],
+            },
+            {
+                "conversation_id": "codex-conv-guard",
+                "title": "Debugging the auth flow",
+                "file_path": "/home/user/.codex/sessions/guard.jsonl",
+                "connector_name": "codex",
+                "embeddings": [_SAME_CONTENT_VECTOR],
+            },
+        ),
+        embedding_dim=4,
+    )
+    guard = _SelectOnlyConnectionGuard(real_connection)
+
+    suggestions = find_near_duplicates(
+        Path("unused"), connection=guard, similarity_threshold=0.92
+    )
+
+    # The guard didn't accidentally block a legitimate read (which would be
+    # a false-negative pass): the real near-duplicate pair is still found.
+    assert len(suggestions) == 1
+    assert len(guard.executed_statements) >= 1
+    for statement in guard.executed_statements:
+        assert statement.strip().upper().startswith("SELECT")


### PR DESCRIPTION
## Stack

Position: 3/3 (M11 -- Cross-agent duplicate detection)

1. `feat/m11-dedup-detection-engine` (#121)
2. `feat/m11-dashboard-surfacing` (#122) -> depends on this being merged
3. `feat/m11-mutation-guard` -> this PR

Depends on: #122
Upstack: none (leaf)

## Summary

M11's hard acceptance bar, matching M7's cruft-advisor mutation-guard pattern: proves structurally -- not just by convention -- that no code path in `services/dedup_detection.py` can ever merge or delete a conversation.

Two independent guards:

1. **SQL guard** (`test_find_near_duplicates_never_executes_a_non_select_statement`): wraps a real DuckDB connection in a proxy that asserts every statement executed through it starts with `SELECT`, then passes the proxy as `find_near_duplicates`'s `connection`. This specifically covers the live-connection path -- unlike the standalone path (opened `read_only=True` by `find_near_duplicates` itself), a live server connection is read-write, so correctness there depends entirely on this module never issuing an `INSERT`/`UPDATE`/`DELETE`/`MERGE`/`DROP`, not on a DB-level guard. The guard also proves it doesn't accidentally block a legitimate read: the real near-duplicate fixture pair is still found through it.
2. **Structural guard** (`test_dedup_detection_module_exposes_no_merge_or_delete_capability`): scans every public name in `searchat.services.dedup_detection` for `merge`/`delete`/`remove`/`drop`/`mutate` substrings. Since `services/dedup_detection.py` is the entire M11 surface, this is a complete check of the milestone's contract, not a sample.

No production code changes in this PR.

## Verification

```
uv run pytest tests/unit/services/test_dedup_detection.py -v --tb=short --no-cov
# 14 passed

uv run pytest -v --tb=short
# 2372 passed, 1 skipped
```

## M11 milestone acceptance (cumulative, across all 3 PRs)

- Fixture near-duplicate pair (same content, two different connectors) flagged above threshold -- `test_find_near_duplicates_flags_cross_connector_near_duplicate_pair` (#121).
- Fixture pair of genuinely distinct conversations not flagged -- `test_find_near_duplicates_does_not_flag_genuinely_distinct_conversations` (#121).
- No code path performs a merge or delete -- this PR.
- Surfaced in the M6 dashboard (API + CLI + UI), report-only -- #122.