### PR TITLE
fix(api): reject cross-origin state-changing requests

### DIFF
--- a/src/searchat/api/app.py
+++ b/src/searchat/api/app.py
@@ -10,10 +10,11 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 from datetime import datetime
+from urllib.parse import urlsplit
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -143,6 +144,72 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# ---------------------------------------------------------------------------
+# Reject cross-origin state-changing requests (drive-by CSRF)
+# ---------------------------------------------------------------------------
+class RejectCrossOriginMutationsMiddleware(BaseHTTPMiddleware):
+    """Reject a state-changing request whose browser-sent Origin header
+    is neither same-origin nor in the configured CORS allowlist.
+
+    CORSMiddleware alone does not stop this class of request: it only
+    withholds `Access-Control-Allow-Origin` from the *response*, which
+    blocks a cross-origin script from *reading* the result but does
+    nothing to stop the request from being sent and executed -- a
+    "simple" cross-origin POST (a bare `<form method=POST>`, no custom
+    Content-Type) never triggers a CORS preflight at all. Any website
+    the user's browser visits can silently auto-submit such a form to
+    this locally-bound server and trigger a real state change (e.g.
+    `POST /api/backup/restore`, which overwrites the live index with an
+    old backup, or `POST /api/shutdown`) with no user interaction and no
+    need to read the response.
+
+    A request whose Origin's host:port matches the request's own Host
+    header is always same-origin and is allowed regardless of the
+    static allowlist -- main()'s own port auto-scanner (PORT_SCAN_RANGE,
+    8000-8010) silently picks a non-default port whenever 8000 is
+    already taken, and SEARCHAT_HOST=0.0.0.0 deployments are reached via
+    a LAN IP; a purely static `cors_origins` check would reject the
+    app's own legitimate frontend under either condition. The static
+    `allowed_origins` list remains the fallback for a deliberately
+    configured cross-origin caller.
+
+    A request with no Origin header (curl, Python's requests, the MCP
+    stdio transport, direct socket-level HTTP -- none of them set one)
+    is allowed through unchanged; only a browser-sent Origin that fails
+    both checks is rejected. GET/HEAD/OPTIONS are never state-changing
+    and are always allowed through unchanged.
+    """
+
+    _SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+    def __init__(self, app: FastAPI, allowed_origins: list[str]) -> None:
+        super().__init__(app)
+        self._allowed_origins = frozenset(allowed_origins)
+
+    @staticmethod
+    def _is_same_origin(origin: str, host_header: str) -> bool:
+        try:
+            origin_netloc = urlsplit(origin).netloc
+        except ValueError:
+            return False
+        return bool(origin_netloc) and origin_netloc.lower() == host_header.lower()
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        if request.method not in self._SAFE_METHODS:
+            origin = request.headers.get("origin")
+            if origin is not None:
+                host_header = request.headers.get("host", "")
+                same_origin = self._is_same_origin(origin, host_header)
+                if not same_origin and origin not in self._allowed_origins:
+                    return JSONResponse(
+                        status_code=403,
+                        content={"detail": "Cross-origin request rejected"},
+                    )
+        return await call_next(request)
+
+
+app.add_middleware(RejectCrossOriginMutationsMiddleware, allowed_origins=_cors_origins)
 
 # ---------------------------------------------------------------------------
 # No-cache middleware for static assets (prevents stale JS/CSS during dev)

