### PR TITLE
feat(config): add per-project retention policy schema (M12 1/3)

### DIFF
--- a/src/searchat/config/settings.default.toml
+++ b/src/searchat/config/settings.default.toml
@@ -180,3 +180,21 @@ similarity_threshold = 0.92
 # max_ply_length, min_exchange_chars, prompt, perturn_prompt) default in
 # code (config/constants.py) and are not duplicated here.
 age_threshold_days = 180
+
+[retention]
+# Per-project retention/archival/distillation policy overrides (M12).
+# Optional -- omit entirely (the default) to use only the global
+# defaults above (lifecycle.age_threshold_days for M8's archive/prune,
+# distillation.age_threshold_days for M9's distillation) for every
+# project. Define one block per project id to override:
+#
+# [retention.project."my-project-id"]
+# never_touch = true            # exempt from BOTH M8 and M9 entirely
+# archive_after_days = 90       # overrides lifecycle.age_threshold_days
+# distill_after_days = 365      # overrides distillation.age_threshold_days
+#
+# Every key is optional; an omitted key falls back to the global
+# default for that milestone. A malformed block (unrecognized key,
+# non-boolean never_touch, non-integer or negative day count) fails
+# CLOSED -- that project is treated as never_touch = true rather than
+# silently falling back to the global default.

--- a/src/searchat/config/settings.py
+++ b/src/searchat/config/settings.py
@@ -894,6 +894,120 @@ class DedupConfig:
         )
 
 
+@dataclass(frozen=True)
+class ProjectRetentionPolicy:
+    """One ``[retention.project."<project_id>"]`` block (M12): per-project
+    overrides for M8's archive/prune age gate and M9's distillation age
+    gate, plus a ``never_touch`` short-circuit that exempts every one of
+    that project's source files/conversations from BOTH milestones'
+    candidate-selection queries regardless of age.
+
+    A ``None`` threshold field means "no override for this milestone" --
+    the caller falls back to its own global default
+    (``lifecycle.age_threshold_days`` for M8,
+    ``distillation.age_threshold_days`` for M9), never to a value
+    hardcoded here.
+    """
+
+    never_touch: bool = False
+    archive_after_days: int | None = None
+    distill_after_days: int | None = None
+
+
+_RETENTION_PROJECT_ALLOWED_KEYS = frozenset(
+    {"never_touch", "archive_after_days", "distill_after_days"}
+)
+
+
+def _parse_project_retention_policy(block: object) -> ProjectRetentionPolicy | None:
+    """Parse one raw ``[retention.project."<id>"]`` TOML table into a
+    `ProjectRetentionPolicy`, or `None` when it is malformed: not a
+    table, an unrecognized key, or a wrong-typed/negative value.
+
+    `None` is a deliberate, distinct outcome from "no override" --
+    `RetentionConfig.from_dict` records it in `invalid_project_ids` so
+    `RetentionConfig.resolve` can fail closed (never_touch) instead of
+    silently falling through to the global default. This is the M12
+    fail-closed contract: any parse ambiguity resolves to "do not
+    touch," never to "use the global default as if unset."
+    """
+    if not isinstance(block, dict):
+        return None
+    if not set(block.keys()) <= _RETENTION_PROJECT_ALLOWED_KEYS:
+        return None
+
+    never_touch = block.get("never_touch", False)
+    if not isinstance(never_touch, bool):
+        return None
+
+    parsed_days: dict[str, int | None] = {}
+    for key in ("archive_after_days", "distill_after_days"):
+        if key not in block:
+            parsed_days[key] = None
+            continue
+        value = block[key]
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            return None
+        parsed_days[key] = value
+
+    return ProjectRetentionPolicy(
+        never_touch=never_touch,
+        archive_after_days=parsed_days["archive_after_days"],
+        distill_after_days=parsed_days["distill_after_days"],
+    )
+
+
+@dataclass(frozen=True)
+class RetentionConfig:
+    """``[retention]`` section (M12): per-project policy overrides
+    consulted by `services/source_lifecycle.py` (M8) and
+    `services/distillation_bridge.py` (M9) before either milestone's own
+    global-default age threshold. Unrelated to `BackupConfig`'s backup
+    retention pruning (M4) -- this is source-conversation lifecycle
+    policy, not backup lifecycle policy.
+
+    A project with no ``[retention.project."<id>"]`` block resolves to
+    `None` via `resolve()`: callers use their own global default. A
+    project whose block failed to parse resolves instead to a
+    ``never_touch=True`` sentinel -- never to `None` -- so a malformed
+    block can only make a milestone do LESS to that project, never fall
+    through to acting on the global default as if nothing were
+    configured.
+    """
+
+    projects: dict[str, ProjectRetentionPolicy]
+    invalid_project_ids: frozenset[str]
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "RetentionConfig":
+        raw_projects = data.get("project", {})
+        if not isinstance(raw_projects, dict):
+            return cls(projects={}, invalid_project_ids=frozenset())
+
+        projects: dict[str, ProjectRetentionPolicy] = {}
+        invalid: set[str] = set()
+        for project_id, block in raw_projects.items():
+            if not isinstance(project_id, str) or not project_id:
+                continue
+            parsed = _parse_project_retention_policy(block)
+            if parsed is None:
+                invalid.add(project_id)
+            else:
+                projects[project_id] = parsed
+        return cls(projects=projects, invalid_project_ids=frozenset(invalid))
+
+    def resolve(self, project_id: str | None) -> ProjectRetentionPolicy | None:
+        """The effective policy for `project_id`, or `None` when the
+        caller should fall back to its own global default. Never `None`
+        for a project with a malformed block -- see the class docstring.
+        """
+        if not project_id:
+            return None
+        if project_id in self.invalid_project_ids:
+            return ProjectRetentionPolicy(never_touch=True)
+        return self.projects.get(project_id)
+
+
 @dataclass
 class ExpertiseConfig:
     enabled: bool
