### PR TITLE
fix(deps): bump python-multipart past DoS CVE range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "pygments>=2.17.0",
     "reportlab>=4.2.0",
     "jinja2>=3.1.0",
-    "python-multipart>=0.0.22",
+    "python-multipart>=0.0.31",
     "zstandard>=0.25.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2714,11 +2714,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612 }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579 },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042 },
 ]
 
 [[package]]
@@ -3536,7 +3536,7 @@ requires-dist = [
     { name = "pyarrow", marker = "extra == 'legacy'", specifier = ">=14.0.0" },
     { name = "pygments", specifier = ">=2.17.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "python-multipart", specifier = ">=0.0.22" },
+    { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "rank-bm25", marker = "extra == 'palace'", specifier = ">=0.2.2" },
     { name = "reportlab", specifier = ">=4.2.0" },
     { name = "rich", specifier = ">=13.0.0" },


### PR DESCRIPTION
## Stack

Position: 1/6

1. `security/bump-python-multipart-dos-cves` -> this PR
2. `security/fix-bookmarks-xss-escaping` -> depends on this
3. `security/bound-conversations-all-default-limit` -> depends on #2
4. `security/fix-backup-name-path-traversal` -> depends on #3
5. `security/reject-cross-origin-state-changing-requests` -> depends on #4
6. `security/bind-server-to-localhost-by-default` -> depends on #5

Depends on: (none - root, targets `main`)

## Summary

`python-multipart` was pinned to `>=0.0.22`, which is vulnerable to several CPU-exhaustion DoS issues in multipart and urlencoded form parsing (CVE-2026-40347, CVE-2026-42561, CVE-2026-53538, CVE-2026-53539, CVE-2026-53540). The parser is reachable through this app's own HTTP API via `request.form()` in `api/routers/fragments.py`'s `/apply-resolution` endpoint.

Bumps the floor to `>=0.0.31` and refreshes the lockfile, landing `0.0.32`.

## Validation

- `uv run pytest` — full suite green (2420 passed, 1 skipped)
- `pip-audit --local` before/after: 66 vulnerabilities across 15 packages -> 61 across 14; `python-multipart` no longer flagged
- Reviewed: no other pin/vendor site for this package exists in the repo; the vulnerable code path is genuinely reachable through this app's own request handling