--- a/tests/api/test_cross_origin_middleware.py
+++ b/tests/api/test_cross_origin_middleware.py
@@ -1,0 +1,159 @@
+"""Regression tests for the cross-origin state-changing request rejection.
+
+CORSMiddleware alone does not stop a "simple" cross-origin POST (a bare
+`<form method=POST>`, no custom Content-Type) from being sent and
+executed server-side -- it only withholds `Access-Control-Allow-Origin`
+from the *response*, which blocks a malicious page's JS from *reading*
+the result but does nothing to stop the mutation itself. Before this
+fix, any website the user's browser visited could silently auto-submit
+a hidden form to a state-changing endpoint like `POST /api/backup/create`
+or `POST /api/index_missing` on this locally-bound, unauthenticated
+server -- a classic "drive-by localhost" attack.
+
+`RejectCrossOriginMutationsMiddleware` closes this by rejecting any
+non-GET/HEAD/OPTIONS request whose browser-sent `Origin` header is
+present but not in the configured CORS allowlist. Requests with no
+Origin header (curl, Python's `requests`, the MCP stdio transport) are
+left untouched, since a non-browser client cannot mount this specific
+attack (no ambient browser session to hijack) and blocking them would
+break legitimate direct API/CLI usage.
+"""
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from searchat.api.app import app
+
+EVIL_ORIGIN = "https://evil.example.com"
+ALLOWED_ORIGIN = "http://localhost:8000"
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_backup_manager():
+    mock = Mock()
+    mock_metadata = Mock()
+    mock_metadata.to_dict.return_value = {
+        "backup_path": "/backups/backup_20250120_100000",
+        "timestamp": "20250120_100000",
+        "file_count": 5,
+        "total_size_mb": 10.5,
+    }
+    mock.create_backup.return_value = mock_metadata
+    return mock
+
+
+@pytest.mark.unit
+class TestRejectCrossOriginMutations:
+    def test_foreign_origin_post_is_rejected_before_reaching_the_endpoint(
+        self, client: TestClient, mock_backup_manager
+    ) -> None:
+        """A drive-by form POST from an attacker's own website carries the
+        attacker's Origin. This must never reach create_backup()."""
+        with patch(
+            "searchat.api.routers.backup.get_backup_manager",
+            return_value=mock_backup_manager,
+        ):
+            response = client.post(
+                "/api/backup/create", headers={"Origin": EVIL_ORIGIN}
+            )
+
+        assert response.status_code == 403
+        mock_backup_manager.create_backup.assert_not_called()
+
+    def test_allowed_origin_post_reaches_the_endpoint(
+        self, client: TestClient, mock_backup_manager
+    ) -> None:
+        with patch(
+            "searchat.api.routers.backup.get_backup_manager",
+            return_value=mock_backup_manager,
+        ):
+            response = client.post(
+                "/api/backup/create", headers={"Origin": ALLOWED_ORIGIN}
+            )
+
+        assert response.status_code == 200
+        mock_backup_manager.create_backup.assert_called_once()
+
+    def test_no_origin_header_reaches_the_endpoint(
+        self, client: TestClient, mock_backup_manager
+    ) -> None:
+        """Non-browser clients (curl, Python requests, the MCP stdio
+        transport) never set an Origin header and must not be blocked."""
+        with patch(
+            "searchat.api.routers.backup.get_backup_manager",
+            return_value=mock_backup_manager,
+        ):
+            response = client.post("/api/backup/create")
+
+        assert response.status_code == 200
+        mock_backup_manager.create_backup.assert_called_once()
+
+    def test_foreign_origin_get_is_not_blocked(self, client: TestClient) -> None:
+        """GET is never state-changing; a foreign Origin must not block it.
+
+        No backup manager is mocked here on purpose: the only thing under
+        test is that the middleware does not intercept the request. A 403
+        would prove a block; any other status proves the request reached
+        the route handler.
+        """
+        response = client.get("/api/backup/list", headers={"Origin": EVIL_ORIGIN})
+
+        assert response.status_code != 403
+
+    def test_foreign_origin_index_missing_is_rejected(self, client: TestClient) -> None:
+        """A second, independent state-changing endpoint carrying no body
+        at all -- the whole request is just the Origin header."""
+        response = client.post(
+            "/api/index_missing", headers={"Origin": EVIL_ORIGIN}
+        )
+
+        assert response.status_code == 403
+
+    def test_same_origin_as_host_header_is_allowed_even_when_not_in_static_allowlist(
+        self, client: TestClient, mock_backup_manager
+    ) -> None:
+        """Regression for the static-allowlist bug: main()'s own port
+        auto-scanner (PORT_SCAN_RANGE 8000-8010) silently binds to a
+        non-default port whenever 8000 is taken, and SEARCHAT_HOST=0.0.0.0
+        deployments are reached via a LAN IP -- neither is in the static
+        cors_origins default, so the app's own legitimate frontend must
+        not be blocked just because its Origin isn't in that list, as
+        long as it matches the request's own Host header (TestClient's
+        default Host is 'testserver', with no port -- matching an Origin
+        of http://testserver that is deliberately NOT in ALLOWED_ORIGIN).
+        """
+        with patch(
+            "searchat.api.routers.backup.get_backup_manager",
+            return_value=mock_backup_manager,
+        ):
+            response = client.post(
+                "/api/backup/create", headers={"Origin": "http://testserver"}
+            )
+
+        assert response.status_code == 200
+        mock_backup_manager.create_backup.assert_called_once()
+
+    def test_mismatched_port_origin_is_still_rejected(
+        self, client: TestClient, mock_backup_manager
+    ) -> None:
+        """An Origin whose host:port does not match Host, and is not in
+        the static allowlist, must still be rejected -- same-origin
+        matching is not a blanket bypass."""
+        with patch(
+            "searchat.api.routers.backup.get_backup_manager",
+            return_value=mock_backup_manager,
+        ):
+            response = client.post(
+                "/api/backup/create", headers={"Origin": "http://testserver:9999"}
+            )
+
+        assert response.status_code == 403
+        mock_backup_manager.create_backup.assert_not_called()