@@ -1136,6 +1250,7 @@ class Config:
     palace: PalaceConfig
     lifecycle: LifecycleConfig
     dedup: DedupConfig
+    retention: RetentionConfig
 
     @classmethod
     def load(cls, config_path: Path | None = None) -> "Config":
@@ -1225,4 +1340,5 @@ class Config:
             palace=PalaceConfig.from_dict(data.get("palace", {})),
             lifecycle=LifecycleConfig.from_dict(data.get("lifecycle", {})),
             dedup=DedupConfig.from_dict(data.get("dedup", {})),
+            retention=RetentionConfig.from_dict(data.get("retention", {})),
         )

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -82,6 +82,57 @@ class TestRetentionConfig:
         assert policy is not None
         assert policy.never_touch is True
 
+    def test_malformed_block_unknown_key_fails_closed_to_never_touch(self) -> None:
+        """An unrecognized key is ambiguous -- M12's contract is that this
+        resolves to never_touch=True, never to silently dropping the
+        unknown key and falling through to the global default."""
+        from searchat.config.settings import RetentionConfig
+
+        config = RetentionConfig.from_dict(
+            {"project": {"proj-a": {"archive_after_dyas": 30}}}
+        )
+        policy = config.resolve("proj-a")
+        assert policy is not None
+        assert policy.never_touch is True
+
+    def test_malformed_block_non_bool_never_touch_fails_closed(self) -> None:
+        from searchat.config.settings import RetentionConfig
+
+        config = RetentionConfig.from_dict(
+            {"project": {"proj-a": {"never_touch": "yes"}}}
+        )
+        policy = config.resolve("proj-a")
+        assert policy is not None
+        assert policy.never_touch is True
+
+    def test_malformed_block_negative_day_count_fails_closed(self) -> None:
+        from searchat.config.settings import RetentionConfig
+
+        config = RetentionConfig.from_dict(
+            {"project": {"proj-a": {"archive_after_days": -1}}}
+        )
+        policy = config.resolve("proj-a")
+        assert policy is not None
+        assert policy.never_touch is True
+
+    def test_malformed_block_non_integer_day_count_fails_closed(self) -> None:
+        from searchat.config.settings import RetentionConfig
+
+        config = RetentionConfig.from_dict(
+            {"project": {"proj-a": {"distill_after_days": "soon"}}}
+        )
+        policy = config.resolve("proj-a")
+        assert policy is not None
+        assert policy.never_touch is True
+
+    def test_malformed_block_not_a_table_fails_closed(self) -> None:
+        from searchat.config.settings import RetentionConfig
+
+        config = RetentionConfig.from_dict({"project": {"proj-a": "not-a-table"}})
+        policy = config.resolve("proj-a")
+        assert policy is not None
+        assert policy.never_touch is True
+
     def test_non_dict_project_section_yields_empty_config(self) -> None:
         from searchat.config.settings import RetentionConfig
 

--- a/tests/unit/config/test_settings.py
+++ b/tests/unit/config/test_settings.py
@@ -22,3 +22,91 @@ class TestConfigLoad:
         config = Config.load()
         assert config is not None
         assert config.paths is not None
