### PR TITLE
fix(api): bound the default limit on GET /conversations/all

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -181,7 +181,7 @@ tool      string  claude|vibe|opencode
 date      string  today|week|month|custom
 date_from  string  Custom date start (YYYY-MM-DD)
 date_to    string  Custom date end (YYYY-MM-DD)
-limit     int     1-5000 (optional)
+limit     int     1-5000 (default: 100)
 offset    int     0+ (default: 0)
 snapshot  string  Optional snapshot dataset (read-only)
 ```

--- a/src/searchat/api/routers/conversations.py
+++ b/src/searchat/api/routers/conversations.py
@@ -402,7 +402,7 @@ async def get_all_conversations(
     date_from: str | None = Query(None, description="Custom date from (YYYY-MM-DD)"),
     date_to: str | None = Query(None, description="Custom date to (YYYY-MM-DD)"),
     tool: str | None = Query(None, description="Filter by tool: claude, vibe, opencode, codex, gemini, continue, cursor, aider"),
-    limit: int | None = Query(None, ge=1, le=5000, description="Max results to return"),
+    limit: int = Query(100, ge=1, le=5000, description="Max results to return"),
     offset: int = Query(0, ge=0, description="Offset for pagination"),
     snapshot: str | None = Query(None, description="Backup snapshot name (read-only)"),
 ):

--- a/tests/api/test_conversations_routes.py
+++ b/tests/api/test_conversations_routes.py
@@ -410,6 +410,41 @@ class TestGetAllConversationsEndpoint:
             assert data["results"][1]["conversation_id"] == "conv-2"
             assert data["results"][1]["message_count"] == 5
 
+    def test_get_all_conversations_default_limit_is_bounded(self, client, mock_duckdb_store):
+        """Omitting `limit` must not dump the entire conversation corpus.
+
+        `full_text` is included per row, so an unbounded default lets any
+        unauthenticated caller pull the whole indexed corpus (potentially
+        gigabytes of conversation content) in a single request. Both
+        legitimate frontend callers (manage.js, search.js) always send an
+        explicit `limit` for exactly this reason; the endpoint's own
+        default must be bounded too.
+        """
+        now = datetime.now()
+        mock_duckdb_store._data = [
+            {
+                "conversation_id": f"conv-{i}",
+                "project_id": "project-a",
+                "title": f"Conversation {i}",
+                "created_at": now,
+                "updated_at": now,
+                "message_count": 1,
+                "file_path": f"/home/user/.claude/conv-{i}.jsonl",
+                "full_text": "x",
+            }
+            for i in range(150)
+        ]
+
+        with patch('searchat.api.routers.conversations.deps.get_duckdb_store', return_value=mock_duckdb_store):
+            response = client.get("/api/conversations/all")
+
+            assert response.status_code == 200
+            data = response.json()
+
+            assert data["total"] == 150
+            assert len(data["results"]) < 150
+            assert len(data["results"]) <= 100
+
     def test_get_all_conversations_filters_zero_messages(self, client, mock_duckdb_store):
         """Test that conversations with 0 messages are filtered out."""
         with patch('searchat.api.routers.conversations.deps.get_duckdb_store', return_value=mock_duckdb_store):


### PR DESCRIPTION
## Stack

Position: 3/6

1. `security/bump-python-multipart-dos-cves` -> #128
2. `security/fix-bookmarks-xss-escaping` -> #129
3. `security/bound-conversations-all-default-limit` -> this PR
4. `security/fix-backup-name-path-traversal` -> depends on this
5. `security/reject-cross-origin-state-changing-requests` -> depends on #4
6. `security/bind-server-to-localhost-by-default` -> depends on #5

Depends on: #129

## Summary

`limit` defaulted to `None` (unbounded) when the `limit` query param was omitted on `GET /api/conversations/all`, so `store.list_conversations()` never applied a SQL `LIMIT` clause and every matching row — including `full_text`, the entire indexed content of each conversation — was serialized into one response. Both real frontend callers (`manage.js`, `search.js`) already send an explicit bounded limit specifically to avoid this (`search.js` even comments on it: "to avoid freezing the browser on large collections"); the endpoint's own default did not carry the same bound, so any direct caller omitting the parameter could pull the entire indexed corpus in a single request.

Defaults `limit` to 100, matching the existing `ge=1`/`le=5000` bounds. Also documents the new default in `docs/api-reference.md`.

## Validation

- `uv run pytest` — full suite green (2426 passed, 1 skipped)
- New test: seeding 150 conversations and requesting with no `limit` param now returns `<=100` results; the same test fails against the pre-fix router (returns all 150) — confirmed via a stash-and-revert reproduction
- Reviewed: this is the only instance of this bug pattern in the router layer; every other `limit`-named param across the router files already ships a concrete bounded default
