### PR TITLE
fix(config): bind the web server to loopback by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,9 +35,10 @@ SEARCHAT_ADDITIONAL_DIRS=
 SEARCHAT_PORT=8000
 
 # Host address
-# Default: 0.0.0.0 (accessible from network)
-# Use 127.0.0.1 for localhost-only access
-SEARCHAT_HOST=0.0.0.0
+# Default: 127.0.0.1 (localhost only)
+# Set to 0.0.0.0 only if you deliberately want the server reachable from
+# other devices on your network -- it has no authentication of any kind.
+SEARCHAT_HOST=127.0.0.1
 
 # ============================================================================
 # Advanced Configuration (Optional)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Security
+- Bind the web server to `127.0.0.1` (localhost only) by default, was `0.0.0.0` (all network interfaces). Set `SEARCHAT_HOST=0.0.0.0` explicitly to restore network-wide access, e.g. for a shared multi-user deployment.
+
 ## 0.6.0
 ### Search
 - Replace BM25 (rank-bm25) keyword search with DuckDB FTS (full-text search with English stemmer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 ### Security
 - Bind the web server to `127.0.0.1` (localhost only) by default, was `0.0.0.0` (all network interfaces). Set `SEARCHAT_HOST=0.0.0.0` explicitly to restore network-wide access, e.g. for a shared multi-user deployment.
+- Reject any state-changing (non-GET/HEAD/OPTIONS) request whose browser-sent `Origin` header is neither same-origin nor in the configured CORS allowlist, closing a drive-by cross-origin request path against every state-changing endpoint.
+- Reject a `backup_name` containing a path separator, `.`/`..`, or a colon in `BackupManager` and its API routes, closing a path-traversal issue that could read or write outside the backup directory.
+- `GET /api/conversations/all` now defaults `limit` to 100 instead of returning every matching conversation (including full text) when the parameter is omitted.
+- Escape `bookmark.title`/`bookmark.project_id` before rendering on the bookmarks page, closing a stored-XSS issue.
+- Bump the `python-multipart` dependency floor past several denial-of-service CVEs in its form-parsing code.
 
 ## 0.6.0
 ### Search

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -24,6 +24,7 @@ Notes:
 - Snapshot mode is feature-flagged via `[snapshots] enabled`.
 - Write-like operations are blocked in snapshot mode (typically `403`).
 - If semantic components are not warmed up, some endpoints return `503` with a warming payload.
+- Any non-`GET`/`HEAD`/`OPTIONS` request whose `Origin` header is present but neither same-origin nor in the configured `[server] cors_origins` allowlist is rejected with `403` before reaching the route handler. A request with no `Origin` header (curl, scripts, the MCP transport) is unaffected.
 
 ---
 

--- a/examples/config_examples/advanced_config.env
+++ b/examples/config_examples/advanced_config.env
@@ -24,8 +24,10 @@ SEARCHAT_AUTO_DETECT=true
 # Web Server
 # ============================================================================
 
-# Server host (0.0.0.0 for all interfaces, 127.0.0.1 for localhost only)
-SEARCHAT_HOST=0.0.0.0
+# Server host (127.0.0.1 for localhost only -- the default; 0.0.0.0 for
+# all interfaces, only if you deliberately want network-wide access --
+# the server has no authentication of any kind)
+SEARCHAT_HOST=127.0.0.1
 
 # Server port (1-65535)
 SEARCHAT_PORT=8000

--- a/examples/config_examples/multi_user.toml
+++ b/examples/config_examples/multi_user.toml
@@ -6,7 +6,11 @@
 # Setup:
 # 1. Place this file at: /etc/searchat/settings.toml
 # 2. Set SEARCHAT_DATA_DIR to shared location
-# 3. Users override with personal paths via environment variables
+# 3. Set SEARCHAT_HOST=0.0.0.0 -- the server binds to localhost only by
+#    default, so a shared multi-user deployment must opt in explicitly to
+#    be reachable from other machines (it has no authentication of any
+#    kind, so only do this on a trusted network)
+# 4. Users override with personal paths via environment variables
 
 [paths]
 # Shared data directory (ensure proper permissions)
@@ -56,5 +60,6 @@ enable_profiling = false
 
 # User-specific overrides via environment:
 #
+# export SEARCHAT_HOST=0.0.0.0       # required for a shared/multi-user server
 # export SEARCHAT_WINDOWS_PROJECTS_DIR=/home/alice/.claude
 # export SEARCHAT_PORT=8001  # Different port per user

--- a/src/searchat/config/constants.py
+++ b/src/searchat/config/constants.py
@@ -38,7 +38,7 @@ ENV_FILE = ".env"
 # Web Server Defaults
 # ============================================================================
 
-DEFAULT_HOST = "0.0.0.0"
+DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8000
 PORT_SCAN_RANGE = (8000, 8010)  # Will try ports in this range
 

--- a/tests/unit/config/test_server_bind_default.py
+++ b/tests/unit/config/test_server_bind_default.py
@@ -1,0 +1,33 @@
+"""Regression test for the default web server bind address.
+
+DEFAULT_HOST used to be "0.0.0.0", so `searchat web` bound to every
+network interface unless a user explicitly set SEARCHAT_HOST. Combined
+with a fully unauthenticated API (no auth of any kind gates any
+endpoint), this made every indexed conversation -- and every
+state-changing endpoint (backup restore/delete, compaction, shutdown)
+-- reachable by any device on the same network, not just the local
+machine.
+
+A live reproduction confirmed the concrete difference: starting a real
+`searchat-web` process with SEARCHAT_HOST unset and inspecting the
+actual bound socket (`lsof -iTCP:<port> -sTCP:LISTEN`) showed
+`TCP *:<port> (LISTEN)` (all interfaces) against the pre-fix default,
+and `TCP 127.0.0.1:<port> (LISTEN)` (loopback only) against the fix.
+SEARCHAT_HOST=0.0.0.0 remains available for a user who explicitly wants
+to expose the server on their network.
+"""
+from __future__ import annotations
+
+from searchat.config.constants import DEFAULT_HOST
+
+
+def test_default_host_is_loopback_only() -> None:
+    assert DEFAULT_HOST == "127.0.0.1", (
+        "the default bind address must be loopback-only; binding to "
+        "0.0.0.0 by default exposes the fully unauthenticated API to "
+        "every device on the local network"
+    )
+
+
+def test_default_host_is_not_all_interfaces() -> None:
+    assert DEFAULT_HOST not in {"0.0.0.0", "::", ""}


### PR DESCRIPTION
## Stack

Position: 6/6

1. `security/bump-python-multipart-dos-cves` -> #128
2. `security/fix-bookmarks-xss-escaping` -> #129
3. `security/bound-conversations-all-default-limit` -> #130
4. `security/fix-backup-name-path-traversal` -> #131
5. `security/reject-cross-origin-state-changing-requests` -> #132
6. `security/bind-server-to-localhost-by-default` -> this PR

Depends on: #132

Upstack: (none - leaf)

## Summary

`DEFAULT_HOST` was `"0.0.0.0"` — `searchat web` bound to every network interface unless a user explicitly set `SEARCHAT_HOST`. Combined with a fully unauthenticated API (no endpoint anywhere requires authentication), every indexed conversation and every state-changing endpoint (backup restore/delete, compaction, shutdown) was reachable by any device on the same network, not just the local machine that indexed the data.

Changes the default to `127.0.0.1`. `SEARCHAT_HOST=0.0.0.0` remains available for a user who explicitly wants network-wide access.

Also updates every checked-in example that documented or set a live `SEARCHAT_HOST=0.0.0.0`, since following them verbatim would silently reverse this fix: `.env.example` (the documented `~/.searchat/.env` copy target, also referenced by `ERROR_NO_CONFIG`'s own recovery instructions), `examples/config_examples/advanced_config.env`, and `examples/config_examples/multi_user.toml` (which legitimately needs network-wide access for its shared-server use case — adds explicit `SEARCHAT_HOST=0.0.0.0` guidance to its setup steps instead of relying on the old insecure default). Documents the change in `CHANGELOG.md` under `Unreleased`/`Security`.

## Validation

- `uv run pytest` — full suite green (2457 passed, 1 skipped)
- Confirmed via a live reproduction: starting a real `searchat-web` process with `SEARCHAT_HOST` unset and inspecting the actual bound socket (`lsof -iTCP:<port> -sTCP:LISTEN`) showed `TCP *:<port> (LISTEN)` (all interfaces) against the pre-fix default and `TCP 127.0.0.1:<port> (LISTEN)` (loopback only) against the fix