+
+
+class TestRetentionConfig:
+    """Tests for `RetentionConfig` (M12): per-project retention policy
+    schema, validation, and the fail-closed contract for malformed
+    blocks.
+    """
+
+    def test_no_project_blocks_resolves_to_none_for_any_project(self) -> None:
+        from searchat.config.settings import RetentionConfig
+
+        config = RetentionConfig.from_dict({})
+        assert config.resolve("any-project") is None
+
+    def test_resolve_with_none_project_id_returns_none(self) -> None:
+        from searchat.config.settings import RetentionConfig
+
+        config = RetentionConfig.from_dict(
+            {"project": {"proj-a": {"never_touch": True}}}
+        )
+        assert config.resolve(None) is None
+        assert config.resolve("") is None
+
+    def test_project_override_parses_all_fields(self) -> None:
+        from searchat.config.settings import ProjectRetentionPolicy, RetentionConfig
+
+        config = RetentionConfig.from_dict(
+            {
+                "project": {
+                    "proj-a": {
+                        "never_touch": False,
+                        "archive_after_days": 90,
+                        "distill_after_days": 365,
+                    }
+                }
+            }
+        )
+        policy = config.resolve("proj-a")
+        assert policy == ProjectRetentionPolicy(
+            never_touch=False, archive_after_days=90, distill_after_days=365
+        )
+
+    def test_project_not_configured_resolves_to_none(self) -> None:
+        from searchat.config.settings import RetentionConfig
+
+        config = RetentionConfig.from_dict(
+            {"project": {"proj-a": {"never_touch": True}}}
+        )
+        assert config.resolve("proj-b") is None
+
+    def test_never_touch_project_resolves_never_touch_true(self) -> None:
+        from searchat.config.settings import RetentionConfig
+
+        config = RetentionConfig.from_dict(
+            {"project": {"proj-a": {"never_touch": True}}}
+        )
+        policy = config.resolve("proj-a")
+        assert policy is not None
+        assert policy.never_touch is True
+
+    def test_non_dict_project_section_yields_empty_config(self) -> None:
+        from searchat.config.settings import RetentionConfig
+
+        config = RetentionConfig.from_dict({"project": "not-a-table"})
+        assert config.resolve("proj-a") is None
+
+    def test_two_projects_with_independent_overrides(self) -> None:
+        """Fixture matching M12's acceptance criterion: two projects on
+        different thresholds, independently resolved."""
+        from searchat.config.settings import RetentionConfig
+
+        config = RetentionConfig.from_dict(
+            {
+                "project": {
+                    "proj-fast": {"distill_after_days": 7},
+                    "proj-slow": {"distill_after_days": 400},
+                }
+            }
+        )
+        assert config.resolve("proj-fast").distill_after_days == 7
+        assert config.resolve("proj-slow").distill_after_days == 400
+
+    def test_config_load_includes_retention_section(self) -> None:
+        from searchat.config.settings import RetentionConfig
+
+        config = Config.load()
+        assert isinstance(config.retention, RetentionConfig)
+        assert config.retention.resolve("any-project") is None


### PR DESCRIPTION
## Stack

Position: 1/3 (M12 -- Per-project retention policies)

1. `feat/m12-retention-policy-schema` -> this PR
2. `feat/m12-source-lifecycle-consumption` -> depends on this being merged
3. `feat/m12-distillation-consumption` -> depends on #2

Depends on: none (root)
Upstack: feat/m12-source-lifecycle-consumption

## Summary

M12's schema layer: `config/settings.py` gains `RetentionConfig` / `ProjectRetentionPolicy` for `[retention.project."<project_id>"]` blocks (`distill_after_days`, `archive_after_days`, `never_touch`), wired into `Config.load()` as `config.retention`.

No consumer changes in this PR -- `services/source_lifecycle.py` (M8) and `services/distillation_bridge.py` (M9) still use only their own global defaults. The next two PRs in this stack wire `RetentionConfig.resolve()` into each milestone's candidate-selection queries.

**Fail-closed contract:** a project's block that fails to parse (unrecognized key, non-boolean `never_touch`, negative/non-integer day count, or a non-table value) resolves to `never_touch=True` via `RetentionConfig.resolve()" -- never to "no override" (which would let the global default apply). This is enforced structurally in `_parse_project_retention_policy`/`RetentionConfig.resolve`, not by caller discipline.

## Preconditions (per the M12 objective)

M8 and M9 are both already merged into `main` as of this stack (source-lifecycle-prune-tombstone and m9-benchmark-and-recall-tests PRs), so PR-2 and PR-3 in this stack consume the real `services/source_lifecycle.py`/`services/distillation_bridge.py`, not stubs.

## Tests

- `tests/unit/config/test_settings.py::TestRetentionConfig` (13 new tests): no-override resolution, full field parsing, per-project independence, and 5 malformed-block fail-closed cases.

## Verification

```
uv run pytest tests/unit/config/test_settings.py -v --tb=short --no-cov -k retention
# 13 passed
```