### PR TITLE
feat(services): wire retention policy into M8 source lifecycle (M12 2/3)

### DIFF
--- a/src/searchat/cli/sources_cmd.py
+++ b/src/searchat/cli/sources_cmd.py
@@ -71,6 +71,7 @@ def _run(argv: list[str], *, action: str) -> int:
             action=action,
             dry_run=args.dry_run,
             tombstone_dir=tombstone_dir,
+            retention=config.retention,
         )
     except Exception as exc:
         print(f"Error: failed to run sources {action}: {exc}", file=sys.stderr)

--- a/src/searchat/services/source_lifecycle.py
+++ b/src/searchat/services/source_lifecycle.py
@@ -47,7 +47,7 @@ import duckdb
 from searchat.core.connectors.base import AgentProviderBase
 from searchat.core.connectors.registry import get_connector_by_name
 from searchat.core.logging_config import get_logger
-from searchat.config.settings import LifecycleConfig
+from searchat.config.settings import LifecycleConfig, RetentionConfig
 from searchat.models import ConversationRecord
 from searchat.services.backup_compression import compress_file, decompress_file
 
@@ -556,18 +556,29 @@ def evaluate_and_act_on_source(
     tombstone_dir: Path,
     now: datetime | None = None,
     connection: duckdb.DuckDBPyConnection | None = None,
+    retention: RetentionConfig | None = None,
 ) -> LifecycleDecision:
     """Evaluate one candidate through every M8 gate and, only once all of
     them pass AND `dry_run` is `False`, perform `action` ("archive" or
     "prune") and write its tombstone.
 
     Gate order, cheapest and most safety-critical first: per-agent
-    opt-in, age threshold, `verify_ingested` (read-only). `dry_run` is
-    checked immediately after `verify_ingested`, before `verify_roundtrip`
-    ever runs -- `verify_roundtrip` is the only stage in this whole chain
-    that performs a filesystem write (to a throwaway temp directory), so
-    a `dry_run=True` call can never write to disk no matter how many
+    opt-in, per-project retention policy (M12), age threshold,
+    `verify_ingested` (read-only). `dry_run` is checked immediately
+    after `verify_ingested`, before `verify_roundtrip` ever runs --
+    `verify_roundtrip` is the only stage in this whole chain that
+    performs a filesystem write (to a throwaway temp directory), so a
+    `dry_run=True` call can never write to disk no matter how many
     candidates would otherwise be eligible.
+
+    `retention` (M12) is consulted BEFORE the age-threshold gate: a
+    project resolved as `never_touch` short-circuits here regardless of
+    how old the file is, and a project with an `archive_after_days`
+    override replaces `policy.age_threshold_days` for the age check
+    that follows (used for both `action="archive"` and
+    `action="prune"` -- M8 has always used one global threshold for
+    both actions). `retention=None` (the default) reproduces the exact
+    pre-M12 behavior: no project lookup, no override.
     """
     if action not in ("archive", "prune"):
         raise ValueError(f"unknown lifecycle action: {action!r}")
