### PR TITLE
fix(web): escape bookmark title/project_id before innerHTML render

### DIFF
--- a/src/searchat/web/static/js/modules/bookmarks.js
+++ b/src/searchat/web/static/js/modules/bookmarks.js
@@ -2,6 +2,12 @@
 
 let bookmarkedConversations = new Set();
 
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text == null ? '' : String(text);
+    return div.innerHTML;
+}
+
 function bookmarkIconSvg(isBookmarked) {
     const fill = isBookmarked ? 'currentColor' : 'none';
     return `
@@ -197,9 +203,9 @@ export async function showBookmarks() {
             div.innerHTML = `
                 <div style="display: flex; justify-content: space-between; align-items: start;">
                     <div style="flex: 1;">
-                        <div class="result-title">${bookmark.title || 'Untitled'}</div>
+                        <div class="result-title">${escapeHtml(bookmark.title) || 'Untitled'}</div>
                         <div class="result-meta">
-                            <span>Project: ${bookmark.project_id || 'Unknown'}</span> •
+                            <span>Project: ${escapeHtml(bookmark.project_id) || 'Unknown'}</span> •
                             <span>Messages: ${bookmark.message_count || 0}</span> •
                             <span>Bookmarked: ${addedDate}</span>
                         </div>

--- a/tests/unit/test_web_bookmarks_escaping.py
+++ b/tests/unit/test_web_bookmarks_escaping.py
@@ -1,0 +1,60 @@
+"""Regression test for the bookmarks page XSS fix.
+
+`bookmarks.js` renders `bookmark.title` / `bookmark.project_id` via
+`div.innerHTML = ...` template literals. Those fields are sourced from the indexed
+conversation's `title` (the first message's raw text, verbatim -- see
+`core/connectors/claude.py`) and `project_id`, both fully attacker/
+content-controlled. Every other rendering module in this codebase
+(`manage.js`, `search.js`, `chat.js`, ...) escapes such fields through a
+local `escapeHtml()` helper before interpolating them into `innerHTML`;
+`bookmarks.js` used to be the one exception. A live headless-browser
+reproduction confirmed the pre-fix template executed a crafted
+`<img onerror=...>` payload verbatim, and that the post-fix template
+renders it as inert escaped text.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+WEB_ROOT = Path(__file__).parents[2] / "src" / "searchat" / "web"
+BOOKMARKS_JS = WEB_ROOT / "static" / "js" / "modules" / "bookmarks.js"
+
+
+def _source() -> str:
+    return BOOKMARKS_JS.read_text(encoding="utf-8")
+
+
+def test_bookmarks_js_exists() -> None:
+    assert BOOKMARKS_JS.exists(), "bookmarks.js module must exist"
+
+
+def test_bookmarks_js_defines_escape_helper() -> None:
+    source = _source()
+    assert "function escapeHtml(" in source, (
+        "bookmarks.js must define an escapeHtml() helper, matching the "
+        "convention used by every other rendering module"
+    )
+
+
+def test_bookmarks_js_escapes_title_before_innerhtml() -> None:
+    source = _source()
+    assert "escapeHtml(bookmark.title)" in source, (
+        "bookmark.title is attacker/content-controlled (first message text) "
+        "and must be escaped before interpolation into innerHTML"
+    )
+
+
+def test_bookmarks_js_escapes_project_id_before_innerhtml() -> None:
+    source = _source()
+    assert "escapeHtml(bookmark.project_id)" in source, (
+        "bookmark.project_id is attacker-influenceable (source directory "
+        "name) and must be escaped before interpolation into innerHTML"
+    )
+
+
+def test_bookmarks_js_never_interpolates_raw_title_into_innerhtml() -> None:
+    source = _source()
+    assert "${bookmark.title || 'Untitled'}" not in source, (
+        "raw unescaped bookmark.title must not be interpolated directly "
+        "into an innerHTML template literal"
+    )


### PR DESCRIPTION
## Stack

Position: 2/6

1. `security/bump-python-multipart-dos-cves` -> #128
2. `security/fix-bookmarks-xss-escaping` -> this PR
3. `security/bound-conversations-all-default-limit` -> depends on this
4. `security/fix-backup-name-path-traversal` -> depends on #3
5. `security/reject-cross-origin-state-changing-requests` -> depends on #4
6. `security/bind-server-to-localhost-by-default` -> depends on #5

Depends on: #128

## Summary

`bookmarks.js` interpolated `bookmark.title` and `bookmark.project_id` directly into an `innerHTML` template literal with no escaping. `conversation.title` is the raw text of a conversation's first message (`core/connectors/claude.py`: `title = text[:100]`, copied verbatim), so any conversation whose first message contains markup — pasted HTML, a prompt-injection payload from fetched content, or a crafted project directory name — becomes stored HTML that executes in the user's own browser the next time they open the bookmarks page.

Every other rendering module in this codebase (`manage.js`, `search.js`, `chat.js`, `disk.js`, ...) already escapes such fields through a local `escapeHtml()` helper; `bookmarks.js` was the one file missing it. Adds the same helper and wraps both fields, matching the existing convention.

## Validation

- `uv run pytest` — full suite green (2425 passed, 1 skipped)
- A live headless-browser reproduction confirmed a crafted `<img onerror=...>` title executed script in the pre-fix DOM and renders as inert escaped text after the fix
- Added `tests/unit/test_web_bookmarks_escaping.py`, matching this repo's existing convention for frontend-JS source assertions (no JS execution harness exists in this repo)