### PR DESCRIPTION
## Stack

Position: 5/6

1. `security/bump-python-multipart-dos-cves` -> #128
2. `security/fix-bookmarks-xss-escaping` -> #129
3. `security/bound-conversations-all-default-limit` -> #130
4. `security/fix-backup-name-path-traversal` -> #131
5. `security/reject-cross-origin-state-changing-requests` -> this PR
6. `security/bind-server-to-localhost-by-default` -> depends on this

Depends on: #131

## Summary

`CORSMiddleware` only withholds `Access-Control-Allow-Origin` from the response of a disallowed cross-origin request; it does not stop the request from being sent and executed. A "simple" cross-origin POST (a bare `<form method=POST>`, no custom Content-Type) never triggers a CORS preflight at all, so any website the user's browser visits can silently auto-submit a hidden form to this locally-bound, unauthenticated server and trigger a real state change — overwriting the live index via `POST /api/backup/restore`, shutting the server down, or (chained with #131's original bug) triggering a path-traversal restore — with no user interaction and no need to read the response back.

Adds `RejectCrossOriginMutationsMiddleware`: rejects any non-GET/HEAD/OPTIONS request whose browser-sent `Origin` header is neither same-origin (its `host:port` matches the request's own `Host` header) nor in the configured CORS allowlist. The same-origin check is dynamic rather than relying solely on the static allowlist, because `main()`'s own port auto-scanner (`PORT_SCAN_RANGE` 8000-8010) silently binds to a non-default port whenever 8000 is already taken, and `SEARCHAT_HOST=0.0.0.0` deployments are reached via a LAN IP — a purely static allowlist would reject the app's own legitimate frontend under either condition. A request with no `Origin` header (curl, Python's `requests`, the MCP stdio transport) is left untouched.

## Validation

- `uv run pytest` — full suite green (2455 passed, 1 skipped)
- Confirmed via reproduction: a POST to `/api/backup/create` carrying `Origin: https://evil.example.com` actually executes `create_backup()` and returns 200 against the pre-fix app; the same request returns 403 without reaching the handler against the fix
- A same-origin request whose Origin is deliberately absent from the static allowlist (matching the port auto-scan / LAN-IP scenario) still returns 200, and a request whose Origin's port genuinely mismatches the Host header is still rejected — both confirmed via dedicated tests
