### PR TITLE
fix: reuse live DuckDB connection for in-process storage diagnostics

### DIFF
--- a/src/searchat/api/dependencies.py
+++ b/src/searchat/api/dependencies.py
@@ -412,12 +412,14 @@ def maybe_auto_compact_on_shutdown() -> None:
         from searchat.services.compaction import run_auto_compact_if_needed
 
         db_path = _config.storage.resolve_duckdb_path(_search_dir)
+        conn = _duckdb_store.connection if _duckdb_store is not None else None
         result = run_auto_compact_if_needed(
             db_path,
             _search_dir,
             auto_trigger_ratio=_config.compaction.auto_trigger_ratio,
             min_interval_days=_config.compaction.min_interval_days,
             timeout_seconds=_config.compaction.max_duration_seconds,
+            conn=conn,
         )
         if result is None:
             return

--- a/src/searchat/api/routers/health.py
+++ b/src/searchat/api/routers/health.py
@@ -154,7 +154,10 @@ def _build_storage_report() -> dict[str, Any]:
     from searchat.services.storage_health import build_storage_doctor_report
 
     try:
-        report = build_storage_doctor_report(deps.get_search_dir(), deps.get_config())
+        store = deps.get_duckdb_store()
+        report = build_storage_doctor_report(
+            deps.get_search_dir(), deps.get_config(), conn=store.connection
+        )
     except Exception as exc:
         return {"status": "error", "error": str(exc)}
     return report.to_dict()