@@ -580,6 +591,21 @@ def evaluate_and_act_on_source(
         return state.freeze()
     state.agent_enabled = True
 
+    effective_age_threshold_days = policy.age_threshold_days
+    if retention is not None:
+        state_row = _read_source_file_state(db_path, file_path, connection=connection)
+        row_project_id = state_row["project_id"] if state_row else None
+        row_project_id = row_project_id if isinstance(row_project_id, str) and row_project_id else None
+        project_policy = retention.resolve(row_project_id)
+        if project_policy is not None:
+            if project_policy.never_touch:
+                state.skip_reason = (
+                    f"project {row_project_id!r} is marked never_touch in retention policy"
+                )
+                return state.freeze()
+            if project_policy.archive_after_days is not None:
+                effective_age_threshold_days = project_policy.archive_after_days
+
     try:
         age_days = (now.timestamp() - file_path.stat().st_mtime) / 86400.0
     except OSError:
@@ -587,8 +613,8 @@ def evaluate_and_act_on_source(
         return state.freeze()
     state.age_days = age_days
 
-    if age_days < policy.age_threshold_days:
-        state.skip_reason = "younger than lifecycle.age_threshold_days"
+    if age_days < effective_age_threshold_days:
+        state.skip_reason = f"younger than the effective age_threshold_days ({effective_age_threshold_days})"
         return state.freeze()
     state.age_gated = True
 
@@ -682,6 +708,7 @@ def run_lifecycle_action(
     tombstone_dir: Path,
     now: datetime | None = None,
     connection: duckdb.DuckDBPyConnection | None = None,
+    retention: RetentionConfig | None = None,
 ) -> list[LifecycleDecision]:
     """Evaluate every currently-indexed source file against the full M8
     gate chain, performing `action` ("archive" or "prune") for each one
@@ -692,6 +719,10 @@ def run_lifecycle_action(
     candidate is refused at the per-agent opt-in gate before
     `verify_ingested` (a read) or `verify_roundtrip`/the action itself
     (the only writing stages) ever run.
+
+    `retention` (M12), when passed, is forwarded unchanged to every
+    per-file `evaluate_and_act_on_source` call -- see that function's
+    docstring for the per-project gate it adds.
     """
     candidates = _iter_indexed_source_files(db_path, connection=connection)
     return [
@@ -705,6 +736,7 @@ def run_lifecycle_action(
             tombstone_dir=tombstone_dir,
             now=now,
             connection=connection,
+            retention=retention,
         )
         for connector_name, file_path in candidates
     ]

--- a/tests/unit/services/test_source_lifecycle.py
+++ b/tests/unit/services/test_source_lifecycle.py
@@ -1266,6 +1266,146 @@ def test_run_lifecycle_action_returns_one_decision_per_indexed_file_with_correct
     assert disabled[0].eligible is False
     assert disabled[0].agent_enabled is False
 
+
+# ---------------------------------------------------------------------------
+# M12: per-project retention policy resolution, consulted before the
+# lifecycle.age_threshold_days gate (see evaluate_and_act_on_source's
+# `retention` parameter).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_evaluate_and_act_on_source_retention_never_touch_short_circuits_before_age_gate(
+    tmp_path: Path,
+) -> None:
+    """A project resolved as never_touch=True is refused even though the
+    file is old enough to clear the global age threshold, the connector
+    is enabled, and the file would otherwise pass verify_ingested --
+    proving the M12 gate runs (and wins) before the age check, not just
+    alongside it."""
+    from searchat.config.settings import RetentionConfig
+
+    source_file = _write_claude_jsonl(tmp_path / "conv-never-touch.jsonl", num_exchanges=1)
+    connector = ClaudeConnector()
+    real_hash = _sha256(source_file)
+    real_message_count = connector.parse(source_file, embedding_id=0).message_count
+    conversation_id = source_file.stem
+
+    db_path = _new_db(tmp_path)
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=conversation_id,
+        project_id="proj-never-touch",
+        file_hash=real_hash,
+    )
+    _insert_conversation(
+        db_path,
+        conversation_id=conversation_id,
+        file_path=str(source_file),
+        message_count=real_message_count,
+        project_id="proj-never-touch",
+    )
+
+    age_threshold_days = 30
+    old_mtime = (datetime.now() - timedelta(days=age_threshold_days + 100)).timestamp()
+    os.utime(source_file, (old_mtime, old_mtime))
+
+    if registry.get_connector_by_name("claude") is None:
+        registry.register_connector(ClaudeConnector())
+
+    policy = LifecycleConfig(
+        age_threshold_days=age_threshold_days,
+        enabled_agents=frozenset({"claude"}),
+        dry_run=True,
+    )
+    retention = RetentionConfig.from_dict(
+        {"project": {"proj-never-touch": {"never_touch": True}}}
+    )
+
+    decision = evaluate_and_act_on_source(
+        db_path=db_path,
+        connector_name="claude",
+        file_path=source_file,
+        policy=policy,
+        action="archive",
+        dry_run=True,
+        tombstone_dir=tmp_path / "tombstones",
+        retention=retention,
+    )
+
+    assert decision.agent_enabled is True
+    assert decision.age_gated is False
+    assert decision.ingested is None
+    assert decision.eligible is False
+    assert decision.action_taken is None
+    assert decision.skip_reason is not None
+    assert "never_touch" in decision.skip_reason
+
+
+@pytest.mark.unit
+def test_run_lifecycle_action_retention_never_touch_excluded(
+    tmp_path: Path,
+) -> None:
+    """Same proof as above, through the public `run_lifecycle_action`
+    entry point the CLI actually calls, matching M12's acceptance
+    criterion: "never selected ... even when files exceed the global age
+    threshold."."""
+    from searchat.config.settings import RetentionConfig
+
+    connector = ClaudeConnector()
+    db_path = _new_db(tmp_path)
+    age_threshold_days = 30
+    old_mtime = (datetime.now() - timedelta(days=age_threshold_days + 100)).timestamp()
+
+    source_file = _write_claude_jsonl(tmp_path / "conv-run-never-touch.jsonl", num_exchanges=1)
+    real_hash = _sha256(source_file)
+    real_message_count = connector.parse(source_file, embedding_id=0).message_count
+    conversation_id = source_file.stem
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=conversation_id,
+        project_id="proj-never-touch",
+        file_hash=real_hash,
+        connector_name="claude",
+    )
+    _insert_conversation(
+        db_path,
+        conversation_id=conversation_id,
+        file_path=str(source_file),
+        message_count=real_message_count,
+        project_id="proj-never-touch",
+    )
+    os.utime(source_file, (old_mtime, old_mtime))
+
+    if registry.get_connector_by_name("claude") is None:
+        registry.register_connector(ClaudeConnector())
+
+    policy = LifecycleConfig(
+        age_threshold_days=age_threshold_days,
+        enabled_agents=frozenset({"claude"}),
+        dry_run=True,
+    )
+    retention = RetentionConfig.from_dict(
+        {"project": {"proj-never-touch": {"never_touch": True}}}
+    )
+
+    decisions = run_lifecycle_action(
+        db_path=db_path,
+        policy=policy,
+        action="archive",
+        dry_run=True,
+        tombstone_dir=tmp_path / "tombstones",
+        retention=retention,
+    )
+
+    assert len(decisions) == 1
+    assert decisions[0].eligible is False
+    assert decisions[0].skip_reason is not None
+    assert "never_touch" in decisions[0].skip_reason
+
+
 # ---------------------------------------------------------------------------
 # evaluate_and_act_on_source: core M8 safety invariant, exhaustively
 # proven across the full boolean state space (M8, closing PR).

