### PR TITLE
fix(backup): reject path-traversal backup names on read and write joins

### DIFF
--- a/src/searchat/api/routers/backup.py
+++ b/src/searchat/api/routers/backup.py
@@ -20,6 +20,7 @@ from searchat.api.dependencies import (
 )
 from searchat.contracts.errors import (
     backup_chain_resolution_unavailable_message,
+    backup_invalid_name_message,
     backup_not_found_message,
     backup_operations_disabled_message,
     backup_summary_unavailable_message,
@@ -51,6 +52,10 @@ async def create_backup(
             message=f"Backup created: {metadata.backup_path.name}",
         )
 
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=backup_invalid_name_message(backup_name or "")) from e
     except Exception as e:
         logger.error(f"Failed to create backup: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=internal_server_error_message()) from e
@@ -75,6 +80,10 @@ async def create_incremental_backup(
             backup=metadata.to_dict(),
             message=f"Incremental backup created: {metadata.backup_path.name}",
         )
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=backup_invalid_name_message(parent)) from e
     except Exception as e:
         logger.error(f"Failed to create incremental backup: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=internal_server_error_message()) from e
@@ -176,7 +185,10 @@ async def restore_backup(
     try:
         backup_manager = get_backup_manager()
 
-        backup_path = backup_manager.backup_dir / backup_name
+        try:
+            backup_path = backup_manager.resolve_backup_path(backup_name)
+        except ValueError:
+            raise HTTPException(status_code=404, detail=backup_not_found_message(backup_name))
 
         if not backup_path.exists():
             raise HTTPException(status_code=404, detail=backup_not_found_message(backup_name))
@@ -213,7 +225,10 @@ async def delete_backup(
         raise HTTPException(status_code=403, detail=backup_operations_disabled_message())
     try:
         backup_manager = get_backup_manager()
-        backup_path = backup_manager.backup_dir / backup_name
+        try:
+            backup_path = backup_manager.resolve_backup_path(backup_name)
+        except ValueError:
+            raise HTTPException(status_code=404, detail=backup_not_found_message(backup_name))
 
         if not backup_path.exists():
             raise HTTPException(status_code=404, detail=backup_not_found_message(backup_name))

--- a/src/searchat/contracts/errors.py
+++ b/src/searchat/contracts/errors.py
@@ -324,6 +324,10 @@ def backup_not_found_message(backup_name: str) -> str:
     return f"Backup not found: {backup_name}"
 
 
+def backup_invalid_name_message(backup_name: str) -> str:
+    return f"Invalid backup name: {backup_name}"
+
+
 def backup_summary_unavailable_message() -> str:
     return "Backup summary unavailable"
 

--- a/src/searchat/services/backup.py
+++ b/src/searchat/services/backup.py
@@ -50,6 +50,29 @@ def _sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
+def _validate_backup_name_component(name: str) -> None:
+    """Reject a backup-name component that could escape `backup_dir`.
+
+    Every backup directory this module creates is a plain
+    `<name>_<timestamp>` folder name minted by `create_backup` /
+    `create_incremental_backup` itself; nothing legitimate needs a path
+    separator, a `.`/`..` segment, or a null byte in a caller-supplied
+    `backup_name`. Used both before a READ join (`resolve_backup_path`)
+    and before a WRITE join (the custom-name prefix accepted by
+    `create_backup` / `create_incremental_backup`) -- neither is safe
+    otherwise.
+    """
+    if (
+        not name
+        or name in {".", ".."}
+        or "/" in name
+        or "\\" in name
+        or ":" in name
+        or "\x00" in name
+    ):
+        raise ValueError(f"Invalid backup name: {name!r}")
+
+
 class BackupManager:
     """Manages backups and restores for Searchat data."""
 
@@ -73,6 +96,25 @@ class BackupManager:
 
         # Ensure backup directory exists
         self.backup_dir.mkdir(parents=True, exist_ok=True)
+
+    def resolve_backup_path(self, backup_name: str) -> Path:
+        """Resolve `backup_name` to a path guaranteed to live inside `backup_dir`.
+
+        Raises ValueError for an empty name, `.`/`..`, an embedded path
+        separator or colon, or (belt-and-braces) a resolved path that is
+        not a strict descendant of `backup_dir` -- e.g. `backup_name=".."`
+        would otherwise resolve to `backup_dir`'s parent (the live
+        `~/.searchat` data directory itself), and on Windows a same-drive
+        `backup_name="C:"` would otherwise re-anchor to `backup_dir`
+        itself rather than a child of it; both are rejected by requiring
+        `candidate != backup_root` in addition to containment.
+        """
+        _validate_backup_name_component(backup_name)
+        backup_root = self.backup_dir.resolve()
+        candidate = (self.backup_dir / backup_name).resolve()
+        if candidate == backup_root or backup_root not in candidate.parents:
+            raise ValueError(f"Invalid backup name: {backup_name!r}")
+        return candidate
 
     def _get_directory_size(self, path: Path) -> int:
         """Calculate total size of all files in a directory."""
@@ -144,7 +186,10 @@ class BackupManager:
             if len(chain) > max_chain_length:
                 raise ValueError(f"Backup chain length exceeds max ({max_chain_length})")
 
-            current_path = self.backup_dir / current
+            try:
+                current_path = self.resolve_backup_path(current)
+            except ValueError as exc:
+                raise ValueError(f"Backup not found in chain: {current}") from exc
             if not current_path.exists() or not current_path.is_dir():
                 raise ValueError(f"Backup not found in chain: {current}")
             manifest = self._load_manifest(current_path)
@@ -168,7 +213,14 @@ class BackupManager:
         """
         errors: list[str] = []
 
-        backup_path = self.backup_dir / backup_name
+        try:
+            backup_path = self.resolve_backup_path(backup_name)
+        except ValueError:
+            return {
+                "backup_name": backup_name,
+                "valid": False,
+                "errors": [f"Backup not found: {backup_name}"],
+            }
         if not backup_path.exists() or not backup_path.is_dir():
             return {
                 "backup_name": backup_name,
@@ -210,7 +262,7 @@ class BackupManager:
         chain_manifests: list[tuple[str, BackupManifest]] = []
         for name in chain:
             try:
-                m = self._load_manifest(self.backup_dir / name)
+                m = self._load_manifest(self.resolve_backup_path(name))
             except ValueError as exc:
                 errors.append(str(exc))
                 continue
@@ -232,7 +284,7 @@ class BackupManager:
 
         if verify_hashes:
             for name, m in chain_manifests:
-                bpath = self.backup_dir / name
+                bpath = self.resolve_backup_path(name)
                 for rel_path, meta in m.files.items():
                     stored_rel = meta.get("stored_rel_path") or rel_path
                     if not isinstance(stored_rel, str) or not stored_rel:
@@ -295,7 +347,20 @@ class BackupManager:
         ).to_dict()
 
     def get_backup_summary(self, backup_name: str) -> dict[str, object]:
-        backup_path = self.backup_dir / backup_name
+        try:
+            backup_path = self.resolve_backup_path(backup_name)
+        except ValueError:
+            return {
+                "name": backup_name,
+                "backup_mode": "unknown",
+                "encrypted": False,
+                "parent_name": None,
+                "chain_length": 0,
+                "snapshot_browsable": False,
+                "has_manifest": False,
+                "valid": False,
+                "errors": ["Backup not found: " + repr(backup_name)],
+            }
         manifest_path = backup_path / BACKUP_MANIFEST_FILE
         try:
             manifest = self._load_manifest(backup_path)
@@ -463,7 +528,7 @@ class BackupManager:
 
         state: dict[str, str] = {}
         for idx, name in enumerate(chain):
-            backup_path = self.backup_dir / name
+            backup_path = self.resolve_backup_path(name)
             manifest = self._load_manifest(backup_path)
             if manifest is None:
                 raise ValueError(f"Backup manifest missing: {name}")
@@ -512,7 +577,7 @@ class BackupManager:
             raise ValueError(f"Backup chain length exceeds max ({max_chain_length})")
 
         for name in parent_chain:
-            m = self._load_manifest(self.backup_dir / name)
+            m = self._load_manifest(self.resolve_backup_path(name))
             if m is None:
                 raise ValueError(f"Backup manifest missing: {name}")
             if bool(m.encrypted) != encrypted:
@@ -523,6 +588,7 @@ class BackupManager:
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         if backup_name:
+            _validate_backup_name_component(backup_name)
             folder_name = f"{backup_name}_{timestamp}"
         else:
             folder_name = f"incremental_{timestamp}"
@@ -645,14 +711,14 @@ class BackupManager:
         if not chain:
             raise ValueError("Empty backup chain")
 
-        base_manifest = self._load_manifest(self.backup_dir / chain[0])
+        base_manifest = self._load_manifest(self.resolve_backup_path(chain[0]))
         if base_manifest is None:
             raise ValueError(f"Backup manifest missing: {chain[0]}")
         if base_manifest.backup_mode != "full":
             raise ValueError("Backup chain base must be a full backup")
         manifests: list[tuple[str, BackupManifest]] = []
         for name in chain:
-            backup_path = self.backup_dir / name
+            backup_path = self.resolve_backup_path(name)
             manifest = self._load_manifest(backup_path)
             if manifest is None:
                 raise ValueError(f"Backup manifest missing: {name}")
@@ -671,7 +737,7 @@ class BackupManager:
             key = get_backup_key()
 
         for name, manifest in manifests:
-            backup_path = self.backup_dir / name
+            backup_path = self.resolve_backup_path(name)
 
             # Apply file overlays.
             for rel_path, meta in manifest.files.items():
@@ -772,6 +838,7 @@ class BackupManager:
         # Generate backup name with timestamp
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         if backup_name:
+            _validate_backup_name_component(backup_name)
             folder_name = f"{backup_name}_{timestamp}"
         else:
             folder_name = f"backup_{timestamp}"
@@ -1155,7 +1222,10 @@ class BackupManager:
         it has no metadata to update (older backups without a manifest are
         still listable, but nothing to persist pinning onto).
         """
-        backup_path = self.backup_dir / backup_name
+        try:
+            backup_path = self.resolve_backup_path(backup_name)
+        except ValueError as exc:
+            raise FileNotFoundError(f"Backup not found: {backup_name}") from exc
         if not backup_path.exists() or not backup_path.is_dir():
             raise FileNotFoundError(f"Backup not found: {backup_name}")
 
@@ -1231,7 +1301,10 @@ class BackupManager:
         while changed:
             changed = False
             for name in list(keep_names):
-                manifest = self._load_manifest(self.backup_dir / name)
+                try:
+                    manifest = self._load_manifest(self.resolve_backup_path(name))
+                except ValueError:
+                    manifest = None
                 parent = manifest.parent_name if manifest is not None else None
                 if parent and parent not in keep_names:
                     keep_names.add(parent)

--- a/tests/api/test_stats_backup_routes.py
+++ b/tests/api/test_stats_backup_routes.py
@@ -42,6 +42,7 @@ def mock_backup_manager():
     """Mock BackupManager."""
     mock = Mock()
     mock.backup_dir = Path("/backups")
+    mock.resolve_backup_path.side_effect = lambda name: mock.backup_dir / name
 
     # Mock BackupMetadata
     mock_metadata = Mock()

--- a/tests/unit/services/test_backup_path_traversal.py
+++ b/tests/unit/services/test_backup_path_traversal.py
@@ -1,0 +1,183 @@
+"""Regression tests for the backup-name path traversal fix.
+
+`BackupManager` and `api/routers/backup.py` used to join a caller-supplied
+`backup_name` (from `DELETE /api/backup/delete/{backup_name}`,
+`POST /api/backup/restore`, `GET /api/backup/validate/{backup_name}`,
+`GET /api/backup/chain/{backup_name}`, and the `backup_name`/`parent`
+custom-name prefixes on `POST /api/backup/create` and
+`POST /api/backup/incremental/create`) directly onto `backup_dir` with no
+containment check: `backup_manager.backup_dir / backup_name`. A name of
+`".."` resolves to `backup_dir`'s parent -- the live `~/.searchat` data
+directory itself -- turning the unauthenticated DELETE endpoint into a
+`shutil.rmtree(~/.searchat)` primitive, and letting the CREATE endpoints
+write a backup's contents to an attacker-chosen filesystem location
+outside `backup_dir` entirely.
+
+`resolve_backup_path` / `_validate_backup_name_component` close this by
+rejecting empty names, `.`/`..`, embedded path separators, and (as a
+second, independent check) any resolved path that still lands outside
+`backup_dir`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from searchat.services.backup import BackupManager
+
+
+@pytest.mark.unit
+class TestResolveBackupPathRejectsTraversal:
+    """Direct tests of the validation helper itself."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "..",
+            ".",
+            "",
+            "../sibling",
+            "sub/dir",
+            "sub\\dir",
+            "..\\..\\evil",
+            "C:",
+            "c:",
+            "D:",
+            "name:stream",
+        ],
+    )
+    def test_rejects_unsafe_names(self, temp_search_dir: Path, name: str) -> None:
+        mgr = BackupManager(temp_search_dir)
+        with pytest.raises(ValueError):
+            mgr.resolve_backup_path(name)
+
+    def test_accepts_a_real_backup_name(self, temp_search_dir: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        meta = mgr.create_backup(backup_name="ok")
+        name = meta.backup_path.name
+
+        resolved = mgr.resolve_backup_path(name)
+
+        assert resolved == meta.backup_path.resolve()
+        assert resolved.is_relative_to(mgr.backup_dir.resolve())
+
+    def test_dotdot_would_have_escaped_to_backup_dirs_parent(
+        self, temp_search_dir: Path
+    ) -> None:
+        """Prove exactly what `backup_name=".."` used to resolve to.
+
+        This is the live `~/.searchat` data directory in production; here
+        it is `temp_search_dir`, the parent of `backup_dir`.
+        """
+        mgr = BackupManager(temp_search_dir)
+        unsafe_join = mgr.backup_dir / ".."
+
+        assert unsafe_join.resolve() == mgr.backup_dir.parent.resolve()
+        assert unsafe_join.resolve() == temp_search_dir.resolve()
+
+
+@pytest.mark.unit
+class TestServiceEntryPointsRejectTraversal:
+    """Every public BackupManager method that used to join backup_dir
+    directly from a caller-supplied name must now refuse `".."`."""
+
+    def test_resolve_backup_chain_rejects_dotdot(self, temp_search_dir: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        with pytest.raises(ValueError):
+            mgr.resolve_backup_chain("..")
+
+    def test_validate_backup_artifact_rejects_dotdot(self, temp_search_dir: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        result = mgr.validate_backup_artifact("..")
+        assert result["valid"] is False
+
+    def test_get_backup_summary_rejects_dotdot(self, temp_search_dir: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        result = mgr.get_backup_summary("..")
+        assert result["valid"] is False
+
+    def test_set_pinned_rejects_dotdot(self, temp_search_dir: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        with pytest.raises(FileNotFoundError):
+            mgr.set_pinned("..", True)
+
+    def test_materialize_backup_rejects_dotdot(self, temp_search_dir: Path, tmp_path: Path) -> None:
+        mgr = BackupManager(temp_search_dir)
+        with pytest.raises(ValueError):
+            mgr.materialize_backup(backup_name="..", dest_dir=tmp_path / "out")
+
+
+@pytest.mark.unit
+class TestCreateBackupRejectsWriteTraversal:
+    """The custom `backup_name` prefix accepted by create_backup /
+    create_incremental_backup is a WRITE-side join: a malicious value
+    would write the backup's contents outside `backup_dir` entirely,
+    not just read from it."""
+
+    def test_create_backup_rejects_traversal_name_and_writes_nothing_outside(
+        self, temp_search_dir: Path, tmp_path: Path
+    ) -> None:
+        mgr = BackupManager(temp_search_dir)
+        escape_target = tmp_path / "outside"
+
+        with pytest.raises(ValueError):
+            mgr.create_backup(backup_name=f"../../../../../..{escape_target}")
+
+        assert not escape_target.exists()
+        # Nothing was created inside backup_dir either.
+        assert list(mgr.backup_dir.iterdir()) == []
+
+    def test_create_incremental_backup_rejects_traversal_custom_name(
+        self, temp_search_dir: Path
+    ) -> None:
+        mgr = BackupManager(temp_search_dir)
+        base_meta = mgr.create_backup(backup_name="base")
+
+        with pytest.raises(ValueError):
+            mgr.create_incremental_backup(
+                parent_name=base_meta.backup_path.name,
+                backup_name="../evil",
+            )
+
+    def test_create_incremental_backup_rejects_traversal_parent_name(
+        self, temp_search_dir: Path
+    ) -> None:
+        mgr = BackupManager(temp_search_dir)
+        with pytest.raises(ValueError):
+            mgr.create_incremental_backup(parent_name="..")
+
+
+@pytest.mark.unit
+class TestDeleteEndpointRejectsEncodedTraversal:
+    """`backup_name="..".` reaches the DELETE route via `%2e%2e` -- httpx's
+    own URL normalization collapses a literal unencoded `..` segment
+    before the request is even sent, but percent-encoded dots are not
+    normalized client-side and decode to `..` once routed. A live
+    pre-fix reproduction against a real BackupManager confirmed this
+    percent-encoded request actually executed
+    `shutil.rmtree(backup_dir.parent)`, deleting a sentinel file placed
+    directly in the data directory one level above `backup_dir`.
+    """
+
+    def test_delete_encoded_dotdot_does_not_touch_parent_directory(
+        self, temp_search_dir: Path
+    ) -> None:
+        from unittest.mock import patch
+
+        from fastapi.testclient import TestClient
+
+        from searchat.api.app import app
+
+        sentinel = temp_search_dir / "sentinel.txt"
+        sentinel.write_text("do not delete me")
+        mgr = BackupManager(temp_search_dir)
+
+        client = TestClient(app)
+        with patch("searchat.api.routers.backup.get_backup_manager", return_value=mgr):
+            response = client.request("DELETE", "/api/backup/delete/%2e%2e")
+
+        assert response.status_code == 404
+        assert sentinel.exists()
+        assert temp_search_dir.exists()
+


### PR DESCRIPTION
## Stack

Position: 4/6

1. `security/bump-python-multipart-dos-cves` -> #128
2. `security/fix-bookmarks-xss-escaping` -> #129
3. `security/bound-conversations-all-default-limit` -> #130
4. `security/fix-backup-name-path-traversal` -> this PR
5. `security/reject-cross-origin-state-changing-requests` -> depends on this
6. `security/bind-server-to-localhost-by-default` -> depends on #5

Depends on: #130

## Summary

`BackupManager` and its API routes joined a caller-supplied `backup_name` straight onto `backup_dir` with no containment check: `backup_dir / backup_name`. `backup_name=".."` resolves to `backup_dir`'s parent — the live `~/.searchat` data directory itself.

A live reproduction against a real `BackupManager` confirmed the pre-fix `DELETE` endpoint, reached via the percent-encoded route `/api/backup/delete/%2e%2e` (a literal unencoded `..` segment is normalized away by the HTTP client before the request is even sent, but `%2e%2e` is not), executed `shutil.rmtree(backup_dir.parent)` and deleted a sentinel file placed directly in the data directory. Separately, `create_backup` with a traversal-crafted custom name wrote a real backup directory to an attacker-chosen filesystem path entirely outside `backup_dir`.

Adds `BackupManager.resolve_backup_path(name)`, which rejects an empty name, `.`/`..`, an embedded path separator or colon, or a resolved path that is not a strict descendant of `backup_dir`, and uses it at every join site that reads from a caller-supplied name (`resolve_backup_chain`, `validate_backup_artifact`, `get_backup_summary`, `set_pinned`, `materialize_backup`, `apply_retention_policy`, and both router handlers). Adds `_validate_backup_name_component()` for the write-side custom-name prefixes in `create_backup` / `create_incremental_backup`.

The containment check requires `candidate != backup_root` in addition to containment, and the name validator rejects an embedded colon: on Windows, `backup_name="C:"` (same drive as `backup_dir`) re-anchors the join to `backup_dir` itself rather than a descendant of it — pathlib's documented same-drive `WindowsPath` join semantics — which a laxer "not strictly outside" check would have let through.

## Validation

- `uv run pytest` — full suite green (2444 passed, 1 skipped)
- Verified via a stash-and-revert reproduction: the same test suite fails against the pre-fix code (`resolve_backup_chain("..")` does not raise, `create_backup` with a traversal name actually creates a directory outside `backup_dir`, and the encoded `DELETE` request deletes the sentinel file) and passes against the fix
- `tests/unit/services/test_backup_path_traversal.py` — new, 18 tests covering every entry point plus the Windows drive-letter class via `_validate_backup_name_component`'s colon rejection