--- a/src/searchat/services/compaction.py
+++ b/src/searchat/services/compaction.py
@@ -697,6 +697,7 @@ def run_auto_compact_if_needed(
     auto_trigger_ratio: float,
     min_interval_days: int,
     timeout_seconds: float | None = None,
+    conn: duckdb.DuckDBPyConnection | None = None,
 ) -> CompactionResult | None:
     """Consult M1's bloat ratio and the compaction-state sidecar; compact
     only when both thresholds are exceeded.
@@ -708,6 +709,16 @@ def run_auto_compact_if_needed(
     `timeout_seconds` is forwarded to `compact_database` -- bounding a
     hung child here matters even more than usual, since this function is
     called from the graceful-shutdown path.
+
+    `conn`: the live server's own DuckDB connection (still open at
+    shutdown time -- see `api/dependencies.py::maybe_auto_compact_on_shutdown`),
+    reused for the bloat-ratio size checks below instead of opening a
+    second, differently-configured connection to the same file, which
+    DuckDB rejects from within the same process (see
+    `services/storage_health.py::inspect_database_size`). Not threaded
+    into `compact_database` itself, which always runs the actual
+    compaction in an isolated subprocess -- a separate process, so no
+    such conflict is possible there.
     """
     from searchat.services.storage_health import (
         compute_bloat_ratio,
@@ -720,8 +731,8 @@ def run_auto_compact_if_needed(
         return None
 
     try:
-        size_info = inspect_database_size(db_path)
-        live_bytes = estimate_live_data_size(db_path)
+        size_info = inspect_database_size(db_path, conn=conn)
+        live_bytes = estimate_live_data_size(db_path, conn=conn)
         ratio = compute_bloat_ratio(size_info.total_bytes, live_bytes)
         state = read_compaction_state(search_dir)
         if not should_auto_compact(

--- a/src/searchat/services/storage_health.py
+++ b/src/searchat/services/storage_health.py
@@ -313,38 +313,105 @@ _EMPTY_DATABASE_SIZE_INFO = DatabaseSizeInfo(
 )
 
 
-def inspect_database_size(db_path: Path) -> DatabaseSizeInfo:
+def _read_database_size(con: duckdb.DuckDBPyConnection) -> DatabaseSizeInfo:
+    """Read `PRAGMA database_size` from an already-open connection/cursor."""
+    cursor = con.execute("PRAGMA database_size")
+    row = cursor.fetchone()
+    if row is None:
+        return _EMPTY_DATABASE_SIZE_INFO
+    columns = {desc[0]: value for desc, value in zip(cursor.description, row)}
+    block_size = int(columns.get("block_size", 0) or 0)
+    total_blocks = int(columns.get("total_blocks", 0) or 0)
+    used_blocks = int(columns.get("used_blocks", 0) or 0)
+    free_blocks = int(columns.get("free_blocks", 0) or 0)
+    wal_bytes = _parse_duckdb_size(str(columns.get("wal_size", "0 bytes")))
+    return DatabaseSizeInfo(
+        total_bytes=block_size * total_blocks,
+        block_size=block_size,
+        total_blocks=total_blocks,
+        used_blocks=used_blocks,
+        free_blocks=free_blocks,
+        wal_bytes=wal_bytes,
+    )
+
+
+def inspect_database_size(
+    db_path: Path, *, conn: duckdb.DuckDBPyConnection | None = None
+) -> DatabaseSizeInfo:
     """Read PRAGMA database_size for `db_path` without mutating it.
 
     Returns an all-zero report when `db_path` does not exist yet (fresh install).
+
+    `conn`: an already-open connection to `db_path` to read through (e.g. a
+    live server's own storage connection), via a fresh cursor on it, instead
+    of opening a brand-new `duckdb.connect()` to the same file. DuckDB
+    refuses a second same-process connection to a file with a different
+    configuration (e.g. the server's `read_only=False` vs. this function's
+    own `read_only=True`) — pass `conn` whenever one is already open in this
+    process (see `build_storage_doctor_report`); leave it `None` for a
+    standalone caller, such as the `searchat doctor` CLI, that owns no other
+    connection to `db_path`.
     """
     if not db_path.exists():
         return _EMPTY_DATABASE_SIZE_INFO
+    if conn is not None:
+        cursor = conn.cursor()
+        try:
+            return _read_database_size(cursor)
+        finally:
+            cursor.close()
     con = duckdb.connect(str(db_path), read_only=True)
     try:
-        cursor = con.execute("PRAGMA database_size")
-        row = cursor.fetchone()
-        if row is None:
-            return _EMPTY_DATABASE_SIZE_INFO
-        columns = {desc[0]: value for desc, value in zip(cursor.description, row)}
-        block_size = int(columns.get("block_size", 0) or 0)
-        total_blocks = int(columns.get("total_blocks", 0) or 0)
-        used_blocks = int(columns.get("used_blocks", 0) or 0)
-        free_blocks = int(columns.get("free_blocks", 0) or 0)
-        wal_bytes = _parse_duckdb_size(str(columns.get("wal_size", "0 bytes")))
-        return DatabaseSizeInfo(
-            total_bytes=block_size * total_blocks,
-            block_size=block_size,
-            total_blocks=total_blocks,
-            used_blocks=used_blocks,
-            free_blocks=free_blocks,
-            wal_bytes=wal_bytes,
-        )
+        return _read_database_size(con)
     finally:
         con.close()
 
 
-def estimate_live_data_size(db_path: Path) -> int:
+def _estimate_live_data_size_via(con: duckdb.DuckDBPyConnection) -> int:
+    """Compute the live-data byte estimate from an already-open connection/cursor."""
+    size_row = con.execute("PRAGMA database_size").fetchone()
+    if size_row is None:
+        return 0
+    columns = {desc[0]: value for desc, value in zip(con.description, size_row)}
+    block_size = int(columns.get("block_size", 0) or 0)
+    if block_size <= 0:
+        return 0
+
+    schemas = [
+        row[0]
+        for row in con.execute(
+            "SELECT DISTINCT table_schema FROM information_schema.tables "
+            "WHERE table_schema = 'main' OR table_schema LIKE 'fts_main_%'"
+        ).fetchall()
+    ]
+
+    live_blocks: set[int] = set()
+    for schema in schemas:
+        tables = [
+            row[0]
+            for row in con.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = ?",
+                [schema],
+            ).fetchall()
+        ]
+        for table in tables:
+            qualified = f'"{schema}"."{table}"'
+            try:
+                block_rows = con.execute(
+                    "SELECT DISTINCT block_id FROM pragma_storage_info(?) "
+                    "WHERE block_id IS NOT NULL AND block_id >= 0",
+                    [qualified],
+                ).fetchall()
+            except duckdb.Error:
+                continue
+            live_blocks.update(int(row[0]) for row in block_rows)
+
+    return len(live_blocks) * block_size
+
+
+def estimate_live_data_size(
+    db_path: Path, *, conn: duckdb.DuckDBPyConnection | None = None
+) -> int:
     """Estimate the bytes actually occupied by live tables in `db_path`.
 
     Sums the distinct storage blocks referenced by `pragma_storage_info` across
@@ -357,49 +424,22 @@ def estimate_live_data_size(db_path: Path) -> int:
     exactly the bloat `searchat compact` (M3) reclaims.
 
     Returns 0 when `db_path` does not exist yet.
+
+    `conn`: see `inspect_database_size` — reuse an already-open connection
+    via a fresh cursor instead of opening a new, differently-configured
+    connection to the same file from within the same process.
     """
     if not db_path.exists():
         return 0
+    if conn is not None:
+        cursor = conn.cursor()
+        try:
+            return _estimate_live_data_size_via(cursor)
+        finally:
+            cursor.close()
     con = duckdb.connect(str(db_path), read_only=True)
     try:
-        size_row = con.execute("PRAGMA database_size").fetchone()
-        if size_row is None:
-            return 0
-        columns = {desc[0]: value for desc, value in zip(con.description, size_row)}
-        block_size = int(columns.get("block_size", 0) or 0)
-        if block_size <= 0:
-            return 0
-
-        schemas = [
-            row[0]
-            for row in con.execute(
-                "SELECT DISTINCT table_schema FROM information_schema.tables "
-                "WHERE table_schema = 'main' OR table_schema LIKE 'fts_main_%'"
-            ).fetchall()
-        ]
-
-        live_blocks: set[int] = set()
-        for schema in schemas:
-            tables = [
-                row[0]
-                for row in con.execute(
-                    "SELECT table_name FROM information_schema.tables WHERE table_schema = ?",
-                    [schema],
-                ).fetchall()
-            ]
-            for table in tables:
-                qualified = f'"{schema}"."{table}"'
-                try:
-                    block_rows = con.execute(
-                        "SELECT DISTINCT block_id FROM pragma_storage_info(?) "
-                        "WHERE block_id IS NOT NULL AND block_id >= 0",
-                        [qualified],
-                    ).fetchall()
-                except duckdb.Error:
-                    continue
-                live_blocks.update(int(row[0]) for row in block_rows)
-
-        return len(live_blocks) * block_size
+        return _estimate_live_data_size_via(con)
     finally:
         con.close()
 
@@ -587,11 +627,20 @@ class StorageDoctorReport:
         }
 
 
-def build_storage_doctor_report(search_dir: Path, config: Config) -> StorageDoctorReport:
-    """Assemble the full read-only storage doctor report for `search_dir`."""
+def build_storage_doctor_report(
+    search_dir: Path, config: Config, *, conn: duckdb.DuckDBPyConnection | None = None
+) -> StorageDoctorReport:
+    """Assemble the full read-only storage doctor report for `search_dir`.
+
+    `conn`: an already-open connection to the store's DuckDB file to reuse
+    for the size checks, e.g. the live server's own connection when this is
+    called in-process from `/api/health` — see `inspect_database_size` for
+    why opening a fresh connection there would fail. Leave `None` for a
+    standalone caller such as the `searchat doctor` CLI.
+    """
     db_path = config.storage.resolve_duckdb_path(search_dir)
-    size_info = inspect_database_size(db_path)
-    live_bytes = estimate_live_data_size(db_path)
+    size_info = inspect_database_size(db_path, conn=conn)
+    live_bytes = estimate_live_data_size(db_path, conn=conn)
     backups = audit_backup_redundancy(search_dir / "backups", search_dir)
     harness_sources = estimate_harness_source_sizes(config)
     last_backup_at, last_backup_age_seconds = estimate_last_backup_age(search_dir)

--- a/tests/api/test_health_routes.py
+++ b/tests/api/test_health_routes.py
@@ -126,7 +126,9 @@ def test_health_deep_healthy_all_pass(monkeypatch: pytest.MonkeyPatch, tmp_path:
     monkeypatch.setattr(deps, "_search_dir", tmp_path)
     monkeypatch.setattr(deps, "_search_engine", engine)
     monkeypatch.setattr(deps, "_backup_manager", backup_manager)
-    monkeypatch.setattr(deps, "_config", MagicMock())
+    config = MagicMock()
+    config.storage.resolve_duckdb_path.return_value = tmp_path / "data" / "searchat.duckdb"
+    monkeypatch.setattr(deps, "_config", config)
 
     mod = _api_app_module()
     client = TestClient(mod.app, raise_server_exceptions=False)
@@ -163,7 +165,9 @@ def test_health_deep_degraded_on_failure(monkeypatch: pytest.MonkeyPatch, tmp_pa
     monkeypatch.setattr(deps, "_search_dir", tmp_path)
     monkeypatch.setattr(deps, "_search_engine", None)
     monkeypatch.setattr(deps, "_backup_manager", backup_manager)
-    monkeypatch.setattr(deps, "_config", MagicMock())
+    config = MagicMock()
+    config.storage.resolve_duckdb_path.return_value = tmp_path / "data" / "searchat.duckdb"
+    monkeypatch.setattr(deps, "_config", config)
 
     mod = _api_app_module()
     client = TestClient(mod.app, raise_server_exceptions=False)
@@ -197,7 +201,9 @@ def test_health_deep_faiss_not_loaded_when_engine_none(
     monkeypatch.setattr(deps, "_search_dir", tmp_path)
     monkeypatch.setattr(deps, "_search_engine", None)
     monkeypatch.setattr(deps, "_backup_manager", backup_manager)
-    monkeypatch.setattr(deps, "_config", MagicMock())
+    config = MagicMock()
+    config.storage.resolve_duckdb_path.return_value = tmp_path / "data" / "searchat.duckdb"
+    monkeypatch.setattr(deps, "_config", config)
 
     mod = _api_app_module()
     client = TestClient(mod.app, raise_server_exceptions=False)
@@ -236,7 +242,9 @@ def test_health_deep_includes_latency_timings(
     monkeypatch.setattr(deps, "_search_dir", tmp_path)
     monkeypatch.setattr(deps, "_search_engine", engine)
     monkeypatch.setattr(deps, "_backup_manager", backup_manager)
-    monkeypatch.setattr(deps, "_config", MagicMock())
+    config = MagicMock()
+    config.storage.resolve_duckdb_path.return_value = tmp_path / "data" / "searchat.duckdb"
+    monkeypatch.setattr(deps, "_config", config)
 
     mod = _api_app_module()
     client = TestClient(mod.app, raise_server_exceptions=False)
@@ -276,7 +284,9 @@ def test_health_deep_disk_space_warning(
     monkeypatch.setattr(deps, "_search_dir", tmp_path)
     monkeypatch.setattr(deps, "_search_engine", engine)
     monkeypatch.setattr(deps, "_backup_manager", backup_manager)
-    monkeypatch.setattr(deps, "_config", MagicMock())
+    config = MagicMock()
+    config.storage.resolve_duckdb_path.return_value = tmp_path / "data" / "searchat.duckdb"
+    monkeypatch.setattr(deps, "_config", config)
 
     # Simulate low disk space: 500MB free
     low_usage = MagicMock()
@@ -322,9 +332,11 @@ def test_health_deep_includes_storage_section_with_real_data(
         "searchat.services.storage_health.get_connectors", lambda: ()
     )
 
+    live_conn = duckdb.connect(str(db_path), read_only=True)
     store = MagicMock()
     store.validate_parquet_scan.return_value = None
     store.count_conversations.return_value = 42
+    store.connection = live_conn
 
     faiss_index = MagicMock()
     faiss_index.ntotal = 100
@@ -346,17 +358,20 @@ def test_health_deep_includes_storage_section_with_real_data(
 
     mod = _api_app_module()
     client = TestClient(mod.app, raise_server_exceptions=False)
-    resp = client.get("/api/health")
-    assert resp.status_code == 200
-    body = resp.json()
+    try:
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        body = resp.json()
 
-    storage = body["storage"]
-    assert storage["db_exists"] is True
-    assert storage["total_bytes"] > 0
-    assert storage["live_bytes"] > 0
-    assert storage["bloat_ratio"] >= 1.0
-    assert storage["harness_sources"] == []
-    assert isinstance(storage["backups"], list)
+        storage = body["storage"]
+        assert storage["db_exists"] is True
+        assert storage["total_bytes"] > 0
+        assert storage["live_bytes"] > 0
+        assert storage["bloat_ratio"] >= 1.0
+        assert storage["harness_sources"] == []
+        assert isinstance(storage["backups"], list)
+    finally:
+        live_conn.close()
 
 
 def test_health_deep_storage_section_degrades_gracefully_on_error(

--- a/tests/unit/services/test_compaction.py
+++ b/tests/unit/services/test_compaction.py
@@ -772,6 +772,32 @@ class TestRunAutoCompactIfNeeded:
         assert result is None
         assert _sha256(db_path) == checksum_before
 
+    def test_reuses_live_connection_without_opening_a_conflicting_one(self, tmp_path: Path) -> None:
+        """Regression test: `api/dependencies.py::maybe_auto_compact_on_shutdown`
+        passes the live server's own (`read_only=False`) `UnifiedStorage`
+        connection as `conn`. Before this fix, the bloat-ratio size checks
+        below always opened a second, differently-configured connection to
+        the same file, which DuckDB rejects from within the same process --
+        silently disabling the shutdown auto-trigger on every real deployment.
+        """
+        search_dir = tmp_path
+        db_path = search_dir / "data" / "searchat.duckdb"
+        db_path.parent.mkdir(parents=True)
+        _build_indexed_bloated_db(db_path)
+
+        live_conn = duckdb.connect(str(db_path), read_only=False)
+        try:
+            with patch("searchat.services.storage_health.compute_bloat_ratio", return_value=2.5):
+                result = comp.run_auto_compact_if_needed(
+                    db_path, search_dir, auto_trigger_ratio=3.0, min_interval_days=7, conn=live_conn
+                )
+        finally:
+            live_conn.close()
+
+        # Below threshold: never fires. The point of this test is that the
+        # in-process size checks above did not raise while `live_conn` was open.
+        assert result is None
+
     def test_never_raises_on_internal_error(self, tmp_path: Path) -> None:
         search_dir = tmp_path
         db_path = search_dir / "data" / "searchat.duckdb"

--- a/tests/unit/services/test_storage_health.py
+++ b/tests/unit/services/test_storage_health.py
@@ -217,6 +217,56 @@ def test_estimate_live_data_size_matches_known_block_count(tmp_path: Path) -> No
     assert estimate_live_data_size(db_path) == len(known_blocks) * block_size
 
 
+def test_inspect_database_size_reuses_open_connection_without_opening_new_one(
+    tmp_path: Path,
+) -> None:
+    """Regression test: a live `searchat web` process holds its own DuckDB
+    connection open `read_only=False` (see `api/dependencies.py`). Opening a
+    second, differently-configured connection to the same file from within
+    the same process raises DuckDB's "different configuration"
+    ConnectionException -- `inspect_database_size` must read through the
+    caller's own connection via `conn=` instead of ever opening a new one
+    when called in-process alongside a live store (see
+    `build_storage_doctor_report` and `/api/health`'s storage section).
+    """
+    db_path = tmp_path / "live.duckdb"
+    live_conn = duckdb.connect(str(db_path), read_only=False)
+    try:
+        live_conn.execute("CREATE TABLE conversations(id INTEGER)")
+        live_conn.execute("INSERT INTO conversations SELECT * FROM range(5)")
+        live_conn.execute("CHECKPOINT")
+
+        info = inspect_database_size(db_path, conn=live_conn)
+    finally:
+        live_conn.close()
+
+    assert info.total_bytes > 0
+    assert info.block_size > 0
+    assert info.total_blocks > 0
+
+
+def test_estimate_live_data_size_reuses_open_connection_without_opening_new_one(
+    tmp_path: Path,
+) -> None:
+    """Same regression as `inspect_database_size` above, for the other
+    function `build_storage_doctor_report` calls against the DuckDB file."""
+    db_path = tmp_path / "live.duckdb"
+    live_conn = duckdb.connect(str(db_path), read_only=False)
+    try:
+        live_conn.execute("CREATE TABLE conversations(id INTEGER, payload VARCHAR)")
+        live_conn.execute(
+            "INSERT INTO conversations SELECT i, md5(i::VARCHAR) FROM range(2000) t(i)"
+        )
+        live_conn.execute("CHECKPOINT")
+
+        live_bytes = estimate_live_data_size(db_path, conn=live_conn)
+    finally:
+        live_conn.close()
+
+    assert live_bytes > 0
+
+
+
 def test_compute_bloat_ratio_pure_math() -> None:
     assert compute_bloat_ratio(3_000_000, 1_000_000) == pytest.approx(3.0)
     assert compute_bloat_ratio(1_000_000, 1_000_000) == pytest.approx(1.0)
@@ -442,3 +492,42 @@ def test_build_storage_doctor_report_assembles_all_sections(
     assert payload["db_exists"] is True
     assert isinstance(payload["backups"], list)
     assert isinstance(payload["harness_sources"], list)
+
+
+def test_build_storage_doctor_report_reuses_live_server_connection(
+    temp_search_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test for `/api/health`'s `storage` section failing
+    whenever queried against a running `searchat web` process. The live
+    app's `UnifiedStorage` connection is opened `read_only=False` (see
+    `api/dependencies.py`); before this fix, `build_storage_doctor_report`
+    unconditionally opened its own second, differently-configured
+    `read_only=True` connection to the same file, which DuckDB rejects with
+    "Can't open a connection to same database file with a different
+    configuration than existing connections" whenever called in-process
+    alongside that live connection. It must instead read through the
+    caller-supplied `conn` via a fresh cursor.
+    """
+    data_root = temp_search_dir / "data"
+    (data_root / "conversations").mkdir(parents=True, exist_ok=True)
+    (data_root / "conversations" / "conv.parquet").write_bytes(b"PAR1conv")
+
+    db_path = data_root / "searchat.duckdb"
+    live_conn = duckdb.connect(str(db_path), read_only=False)
+    try:
+        live_conn.execute("CREATE TABLE dummy_bloat(id INTEGER)")
+        live_conn.execute("INSERT INTO dummy_bloat SELECT * FROM range(10)")
+        live_conn.execute("CHECKPOINT")
+
+        monkeypatch.setattr("searchat.services.storage_health.get_connectors", lambda: ())
+
+        config = Mock()
+        config.storage.resolve_duckdb_path.return_value = db_path
+
+        report = build_storage_doctor_report(temp_search_dir, config, conn=live_conn)
+    finally:
+        live_conn.close()
+
+    assert report.db_exists is True
+    assert report.total_bytes > 0
+    assert report.live_bytes > 0


### PR DESCRIPTION
## Summary

Fixes a DuckDB connection conflict that broke storage diagnostics whenever they ran inside the live `searchat web` process. Two independent call sites shared the same root cause and are fixed together:

1. `GET /api/health`'s `storage` section (M1 doctor diagnostics) — always failed against a running server.
2. `services/compaction.py`'s auto-compact-on-shutdown trigger (M3) — silently disabled on every real deployment, never previously detected because its failure is swallowed by a catch-all `except`/log.

## Root cause

`api/dependencies.py` opens the app's main `UnifiedStorage` connection with `read_only=False` (required for live indexing). Two helper functions in `services/storage_health.py` — `inspect_database_size` and `estimate_live_data_size` — each independently opened a *second* connection to the same file via `duckdb.connect(db_path, read_only=True)`. DuckDB's Python binding tracks open connections per file path within a process and rejects a second connection to an already-open file with different connect-time configuration:

```
Connection Error: Can't open a connection to same database file with a different configuration than existing connections
```

This fired every time `/api/health`'s `storage` section was requested against a live server, and every time `run_auto_compact_if_needed` (which calls the same two helpers) ran from the graceful-shutdown path — meaning M3's shutdown auto-compaction has never successfully computed a bloat ratio in a real deployment.

The standalone `searchat doctor` CLI was never affected — it runs in its own process with no competing connection to conflict with.

## Fix

`inspect_database_size`, `estimate_live_data_size`, `build_storage_doctor_report`, and `run_auto_compact_if_needed` each gained an optional keyword-only `conn: duckdb.DuckDBPyConnection | None = None`. When supplied, they derive a fresh cursor via `conn.cursor()` — the same concurrent-read idiom `UnifiedStorage._read_cursor()` already uses internally — instead of opening a new connection. When omitted (the CLI path), behavior is unchanged.

- `api/routers/health.py::_build_storage_report()` now passes the live store's `.connection`.
- `api/dependencies.py::maybe_auto_compact_on_shutdown()` now passes the live store's `.connection` through to `run_auto_compact_if_needed`.
- `compact_database` itself is untouched — it always runs the actual compaction in an isolated subprocess, a separate OS process, so no such conflict is possible there.

## Test changes

Five existing `tests/api/test_health_routes.py` tests broke when this fix was first applied: their `config` mocks never configured a real `resolve_duckdb_path` return value, so the *old* code happened to fail loudly on that garbage `Mock` path (caught gracefully, degrading the storage section to an error) while the *new* code succeeds on it too eagerly and produces a non-JSON-serializable report. Fixed by giving each mock a real (non-existent, which is fine) `Path` return value, and by giving `test_health_deep_includes_storage_section_with_real_data` a genuine live `read_only=False` connection on `store.connection` matching how the fix actually behaves in production — rather than weakening the production fix to accommodate an unrealistic mock.

New regression tests added, each reproducing the exact original failure by holding a real `read_only=False` connection open and calling the fixed function against the same file:

- `test_inspect_database_size_reuses_open_connection_without_opening_new_one`
- `test_estimate_live_data_size_reuses_open_connection_without_opening_new_one`
- `test_build_storage_doctor_report_reuses_live_server_connection`
- `test_reuses_live_connection_without_opening_a_conflicting_one` (compaction)

## Verification

- Targeted: `uv run pytest tests/unit/services/test_storage_health.py tests/unit/services/test_compaction.py tests/unit/test_cli_doctor.py tests/unit/test_cli_compact.py tests/api/test_health_routes.py -v --tb=short --no-cov` — 80 passed.
- Full suite: `uv run pytest -v --tb=short` — **2420 passed, 1 skipped**, 84.16% coverage (gate is 80%).
- `ruff check` on all touched files — clean.
- `mypy` on all touched files — 4 pre-existing errors elsewhere in `storage_health.py`, confirmed identical before/after this change via `git stash`; none introduced by this PR.
- Manual: started `searchat web` against a real, existing `~/.searchat` index (12,036 conversations) and curled `GET /api/health` before and after this fix. Before: `storage.status = "error"` with the connection-conflict message. After: full real diagnostics (bloat ratio, backup redundancy, per-harness sizes) returned successfully while the server was running.

## Commits

- `fix(api): reuse live connection for storage doctor diagnostics`
- `fix(compaction): reuse live connection in auto-compact shutdown check`