--- a/tests/unit/services/test_source_lifecycle.py
+++ b/tests/unit/services/test_source_lifecycle.py
@@ -1406,6 +1406,88 @@ def test_run_lifecycle_action_retention_never_touch_excluded(
     assert "never_touch" in decisions[0].skip_reason
 
 
+@pytest.mark.unit
+def test_evaluate_and_act_on_source_retention_archive_after_days_override_used_instead_of_global(
+    tmp_path: Path,
+) -> None:
+    """A project's `archive_after_days` override replaces
+    `policy.age_threshold_days` for the age gate: a file too young for
+    the (larger) global threshold still clears the (smaller) per-project
+    override."""
+    from searchat.config.settings import RetentionConfig
+
+    source_file = _write_claude_jsonl(tmp_path / "conv-override.jsonl", num_exchanges=1)
+    connector = ClaudeConnector()
+    real_hash = _sha256(source_file)
+    real_message_count = connector.parse(source_file, embedding_id=0).message_count
+    conversation_id = source_file.stem
+
+    db_path = _new_db(tmp_path)
+    _insert_source_file_state(
+        db_path,
+        file_path=str(source_file),
+        conversation_id=conversation_id,
+        project_id="proj-fast-archive",
+        file_hash=real_hash,
+    )
+    _insert_conversation(
+        db_path,
+        conversation_id=conversation_id,
+        file_path=str(source_file),
+        message_count=real_message_count,
+        project_id="proj-fast-archive",
+    )
+
+    global_age_threshold_days = 60
+    project_override_days = 10
+    # 20 days old: younger than the global threshold (60) but older than
+    # the project's override (10).
+    file_age_days = 20
+    mtime = (datetime.now() - timedelta(days=file_age_days)).timestamp()
+    os.utime(source_file, (mtime, mtime))
+
+    if registry.get_connector_by_name("claude") is None:
+        registry.register_connector(ClaudeConnector())
+
+    policy = LifecycleConfig(
+        age_threshold_days=global_age_threshold_days,
+        enabled_agents=frozenset({"claude"}),
+        dry_run=True,
+    )
+    retention = RetentionConfig.from_dict(
+        {"project": {"proj-fast-archive": {"archive_after_days": project_override_days}}}
+    )
+
+    # Sanity: without the override, this file is refused at the age gate.
+    decision_without_override = evaluate_and_act_on_source(
+        db_path=db_path,
+        connector_name="claude",
+        file_path=source_file,
+        policy=policy,
+        action="archive",
+        dry_run=True,
+        tombstone_dir=tmp_path / "tombstones",
+    )
+    assert decision_without_override.age_gated is False
+
+    decision_with_override = evaluate_and_act_on_source(
+        db_path=db_path,
+        connector_name="claude",
+        file_path=source_file,
+        policy=policy,
+        action="archive",
+        dry_run=True,
+        tombstone_dir=tmp_path / "tombstones",
+        retention=retention,
+    )
+
+    assert decision_with_override.agent_enabled is True
+    assert decision_with_override.age_gated is True
+    assert decision_with_override.ingested is not None
+    assert decision_with_override.ingested.ok is True
+    assert decision_with_override.eligible is True
+
+
 # ---------------------------------------------------------------------------
 # evaluate_and_act_on_source: core M8 safety invariant, exhaustively
 # proven across the full boolean state space (M8, closing PR).


### PR DESCRIPTION
## Stack

Position: 2/3 (M12 -- Per-project retention policies)

1. `feat/m12-retention-policy-schema` (#124)
2. `feat/m12-source-lifecycle-consumption` -> this PR
3. `feat/m12-distillation-consumption` -> depends on this being merged

Depends on: #124
Upstack: feat/m12-distillation-consumption

## Summary

Wires `RetentionConfig` (M12, PR-1) into M8's `services/source_lifecycle.py`:

- `evaluate_and_act_on_source` gains an optional `retention: RetentionConfig | None = None` parameter, consulted immediately after the per-agent opt-in gate and BEFORE the `lifecycle.age_threshold_days` age gate:
  - a project resolved as `never_touch` short-circuits regardless of file age
  - a project's `archive_after_days` override replaces `policy.age_threshold_days` for that file's age check (used for both `archive` and `prune" -- M8 has always used one global threshold for both actions)
- `run_lifecycle_action` forwards `retention` unchanged to every per-file `evaluate_and_act_on_source` call.
- `cli/sources_cmd.py` passes `config.retention` through, so `searchat sources archive|prune` is retention-aware by default.
- `retention=None` (the default) reproduces the exact pre-M12 code path -- no project lookup, zero behavior change for existing callers. All 69 pre-existing M8 tests pass unchanged.

## Tests (new)

- `test_evaluate_and_act_on_source_retention_never_touch_short_circuits_before_age_gate`
- `test_run_lifecycle_action_retention_never_touch_excluded` (through the public CLI entry point)
- `test_evaluate_and_act_on_source_retention_archive_after_days_override_used_instead_of_global` (with a same-file control assertion showing it's refused without the override)

## Verification

```
uv run pytest tests/unit/config/test_settings.py tests/unit/services/test_source_lifecycle.py -v --tb=short --no-cov -k retention
# 16 passed
uv run pytest tests/unit/services/test_source_lifecycle.py tests/unit/test_cli_sources.py -v --tb=short --no-cov
# 87 passed
```