### PR TITLE
feat(services): wire retention policy into M9 distillation bridge (M12 3/3)

### DIFF
--- a/src/searchat/services/distillation_bridge.py
+++ b/src/searchat/services/distillation_bridge.py
@@ -54,7 +54,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from searchat.config.settings import Config
+from searchat.config.settings import Config, RetentionConfig
 from searchat.core.logging_config import get_logger
 from searchat.core.progress import NullProgressAdapter
 from searchat.core.unified_indexer import UnifiedIndexer, _segment_exchanges
@@ -153,27 +153,58 @@ def select_distillation_candidates(
     *,
     age_threshold_days: int,
     now: datetime | None = None,
+    retention: RetentionConfig | None = None,
 ) -> list[str]:
     """Conversation ids eligible for distillation: `updated_at` older than
     `age_threshold_days` AND still present in the hot index (at least one
     `exchanges` row). Already-evicted conversations are structurally
     excluded -- they have zero exchange rows -- making repeated calls
     naturally idempotent without consulting palace state at all.
+
+    `retention` (M12), when passed, is consulted per-conversation BEFORE
+    `age_threshold_days`: a conversation whose project resolves to
+    `never_touch` is excluded outright, and a project's
+    `distill_after_days` override replaces `age_threshold_days` for
+    that conversation's cutoff. `retention=None` (the default)
+    reproduces the exact pre-M12 code path (a single SQL-side cutoff,
+    no per-row project lookup).
     """
     now = now or datetime.now()
-    cutoff = now - timedelta(days=age_threshold_days)
     cur = storage.connection.cursor()
     try:
+        if retention is None:
+            cutoff = now - timedelta(days=age_threshold_days)
+            rows = cur.execute(
+                "SELECT DISTINCT c.conversation_id FROM conversations c "
+                "JOIN exchanges e ON e.conversation_id = c.conversation_id "
+                "WHERE c.updated_at < ? "
+                "ORDER BY c.conversation_id",
+                [cutoff],
+            ).fetchall()
+            return [row[0] for row in rows]
+
         rows = cur.execute(
-            "SELECT DISTINCT c.conversation_id FROM conversations c "
+            "SELECT DISTINCT c.conversation_id, c.project_id, c.updated_at "
+            "FROM conversations c "
             "JOIN exchanges e ON e.conversation_id = c.conversation_id "
-            "WHERE c.updated_at < ? "
             "ORDER BY c.conversation_id",
-            [cutoff],
         ).fetchall()
-        return [row[0] for row in rows]
     finally:
         cur.close()
+
+    candidates: list[str] = []
+    for conversation_id, project_id, updated_at in rows:
+        resolved_project_id = project_id if isinstance(project_id, str) and project_id else None
+        project_policy = retention.resolve(resolved_project_id)
+        threshold_days = age_threshold_days
+        if project_policy is not None:
+            if project_policy.never_touch:
+                continue
+            if project_policy.distill_after_days is not None:
+                threshold_days = project_policy.distill_after_days
+        if updated_at < now - timedelta(days=threshold_days):
+            candidates.append(conversation_id)
+    return candidates
 
 
 # ---------------------------------------------------------------------------
@@ -422,6 +453,7 @@ def run_tiering_cycle(
         storage,
         age_threshold_days=config.distillation.age_threshold_days,
         now=now,
+        retention=config.retention,
     )
     if not candidates:
         return TieringCycleStats(0, 0, 0, 0, 0, palace_unavailable=False)

--- a/tests/unit/services/test_distillation_bridge.py
+++ b/tests/unit/services/test_distillation_bridge.py
@@ -202,6 +202,46 @@ class TestSelectDistillationCandidates:
         )
         assert candidates == ["a-conv", "b-conv"]
 
+    def test_retention_never_touch_project_excluded_even_when_older_than_global_threshold(
+        self, storage: UnifiedStorage
+    ) -> None:
+        """M12: a conversation whose project resolves to never_touch is
+        excluded outright, even though it is far older than
+        age_threshold_days -- a sibling conversation in a different
+        project is still selected, proving the exclusion is
+        project-specific, not a side effect of passing `retention`."""
+        from searchat.config.settings import RetentionConfig
+
+        now = datetime(2026, 1, 1)
+        never_touch_messages = _make_messages(1)
+        _insert_conversation(
+            storage,
+            conversation_id="never-touch-conv",
+            project_id="proj-never-touch",
+            updated_at=now - timedelta(days=400),
+            messages=never_touch_messages,
+        )
+        _seed_hot_exchanges(storage, "never-touch-conv", "proj-never-touch", never_touch_messages)
+
+        other_messages = _make_messages(1)
+        _insert_conversation(
+            storage,
+            conversation_id="other-conv",
+            project_id="proj-1",
+            updated_at=now - timedelta(days=400),
+            messages=other_messages,
+        )
+        _seed_hot_exchanges(storage, "other-conv", "proj-1", other_messages)
+
+        retention = RetentionConfig.from_dict(
+            {"project": {"proj-never-touch": {"never_touch": True}}}
+        )
+        candidates = distillation_bridge.select_distillation_candidates(
+            storage, age_threshold_days=180, now=now, retention=retention,
+        )
+        assert candidates == ["other-conv"]
+
+
 
 # ---------------------------------------------------------------------------
 # 2. Distillate generation

--- a/tests/unit/services/test_distillation_bridge.py
+++ b/tests/unit/services/test_distillation_bridge.py
@@ -241,6 +241,41 @@ class TestSelectDistillationCandidates:
         )
         assert candidates == ["other-conv"]
 
+    def test_retention_project_distill_after_days_override_used_instead_of_global(
+        self, storage: UnifiedStorage
+    ) -> None:
+        """M12: a project's distill_after_days override replaces
+        age_threshold_days for that project's conversations -- a
+        conversation too young for the (larger) global threshold is
+        still selected once the (smaller) per-project override applies,
+        and is NOT selected without the override present."""
+        from searchat.config.settings import RetentionConfig
+
+        now = datetime(2026, 1, 1)
+        messages = _make_messages(1)
+        # 10 days old: younger than the global threshold (180) but older
+        # than the project's override (5).
+        _insert_conversation(
+            storage,
+            conversation_id="fast-distill-conv",
+            project_id="proj-fast-distill",
+            updated_at=now - timedelta(days=10),
+            messages=messages,
+        )
+        _seed_hot_exchanges(storage, "fast-distill-conv", "proj-fast-distill", messages)
+
+        without_override = distillation_bridge.select_distillation_candidates(
+            storage, age_threshold_days=180, now=now,
+        )
+        assert without_override == []
+
+        retention = RetentionConfig.from_dict(
+            {"project": {"proj-fast-distill": {"distill_after_days": 5}}}
+        )
+        with_override = distillation_bridge.select_distillation_candidates(
+            storage, age_threshold_days=180, now=now, retention=retention,
+        )
+        assert with_override == ["fast-distill-conv"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stack

Position: 3/3 (M12 -- Per-project retention policies)

1. `feat/m12-retention-policy-schema` (#124)
2. `feat/m12-source-lifecycle-consumption` (#125)
3. `feat/m12-distillation-consumption` -> this PR

Depends on: #125
Upstack: none (leaf)

## Summary

Wires `RetentionConfig` (M12, PR-1) into M9's `services/distillation_bridge.py`:

- `select_distillation_candidates` gains an optional `retention: RetentionConfig | None = None` parameter. When passed, each conversation's project is resolved BEFORE `distillation.age_threshold_days`: a `never_touch` project is excluded outright, and a project's `distill_after_days` override replaces the global threshold for that conversation's cutoff.
  - `retention=None` (the default) keeps the exact pre-M12 code path: a single SQL-side `WHERE c.updated_at < ?` cutoff, no per-row project lookup or Python-side filtering.
  - `retention" not `None`: fetches `(conversation_id, project_id, updated_at)` for every hot-indexed conversation and resolves each row's effective threshold in Python (no way to express a per-project SQL predicate without a join to a policy table that doesn't exist).
- `run_tiering_cycle` passes `config.retention` through, so the M9 tiering pass is retention-aware by default.

**Note:** M9 (`feat/m9-*`) was already merged into `main` before this stack started, so this PR consumes the real `distillation_bridge.py` -- not a stub interface, and needs no re-verification once M9 "lands" (it already has).

All 20 pre-existing M9 tests pass unchanged.

## Tests (new)

- `test_retention_never_touch_project_excluded_even_when_older_than_global_threshold` (with a sibling conversation in a different project still selected, proving the exclusion is project-specific)
- `test_retention_project_distill_after_days_override_used_instead_of_global` (with a control assertion showing the same conversation is not selected without the override)

## Verification

```
uv run pytest tests/unit/services/test_distillation_bridge.py -v --tb=short --no-cov -k retention
# 2 passed
uv run pytest tests/unit/services/test_distillation_bridge.py -q --no-cov
# 22 passed
```

## M12 cumulative acceptance (this PR closes the stack)

- `never_touch=true` is never selected by M8's or M9's candidate-selection queries even when files/conversations exceed the global age threshold -- covered by PR-2 and this PR's never_touch tests.
- A project with an explicit `distill_after_days`/`archive_after_days` override uses that value instead of the global default -- covered by PR-2 and this PR's override tests.
- A malformed policy block fails closed (disables lifecycle actions for that project) -- covered by PR-1's 5 malformed-block tests; M8/M9 inherit this via `RetentionConfig.resolve()`, which never returns "no override" for a malformed block.

Full required suite: `uv run pytest -v --tb=short` -> 2416 passed, 1 skipped, 84.14% coverage (gate: 80%).